### PR TITLE
Fix replication lag issue

### DIFF
--- a/templates/db/postgresql/postgresql/pgsql.replication.lag.sql
+++ b/templates/db/postgresql/postgresql/pgsql.replication.lag.sql
@@ -1,27 +1,31 @@
 DO LANGUAGE plpgsql $$
 DECLARE
 	ver integer;
-	res text;
+	partners integer;
+	res text := 0;
 BEGIN
 	SELECT current_setting('server_version_num') INTO ver;
+	SELECT count(*) FROM pg_stat_replication INTO partners;
 
-	IF (ver >= 100000) THEN
-		SELECT * INTO res from (
-			SELECT
-				CASE WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn()
-					THEN 0
-					ELSE COALESCE(EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp())::integer, 0)
-				END
-			) T;
+	IF (partners != 0) THEN
+		IF (ver >= 100000) THEN
+			SELECT * INTO res from (
+				SELECT
+					CASE WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn()
+						THEN 0
+						ELSE COALESCE(EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp())::integer, 0)
+					END
+				) T;
 
-	ELSE
-		SELECT * INTO res from (
-			SELECT
-				CASE WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location()
-					THEN 0
-					ELSE COALESCE(EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp())::integer, 0)
-				END
-			) T;
+		ELSE
+			SELECT * INTO res from (
+				SELECT
+					CASE WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location()
+						THEN 0
+						ELSE COALESCE(EXTRACT(EPOCH FROM now() - pg_last_xact_replay_timestamp())::integer, 0)
+					END
+				) T;
+		END IF;
 	END IF;
 
 	perform set_config('zbx_tmp.repl_lag_res', res, false);


### PR DESCRIPTION
Our DB servers are set up as masters with no replication partners. This means that the lag time is wrong. This PR should fix this issue.