### PR TITLE
Ensure the testPageDashboard runs successfully

### DIFF
--- a/ui/tests/selenium/testPageDashboard.php
+++ b/ui/tests/selenium/testPageDashboard.php
@@ -92,6 +92,9 @@ class testPageDashboard extends CLegacyWebTest {
 		$this->zbxTestLogin('zabbix.php?action=charts.view');
 		$this->zbxTestCheckHeader('Graphs');
 		$this->query('xpath://a[text()="Filter"]')->one()->click();
+		if ($this->query('xpath://li[contains(@class, "ui-tabs-active")]')->one(false) instanceof CNullElement) {
+			$this->query('xpath://a[text()="Filter"]')->one()->click();
+		}
 		$filter = $this->query('name:zbx_filter')->asForm()->one();
 		$filter->fill([
 			'Host' => [


### PR DESCRIPTION
Sometimes when the Filter button was clicked, the filter form was not visabled. And at this
time when we query the 'zbx_filter' by name, we could not find any valid zbx_filter, and then
the case failed.
In order to ensure that the case run successfully, we should check the filter form is whether visable
or not, if not, just click the Filter button again.