### PR TITLE
Added command show variables for mysql-agent2

### DIFF
--- a/src/go/plugins/mysql/handler_show_variables.go
+++ b/src/go/plugins/mysql/handler_show_variables.go
@@ -1,0 +1,52 @@
+/*
+** Zabbix
+** Copyright (C) 2001-2021 Zabbix SIA
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation; either version 2 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**/
+
+package mysql
+
+import (
+	"context"
+	"encoding/json"
+
+	"zabbix.com/pkg/zbxerr"
+)
+
+func showVarsHandler(ctx context.Context, conn MyClient, _ map[string]string,
+	_ ...string) (interface{}, error) {
+	rows, err := conn.Query(ctx, `SHOW GLOBAL VARIABLES`)
+	if err != nil {
+		return nil, zbxerr.ErrorCannotFetchData.Wrap(err)
+	}
+
+	data, err := rows2data(rows)
+	if err != nil {
+		return nil, zbxerr.ErrorCannotFetchData.Wrap(err)
+	}
+
+	res := make(map[string]string)
+	for _, row := range data {
+		res[row["Variable_name"]] = row["Value"]
+	}
+
+	jsonRes, err := json.Marshal(res)
+	if err != nil {
+		return nil, zbxerr.ErrorCannotMarshalJSON.Wrap(err)
+	}
+
+	return string(jsonRes), nil
+}

--- a/src/go/plugins/mysql/metrics.go
+++ b/src/go/plugins/mysql/metrics.go
@@ -34,6 +34,7 @@ const (
 	keyReplicationDiscovery   = "mysql.replication.discovery"
 	keyReplicationSlaveStatus = "mysql.replication.get_slave_status"
 	keyStatusVars             = "mysql.get_status_variables"
+	keyShowVars               = "mysql.get_show_variables"
 	keyVersion                = "mysql.version"
 )
 
@@ -56,6 +57,8 @@ func getHandlerFunc(key string) handlerFunc {
 		return replicationSlaveStatusHandler
 	case keyStatusVars:
 		return statusVarsHandler
+	case keyShowVars:
+		return showVarsHandler
 	case keyVersion:
 		return versionHandler
 


### PR DESCRIPTION
The mysql-agent2 has the command show-status [1].
This request added command show-variables [2] for mysql-agent2.

[1] https://dev.mysql.com/doc/refman/8.0/en/show-status.html
[2] https://dev.mysql.com/doc/refman/8.0/en/show-variables.html
