### PR TITLE
update cpu.c

### DIFF
--- a/src/libs/zbxsysinfo/aix/cpu.c
+++ b/src/libs/zbxsysinfo/aix/cpu.c
@@ -17,11 +17,11 @@
 ** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 **/
 
-#include <sys/dr.h>
 #include "common.h"
 #include "sysinfo.h"
 #include "stats.h"
 #include "log.h"
+#include <sys/dr.h>
 
 int	SYSTEM_CPU_NUM(AGENT_REQUEST *request, AGENT_RESULT *result)
 {


### PR DESCRIPTION
include sys/dr.h last to prevent compiling error on AIX 6.1 with gcc-6.3.
If include it first, it will cause error "conflicting types for 'fgetpos64' in stdio.h"