### PR TITLE
fix the bug that a form in overlay-dialogue could not trigger the submit event

### DIFF
--- a/ui/tests/include/web/elements/CFormElement.php
+++ b/ui/tests/include/web/elements/CFormElement.php
@@ -298,7 +298,18 @@ class CFormElement extends CElement {
 			$submit->click();
 		}
 		else {
-			parent::submit();
+			/**
+			 * if the form is in overlay-dialogue, we would not find any submit button in it,
+			 * the submit button is in overlay-dialogue-footer. As the submit button may not
+			 * have the submit type, so we should find the submit button and click it directly.
+			 */
+			$submit = $this->query('xpath://div[@class="overlay-dialogue-footer"]//button[text()!="Cancel"]')
+				->one(false);
+			if ($submit->isValid()) {
+				$submit->click();
+			} else {
+				parent::submit();
+			}
 		}
 
 		return $this;


### PR DESCRIPTION
in the overlay-dialogue, the form element is in overlay-dialogue-body,
but we could not find any button which has the submit type.
when the $form->submit() is called, nothing would be happened, and
the overlay-dialogue would not disappear, this leads lots of test case
to run abnormally.