### PR TITLE
added LANG=C.UTF-8 locale for non en_EN PostgreSQL

### DIFF
--- a/templates/db/postgresql/template_db_postgresql.conf
+++ b/templates/db/postgresql/template_db_postgresql.conf
@@ -19,7 +19,7 @@ UserParameter=pgsql.frozenxid[*], psql -qtAX -h "$1" -p "$2" -U "$3" -d "$4" -f 
 
 UserParameter=pgsql.discovery.db[*], psql -qtAX -h "$1" -p "$2" -U "$3" -d "$4" -f "/var/lib/zabbix/postgresql/pgsql.discovery.db.sql"
 UserParameter=pgsql.db.size[*], psql -qtAX -h "$1" -p "$2" -U "$3" -d "$4" -c "SELECT pg_database_size('$5')"
-UserParameter=pgsql.ping[*], pg_isready -h "$1" -p "$2" -U "$3" -d "$4"
+UserParameter=pgsql.ping[*], LANG=C.UTF-8 pg_isready -h "$1" -p "$2" -U "$3" -d "$4"
 UserParameter=pgsql.ping.time[*], LANG=C.UTF-8 psql -qtAX -h "$1" -p "$2" -U "$3" -d "$4" -f "/var/lib/zabbix/postgresql/pgsql.ping.time.sql"
 UserParameter=pgsql.version[*], psql -qtAX -h "$1" -p "$2" -U "$3" -d "$4" -c "SELECT version();"
 


### PR DESCRIPTION
If the installed PostgreSQL the locale differs from the en_EN one, then the pgsql.ping does not work.
The service is always displayed as down.