### PR TITLE
Fixed an input validation issue

### DIFF
--- a/ui/app/controllers/CControllerHintboxEventlist.php
+++ b/ui/app/controllers/CControllerHintboxEventlist.php
@@ -75,7 +75,7 @@ class CControllerHintboxEventlist extends CController {
 		foreach ($filter_tags as $filter_tag) {
 			$fields = [
 				'tag' =>		'required|string',
-				'operator' =>	'required|in '.implode(',', [TAG_OPERATOR_EQUAL, TAG_OPERATOR_LIKE]),
+				'operator' =>   'required|in '.implode(',', [TAG_OPERATOR_EQUAL, TAG_OPERATOR_LIKE, TAG_OPERATOR_NOT_EXISTS, TAG_OPERATOR_NOT_EQUAL, TAG_OPERATOR_NOT_LIKE]),
 				'value' =>		'required|string'
 			];
 


### PR DESCRIPTION
The tooltip pop-up window, which appears when hovering over "duration" column in "problems" widget, does not work correctly when tag based filter operator is set NOT_EXIST, NOT_EQAL and NOT_LIKE although dialog used for altering widget settings lists those additional operators and allows such selection to be saved.