### PR TITLE
Set the default value of token to {ALERT.SENDTO}

### DIFF
--- a/templates/media/pagerduty/media_pagerduty.xml
+++ b/templates/media/pagerduty/media_pagerduty.xml
@@ -53,7 +53,7 @@
                 </parameter>
                 <parameter>
                     <name>token</name>
-                    <value>&lt;put your key&gt;</value>
+                    <value>{ALERT.SENDTO}</value>
                 </parameter>
                 <parameter>
                     <name>triggerdesc</name>


### PR DESCRIPTION
Making the default value of token {ALERT.SENDTO} suggests to users that they can have multiple PagerDuty users with different tokens set as their send to value. This is especially helpful when you have multiple teams that need to action different alerts.

For example in my use case I use actions to direct some alerts to one of two different PagerDuty users which have different tokens and thus different escalation policies.

Not a big deal I guess as users can make this change themselves if they want but it just seems like a more flexible default.