### PR TITLE
Tls autoregistration

### DIFF
--- a/create/src/schema.tmpl
+++ b/create/src/schema.tmpl
@@ -1215,6 +1215,8 @@ FIELD		|listen_dns	|t_varchar(255)	|''	|NOT NULL	|0
 FIELD		|host_metadata	|t_varchar(255)	|''	|NOT NULL	|0
 FIELD		|flags		|t_integer	|'0'	|NOT NULL	|0
 FIELD		|tls_accepted	|t_integer	|'1'	|NOT NULL	|0
+FIELD		|tls_issuer	|t_varchar(1024)|''	|NOT NULL	|0
+FIELD		|tls_subject	|t_varchar(1024)|''	|NOT NULL	|0
 INDEX		|1		|host
 INDEX		|2		|proxy_hostid
 

--- a/include/db.h
+++ b/include/db.h
@@ -603,11 +603,12 @@ const char	*zbx_user_string(zbx_uint64_t userid);
 int	DBget_user_names(zbx_uint64_t userid, char **alias, char **name, char **surname);
 
 void	DBregister_host(zbx_uint64_t proxy_hostid, const char *host, const char *ip, const char *dns,
-		unsigned short port, unsigned int connection_type, const char *host_metadata, unsigned short flag,
-		int now);
+		unsigned short port, unsigned int connection_type, const char *tls_issuer, unsigned short flag, int now,
+		const char *host_metadata, const char *tls_subject);
+
 void	DBregister_host_prepare(zbx_vector_ptr_t *autoreg_hosts, const char *host, const char *ip, const char *dns,
-		unsigned short port, unsigned int connection_type, const char *host_metadata, unsigned short flag,
-		int now);
+		unsigned short port, unsigned int connection_type, const char *host_metadata, const char *tls_subject,
+		const char *tls_issuer, unsigned short flag, int now);
 void	DBregister_host_flush(zbx_vector_ptr_t *autoreg_hosts, zbx_uint64_t proxy_hostid);
 void	DBregister_host_clean(zbx_vector_ptr_t *autoreg_hosts);
 

--- a/src/libs/zbxdbhigh/db.c
+++ b/src/libs/zbxdbhigh/db.c
@@ -46,6 +46,8 @@ typedef struct
 	char		*ip;
 	char		*dns;
 	char		*host_metadata;
+	char		*tls_subject;
+	char		*tls_issuer;
 	int		now;
 	unsigned short	port;
 	unsigned short	flag;
