### PR TITLE
Master can not have replication lag

### DIFF
--- a/templates/db/postgresql/postgresql/pgsql.replication.lag.sql
+++ b/templates/db/postgresql/postgresql/pgsql.replication.lag.sql
@@ -5,24 +5,29 @@ DECLARE
 BEGIN
 	SELECT current_setting('server_version_num') INTO ver;
 
-	IF (ver >= 100000) THEN
-		SELECT * INTO res from (
-			SELECT
-				CASE WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn()
-					THEN 0
-					ELSE COALESCE(EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp())::integer, 0)
-				END
-			) T;
-
+	IF NOT(pg_is_in_recovery()) THEN
+		select 0 into res;
 	ELSE
-		SELECT * INTO res from (
-			SELECT
-				CASE WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location()
-					THEN 0
-					ELSE COALESCE(EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp())::integer, 0)
-				END
-			) T;
-	END IF;
+		IF (ver >= 100000) THEN
+			SELECT * INTO res from (
+				SELECT
+					CASE WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn()
+						THEN 0
+						ELSE COALESCE(EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp())::integer, 0)
+					END
+				) T;
+
+		ELSE
+			SELECT * INTO res from (
+				SELECT
+					CASE WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location()
+						THEN 0
+						ELSE COALESCE(EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp())::integer, 0)
+					END
+				) T;
+		END IF;
+
+	END IF;	
 
 	perform set_config('zbx_tmp.repl_lag_res', res, false);
 END $$;


### PR DESCRIPTION
When postgres start after unclean shutdown it perform some initial recovery before database became open. That recover process involves some WAL replay, so pg_last_wal_replay_lsn() points to recovery end. A lag measured by pgsql.replication.lag.sql script grows linear by time. 
So i have covered original script with pg_is_in_recovery() function.