### PR TITLE
[ZBXNEXT-5948] fix zabbix sso login problems while behind reverse proxy

### DIFF
--- a/ui/conf/zabbix.conf.php.example
+++ b/ui/conf/zabbix.conf.php.example
@@ -45,3 +45,4 @@ $IMAGE_FORMAT_DEFAULT	= IMAGE_FORMAT_PNG;
 //$SSO['SP_CERT']			= 'conf/certs/sp.crt';
 //$SSO['IDP_CERT']		= 'conf/certs/idp.crt';
 //$SSO['SETTINGS']		= [];
+//$SSO['ProxyVars']      = false; //Change to true if you are using zabbix behind reverse proxy (or kubernetes ingress)

--- a/ui/index_sso.php
+++ b/ui/index_sso.php
@@ -54,7 +54,6 @@ require_once __DIR__.'/vendor/xmlseclibs/xmlseclibs.php';
 use OneLogin\Saml2\Auth;
 use OneLogin\Saml2\Utils;
 
-$baseurl = Utils::getSelfURLNoQuery();
 $relay_state = null;
 
 $sp_key = '';
@@ -62,6 +61,15 @@ $sp_cert = '';
 $idp_cert = '';
 
 global $SSO;
+
+if (is_array($SSO) && array_key_exists('ProxyVars', $SSO)) {
+	if (is_bool($SSO['ProxyVars'])) {
+		Utils::setProxyVars($SSO['ProxyVars']);
+	}
+}
+
+$baseurl = Utils::getSelfURLNoQuery();
+
 
 if (is_array($SSO) && array_key_exists('SP_KEY', $SSO)) {
 	if (file_exists($SSO['SP_KEY'])) {


### PR DESCRIPTION
Allow to use zabbix saml authentication behind reverse proxy.