@@ -1475,13 +1477,13 @@ const char	*DBsql_id_cmp(zbx_uint64_t id)
  ******************************************************************************/
 void	DBregister_host(zbx_uint64_t proxy_hostid, const char *host, const char *ip, const char *dns,
 		unsigned short port, unsigned int connection_type, const char *host_metadata, unsigned short flag,
-		int now)
+		int now, const char *tls_subject, const char *tls_issuer)
 {
 	zbx_vector_ptr_t	autoreg_hosts;
 
 	zbx_vector_ptr_create(&autoreg_hosts);
 
-	DBregister_host_prepare(&autoreg_hosts, host, ip, dns, port, connection_type, host_metadata, flag, now);
+	DBregister_host_prepare(&autoreg_hosts, host, ip, dns, port, connection_type, host_metadata, tls_subject, tls_issuer, flag, now);
 	DBregister_host_flush(&autoreg_hosts, proxy_hostid);
 
 	DBregister_host_clean(&autoreg_hosts);
@@ -1519,12 +1521,14 @@ static void	autoreg_host_free(zbx_autoreg_host_t *autoreg_host)
 	zbx_free(autoreg_host->ip);
 	zbx_free(autoreg_host->dns);
 	zbx_free(autoreg_host->host_metadata);
+	zbx_free(autoreg_host->tls_subject);
+	zbx_free(autoreg_host->tls_issuer);
 	zbx_free(autoreg_host);
 }
 
 void	DBregister_host_prepare(zbx_vector_ptr_t *autoreg_hosts, const char *host, const char *ip, const char *dns,
-		unsigned short port, unsigned int connection_type, const char *host_metadata, unsigned short flag,
-		int now)
+		unsigned short port, unsigned int connection_type, const char *host_metadata, const char *tls_subject,
+		const char *tls_issuer, unsigned short flag, int now)
 {
 	zbx_autoreg_host_t	*autoreg_host;
 	int 			i;
@@ -1549,6 +1553,8 @@ void	DBregister_host_prepare(zbx_vector_ptr_t *autoreg_hosts, const char *host, 
 	autoreg_host->port = port;
 	autoreg_host->connection_type = connection_type;
 	autoreg_host->host_metadata = zbx_strdup(NULL, host_metadata);
+	autoreg_host->tls_subject = zbx_strdup(NULL, tls_subject);
+	autoreg_host->tls_issuer = zbx_strdup(NULL, tls_issuer);
 	autoreg_host->flag = flag;
 	autoreg_host->now = now;
 
@@ -1723,7 +1729,7 @@ void	DBregister_host_flush(zbx_vector_ptr_t *autoreg_hosts, zbx_uint64_t proxy_h
 		autoreg_hostid = DBget_maxid_num("autoreg_host", create);
 
 		zbx_db_insert_prepare(&db_insert, "autoreg_host", "autoreg_hostid", "proxy_hostid", "host", "listen_ip",
-				"listen_dns", "listen_port", "tls_accepted", "host_metadata", "flags", NULL);
+				"listen_dns", "listen_port", "tls_accepted", "host_metadata", "tls_subject", "tls_issuer", "flags", NULL);
 	}
 
 	if (0 != (update = autoreg_hosts->values_num - create))
@@ -1745,7 +1751,8 @@ void	DBregister_host_flush(zbx_vector_ptr_t *autoreg_hosts, zbx_uint64_t proxy_h
 			zbx_db_insert_add_values(&db_insert, autoreg_host->autoreg_hostid, proxy_hostid,
 					autoreg_host->host, autoreg_host->ip, autoreg_host->dns,
 					(int)autoreg_host->port, (int)autoreg_host->connection_type,
-					autoreg_host->host_metadata, autoreg_host->flag);
+					autoreg_host->host_metadata, autoreg_host->tls_subject,
+					autoreg_host->tls_issuer, autoreg_host->flag);
 		}
 		else
 		{

--- a/src/libs/zbxdbhigh/proxy.c
+++ b/src/libs/zbxdbhigh/proxy.c
@@ -4467,7 +4467,7 @@ static int	process_autoregistration_contents(struct zbx_json_parse *jp_data, zbx
 			continue;
 		}
 
-		DBregister_host_prepare(&autoreg_hosts, host, ip, dns, port, connection_type, host_metadata, flags,
+		DBregister_host_prepare(&autoreg_hosts, host, ip, dns, port, 0, 0, connection_type, host_metadata, flags,
 				itemtime);
 	}
 

--- a/src/zabbix_server/operations.c
+++ b/src/zabbix_server/operations.c
@@ -470,7 +470,7 @@ static zbx_uint64_t	add_discovered_host(const DB_EVENT *event)
 	else if (EVENT_OBJECT_ZABBIX_ACTIVE == event->object)
 	{
 		result = DBselect(
-				"select proxy_hostid,host,listen_ip,listen_dns,listen_port,flags,tls_accepted"
+				"select proxy_hostid,host,listen_ip,listen_dns,listen_port,flags,tls_accepted,tls_subject,tls_issuer"
 				" from autoreg_host"
 				" where autoreg_hostid=" ZBX_FS_UI64,
 				event->objectid);
@@ -554,6 +554,12 @@ static zbx_uint64_t	add_discovered_host(const DB_EVENT *event)
 							"tls_psk_identity", "tls_psk", NULL);
 					zbx_db_insert_add_values(&db_insert, hostid, proxy_hostid, row[1], row[1],
 						tls_accepted, tls_accepted, psk_identity, psk);
+				}
+				else if (ZBX_TCP_SEC_TLS_CERT == tls_accepted)
+				{
+					zbx_db_insert_prepare(&db_insert, "hosts", "hostid", "proxy_hostid", "host",
+							"name", "tls_subject", "tls_issuer", "tls_accept", NULL);
+					zbx_db_insert_add_values(&db_insert, hostid, proxy_hostid, row[1], row[1],row[7],row[8],ZBX_TCP_SEC_TLS_CERT);
 				}
 				else
 				{

--- a/ui/app/controllers/CControllerAutoregUpdate.php
+++ b/ui/app/controllers/CControllerAutoregUpdate.php
@@ -23,7 +23,9 @@ class CControllerAutoregUpdate extends CController {
 
 	protected function checkInput() {
 		$fields = [
-			'tls_accept' =>				'in '.HOST_ENCRYPTION_NONE.','.HOST_ENCRYPTION_PSK.','.(HOST_ENCRYPTION_NONE | HOST_ENCRYPTION_PSK),
+			'tls_accept' =>				'in '.HOST_ENCRYPTION_NONE.','.HOST_ENCRYPTION_PSK.','.HOST_ENCRYPTION_CERTIFICATE.
+				 ','.(HOST_ENCRYPTION_NONE | HOST_ENCRYPTION_PSK ).','.(HOST_ENCRYPTION_NONE | HOST_ENCRYPTION_CERTIFICATE ).','.(HOST_ENCRYPTION_PSK | HOST_ENCRYPTION_CERTIFICATE ).
+				','.(HOST_ENCRYPTION_NONE | HOST_ENCRYPTION_PSK | HOST_ENCRYPTION_CERTIFICATE ),
 			'tls_psk_identity' =>		'db config_autoreg_tls.tls_psk_identity',
 			'tls_psk' =>				'db config_autoreg_tls.tls_psk'
 		];

--- a/ui/app/views/administration.autoreg.edit.php
+++ b/ui/app/views/administration.autoreg.edit.php
@@ -48,7 +48,7 @@ $autoreg_tab = (new CFormList())
 				->setLabel(_('No encryption'))
 			)
 			->addItem((new CCheckBox('tls_in_psk'))->setLabel(_('PSK')))
-	);
+			->addItem((new CCheckBox('tls_in_cert'))->setLabel(_('Certificate')));
 
 if ($data['change_psk']) {
 	$autoreg_tab

--- a/ui/app/views/js/administration.autoreg.edit.js.php
+++ b/ui/app/views/js/administration.autoreg.edit.js.php
@@ -38,6 +38,9 @@
 		else {
 			$tls_psk.hide();
 		}
+		if (($('#tls_accept').val() & <?= HOST_ENCRYPTION_CERTIFICATE ?>) == <?= HOST_ENCRYPTION_CERTIFICATE ?>) {
+			$('#tls_in_cert').prop('checked', true);
+		}
 
 		// Show/hide PSK fields.
 		$('#tls_in_psk').on('click', function() {
@@ -56,6 +59,9 @@
 			}
 			else {
 				$('#tls_psk_identity, #tls_psk').val('');
+			}
+			if ($('#tls_in_cert').is(':checked')) {
+				tls_accept |= <?= HOST_ENCRYPTION_CERTIFICATE ?>;
 			}
 
 			$('#tls_accept').val(tls_accept);

--- a/ui/include/classes/api/services/CAutoregistration.php
+++ b/ui/include/classes/api/services/CAutoregistration.php
@@ -122,7 +122,7 @@ class CAutoregistration extends CApiService {
 	 */
 	protected function validateUpdate(array &$autoreg, array &$db_autoreg = null) {
 		$api_input_rules = ['type' => API_OBJECT, 'flags' => API_NOT_EMPTY, 'fields' => [
-			'tls_accept' =>			['type' => API_INT32, 'in' => HOST_ENCRYPTION_NONE.':'.(HOST_ENCRYPTION_NONE | HOST_ENCRYPTION_PSK)],
+			'tls_accept' =>			['type' => API_INT32, 'in' => HOST_ENCRYPTION_NONE.':'.(HOST_ENCRYPTION_NONE | HOST_ENCRYPTION_PSK | HOST_ENCRYPTION_CERTIFICATE)],
 			'tls_psk_identity' =>	['type' => API_STRING_UTF8, 'length' => DB::getFieldLength('config_autoreg_tls', 'tls_psk_identity')],
 			'tls_psk' =>			['type' => API_PSK, 'length' => DB::getFieldLength('config_autoreg_tls', 'tls_psk')]
 		]];


### PR DESCRIPTION
This PR implements autoregistration with TLS using certificates, as described in https://support.zabbix.com/browse/ZBXNEXT-6138.
This is essentially the same patch, only the DB change was moved from dbschema.c to the DB template.