### PR TITLE
ZBX-17798: debian sysv init script help fix

### DIFF
--- a/misc/init.d/debian/zabbix-agent
+++ b/misc/init.d/debian/zabbix-agent
@@ -26,8 +26,7 @@ case "$1" in
 	$0 start
 	;;
   *)
-	N=/etc/init.d/$NAME
-	echo "Usage: $N {start|stop|restart|force-reload}" >&2
+	echo "Usage: $0 {start|stop|restart|force-reload}" >&2
 	exit 1
 	;;
 esac

--- a/misc/init.d/debian/zabbix-server
+++ b/misc/init.d/debian/zabbix-server
@@ -26,8 +26,7 @@ case "$1" in
 	$0 start
 	;;
   *)
-	N=/etc/init.d/$NAME
-	echo "Usage: $N {start|stop|restart|force-reload}" >&2
+	echo "Usage: $0 {start|stop|restart|force-reload}" >&2
 	exit 1
 	;;
 esac


### PR DESCRIPTION
The help of sysv init script is not correct and could be confusing.
Reported by Peter Kopshoff, see
https://support.zabbix.com/browse/ZBX-17798