### PR TITLE
fix test file path in removeTestFile function

### DIFF
--- a/ui/tests/selenium/dashboard/testDashboardDynamicItemWidgets.php
+++ b/ui/tests/selenium/dashboard/testDashboardDynamicItemWidgets.php
@@ -358,6 +358,6 @@ class testDashboardDynamicItemWidgets extends CWebTest {
 	}
 
 	public function removeTestFile() {
-		@unlink(PHPUNIT_BASEDIR.'/frontends/php/iframe.php');
+		@unlink(PHPUNIT_BASEDIR.'/ui/iframe.php');
 	}
 }


### PR DESCRIPTION
After v5.0, the frontends code of zabbix was under the ui/ directory.
In the ui/tests/selenium/dashboard/testDashboardDynamicItemWidgets.php, the createTestFile() function
create a test file as ui/iframe.php, but the removeTestFile() funtion delete a non-existent file frontends/php/iframe.php.
And after the test suite execute completely, the ui/ifram.php will be left under the ui/ directory.