### PR TITLE
Update and fix strings in the French translation

### DIFF
--- a/ui/locale/fr/LC_MESSAGES/frontend.po
+++ b/ui/locale/fr/LC_MESSAGES/frontend.po
@@ -1,26 +1,24 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: Zabbix 4.2\n"
+"Project-Id-Version: Zabbix 5.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-26 19:55+0200\n"
-"PO-Revision-Date: 2018-01-15 09:21+0300\n"
-"Last-Translator: Christophe <ctr@pmspos.fr>\n"
+"POT-Creation-Date: 2021-11-30 17:52+0100\n"
+"PO-Revision-Date: 2021-11-30 19:22+0100\n"
+"Last-Translator: Davy Defaud <davy.defaud@free.fr>\n"
 "Language-Team: Zabbix <info@zabbix.com>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Pootle 2.5.1.3\n"
-"X-Poedit-Basepath: ../../\n"
-"X-POOTLE-MTIME: 1516000918.000000\n"
+"Plural-Forms: nplurals=2; plural=(n >= 2);\n"
+"X-Generator: Poedit 2.4.2\n"
 
 #: include/classes/db/MysqlDbBackend.php:70
 #: include/classes/db/OracleDbBackend.php:142
 #: include/classes/db/PostgresqlDbBackend.php:96
 #, c-format
 msgid "\"%1$s\" instead \"%2$s\""
-msgstr ""
+msgstr "« %1$s » au lieu de « %2$s »"
 
 #: include/classes/import/validators/C10XmlValidator.php:321
 #: include/classes/import/validators/C10XmlValidator.php:338
@@ -37,13 +35,13 @@ msgstr ""
 #: include/classes/import/validators/C60XmlValidator.php:2049
 #, c-format
 msgid "\"%1$s\" is expected"
-msgstr "\"%1$s\" est attendu"
+msgstr "« %1$s » est attendu"
 
 #: include/classes/api/services/CReport.php:229
 #: include/classes/api/services/CReport.php:636
 #, c-format
 msgid "\"%1$s\" must be an empty string or greater than \"%2$s\"."
-msgstr ""
+msgstr "« %1$s » doit être une chaîne de caractères vide ou supérieure à « %2$s »."
 
 #: include/classes/api/services/CMaintenance.php:359
 #: include/classes/api/services/CMaintenance.php:366
@@ -54,26 +52,26 @@ msgstr ""
 #: maintenance.php:143
 #, c-format
 msgid "\"%1$s\" must be between 1970.01.01 and 2038.01.18."
-msgstr ""
+msgstr "« %1$s » doit être comprise entre 1970.01.01 et 2038.01.18."
 
 #: include/classes/api/services/CItemGeneral.php:1399
 #, c-format
 msgid "\"%1$s\" value must be less than or equal to \"%2$s\" value"
-msgstr "La valeur \"%1$s\" doit être inférieure ou égale à la valeur \"%2$s\""
+msgstr "La valeur « %1$s » doit être inférieure ou égale à la valeur « %2$s »"
 
 #: include/classes/import/validators/C10XmlValidator.php:356
 #: include/classes/import/validators/C10XmlValidator.php:378
 #: include/classes/import/validators/C10XmlValidator.php:399
 msgid "\"host:key\" pair is expected"
-msgstr "une paire \"hôte:clé\" est attendue"
+msgstr "une paire « hôte:clef » est attendue"
 
 #: include/classes/api/services/CItemGeneral.php:2253
 msgid "\"hostid\" of dependent item and master item should match"
-msgstr ""
+msgstr "Les paramètres « hostid » d’un élément dépendant et de son maître doivent correspondre"
 
 #: include/classes/api/services/CItemGeneral.php:2260
 msgid "\"ruleid\" of dependent item and master item should match"
-msgstr ""
+msgstr "Les paramètres « ruleid » d’un élément dépendant et de son maître doivent correspondre"
 
 #: include/forms.inc.php:1293
 #: include/views/configuration.host.discovery.edit.php:873
@@ -110,7 +108,7 @@ msgstr[1] "les problèmes %1$d de %3$d%2$s sont affichés"
 #: app/controllers/CControllerPopupAcknowledgeEdit.php:117
 #, c-format
 msgid "%1$d problems selected."
-msgstr ""
+msgstr "%1$d problèmes sélectionnés."
 
 #: chart4.php:94
 #, c-format
@@ -120,13 +118,13 @@ msgstr "%1$s (année %2$s)"
 #: include/classes/core/CModuleManager.php:228
 #, c-format
 msgid "%1$s - thrown by module located at %2$s."
-msgstr ""
+msgstr "%1$s — exception propagée par le module situé dans %2$s."
 
 #: include/classes/api/services/CItemGeneral.php:2608
 #: include/classes/import/readers/CXmlImportReader.php:46
 #, c-format
 msgid "%1$s [Line: %2$s | Column: %3$s]"
-msgstr "%1$s [Ligne : %2$s | Colonne : %3$s]"
+msgstr "%1$s [Ligne : %2$s | Colonne : %3$s]"
 
 #: include/actions.inc.php:1893
 #, c-format
@@ -139,12 +137,12 @@ msgstr[1] "%1$s actions"
 #: jsLoader.php:326
 #, c-format
 msgid "%1$s characters"
-msgstr ""
+msgstr "%1$s caractères"
 
 #: jsLoader.php:327
 #, c-format
 msgid "%1$s characters remaining"
-msgstr ""
+msgstr "%1$s caractères restants"
 
 #: app/views/popup.acknowledge.edit.php:60
 #: app/views/popup.acknowledge.edit.php:65
@@ -158,15 +156,15 @@ msgstr[1] "%1$s événements"
 #, c-format
 msgid "%1$s host in maintenance"
 msgid_plural "%1$s hosts in maintenance"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%1$s hôte en maintenance"
+msgstr[1] "%1$s hôtes en maintenance"
 
 #: include/func.inc.php:2482
 #, c-format
 msgid "%1$s hour"
 msgid_plural "%1$s hours"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%1$s heure"
+msgstr[1] "%1$s heures"
 
 #: app/controllers/CControllerWidgetPlainTextView.php:134
 #: app/controllers/CControllerWidgetPlainTextView.php:135
@@ -248,8 +246,8 @@ msgstr[1] "%1$s secondes"
 #, c-format
 msgid "%1$s unacknowledged problem"
 msgid_plural "%1$s unacknowledged problems"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%1$s problème non acquitté"
+msgstr[1] "%1$s problèmes non acquittés"
 
 #: app/views/monitoring.widget.problemhosts.view.php:108
 #: app/views/monitoring.widget.problems.view.php:207
@@ -292,11 +290,11 @@ msgstr "(%1$s %2$s)"
 
 #: app/partials/popup.operations.php:56
 msgid "(0 - infinitely)"
-msgstr "(0 - indéfiniment)"
+msgstr "(0 — indéfiniment)"
 
 #: app/partials/popup.operations.php:67
 msgid "(0 - use action default)"
-msgstr "(0 - utiliser les paramètres par défaut de l'action)"
+msgstr "(0 — utiliser les paramètres par défaut de l’action)"
 
 #: include/views/configuration.hostgroups.list.php:36
 msgid "(Only super admins can create groups)"
@@ -311,7 +309,7 @@ msgstr "(pas de proxy)"
 
 #: include/classes/setup/CSetupWizard.php:480
 msgid "0 - use default port"
-msgstr "0 - utiliser le port par défaut"
+msgstr "0 — utiliser le port par défaut"
 
 #: include/triggers.inc.php:1598
 msgid "0 or 1"
@@ -361,7 +359,7 @@ msgstr "<chaîne vide>"
 
 #: include/forms.inc.php:1341 include/views/js/item.preprocessing.js.php:197
 msgid "<label name>"
-msgstr "<nom de l'étiquette>"
+msgstr "<nom de l’étiquette>"
 
 #: include/views/monitoring.sysmap.edit.php:127
 msgid "<manual>"
@@ -371,16 +369,16 @@ msgstr "<manuel>"
 #: include/views/js/item.preprocessing.js.php:195
 #: include/views/js/item.preprocessing.js.php:204
 msgid "<metric name>{<label name>=\"<label value>\", ...} == <value>"
-msgstr "<nom de la métrique>{<nom de l'étiquette>=\"<valeur de l'étiquette>\", ...} == <valeur>"
+msgstr "<nom de la métrique>{<nom de l’étiquette>=\"<valeur de l’étiquette>\", …} == <valeur>"
 
 #: app/views/administration.script.edit.php:109
 msgid "<sub-menu/sub-menu/...>"
-msgstr ""
+msgstr "<sous‑menu/sous‑menu/…>"
 
 #: jsLoader.php:183
 msgctxt "abbreviation of severity level"
 msgid "A"
-msgstr ""
+msgstr "M"
 
 #: include/classes/widgets/CWidgetHelper.php:797
 msgid "ADD OVERRIDE"
@@ -392,51 +390,51 @@ msgstr "ET"
 
 #: app/views/administration.user.list.php:114
 msgid "API access"
-msgstr ""
+msgstr "Accès à l’API"
 
 #: app/controllers/CControllerPopupGeneric.php:333
 #: app/views/administration.userrole.edit.php:285
 msgid "API methods"
-msgstr ""
+msgstr "Méthodes de l’API"
 
 #: app/controllers/CControllerAuditLogList.php:210
 msgid "API token"
-msgstr ""
+msgstr "Jeton d’API"
 
 #: include/classes/api/services/CToken.php:299
 #, c-format
 msgid "API token \"%1$s\" already exists for userid \"%2$s\"."
-msgstr ""
+msgstr "Un jeton d’API « %1$s » existe déjà pour l’identifiant d’utilisateur « %2$s »."
 
 #: app/controllers/CControllerTokenCreate.php:98
 msgid "API token added"
-msgstr ""
+msgstr "Jeton d’API ajouté"
 
 #: app/controllers/CControllerTokenDelete.php:61
 msgid "API token deleted"
 msgid_plural "API tokens deleted"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Jeton d’API supprimé"
+msgstr[1] "Jetons d’API supprimés"
 
 #: app/controllers/CControllerTokenDisable.php:63
 msgid "API token disabled"
 msgid_plural "API tokens disabled"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Jeton d’API désactivé"
+msgstr[1] "Jetons d’API désactivés"
 
 #: app/controllers/CControllerTokenEnable.php:63
 msgid "API token enabled"
 msgid_plural "API tokens enabled"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Jeton d’API activé"
+msgstr[1] "Jetons d’API activés"
 
 #: include/classes/api/clients/CLocalApiClient.php:198
 msgid "API token expired."
-msgstr ""
+msgstr "Le jeton d’API a expiré."
 
 #: app/controllers/CControllerTokenUpdate.php:114
 msgid "API token updated"
-msgstr ""
+msgstr "Jeton d’API mis à jour"
 
 #: app/controllers/CControllerTokenEdit.php:107
 #: app/controllers/CControllerTokenList.php:193
@@ -454,11 +452,11 @@ msgstr ""
 #: include/classes/helpers/CMenuHelper.php:373 include/html.inc.php:817
 #: include/html.inc.php:897
 msgid "API tokens"
-msgstr ""
+msgstr "Jetons d’API"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:339
 msgid "Abscissa"
-msgstr ""
+msgstr "Abscisse"
 
 #: include/func.inc.php:1511
 msgid "Access denied"
@@ -466,49 +464,48 @@ msgstr "Accès refusé"
 
 #: sysmap.php:81
 msgid "Access denied!"
-msgstr "Accès refusé !"
+msgstr "Accès refusé !"
 
 #: app/views/administration.user.edit.php:603
 #: app/views/administration.userrole.edit.php:271
 msgid "Access to API"
-msgstr ""
+msgstr "Accès à l’API"
 
 #: app/views/administration.user.edit.php:456
 #: app/views/administration.userrole.edit.php:81
 msgid "Access to UI elements"
-msgstr ""
+msgstr "Accès aux éléments de l’interface"
 
 #: app/views/administration.user.edit.php:632
 #: app/views/administration.userrole.edit.php:320
 msgid "Access to actions"
-msgstr ""
+msgstr "Accès aux actions"
 
 #: app/views/administration.user.edit.php:574
 #: app/views/administration.userrole.edit.php:222
 msgid "Access to modules"
-msgstr ""
+msgstr "Accès aux modules"
 
 #: app/views/administration.user.edit.php:478
 #: app/views/administration.userrole.edit.php:134
 msgid "Access to services"
-msgstr ""
+msgstr "Accès aux services"
 
 #: app/views/hintbox.eventlist.php:76
-#: app/views/monitoring.widget.problems.view.php:66
-#: include/actions.inc.php:161 include/blocks.inc.php:581
-#: include/classes/screens/CScreenProblem.php:868
+#: app/views/monitoring.widget.problems.view.php:66 include/actions.inc.php:161
+#: include/blocks.inc.php:581 include/classes/screens/CScreenProblem.php:868
 #: include/classes/screens/CScreenProblem.php:893
 #: include/classes/screens/CScreenProblem.php:1162 include/events.inc.php:290
 msgid "Ack"
-msgstr "Acquitté"
+msgstr "Acquittement"
 
 #: app/views/popup.acknowledge.edit.php:83 jsLoader.php:350
 msgid "Acknowledge"
-msgstr "Acquittement"
+msgstr "Accuser réception"
 
 #: include/classes/helpers/CRoleHelper.php:420
 msgid "Acknowledge problems"
-msgstr ""
+msgstr "Accuser réception des problèmes"
 
 #: app/views/popup.condition.common.php:684 include/actions.inc.php:2075
 #: include/events.inc.php:196
@@ -598,12 +595,12 @@ msgstr "Action"
 #: include/classes/api/services/CAction.php:2678
 #, c-format
 msgid "Action \"%1$s\" already exists."
-msgstr "Action \"%1$s\" déjà existante."
+msgstr "Action « %1$s » déjà existante."
 
 #: include/classes/api/services/CRole.php:761
 #, c-format
 msgid "Action \"%2$s\" is not available for user role \"%1$s\"."
-msgstr ""
+msgstr "L’action « %2$s » n’est pas disponible pour le rôle utilisateur « %1$s »."
 
 #: actionconf.php:279
 msgid "Action added"
@@ -612,7 +609,7 @@ msgstr "Action ajoutée"
 #: include/classes/core/ZBase.php:500
 #, c-format
 msgid "Action class %1$s must extend %2$s class."
-msgstr ""
+msgstr "La classe d’action « %1$s » doit être une extension de la classe « %2$s »."
 
 #: actionconf.php:301
 msgid "Action deleted"
@@ -641,7 +638,7 @@ msgstr "Journal des actions"
 #: app/views/administration.script.list.php:51
 #: app/views/administration.script.list.php:90
 msgid "Action operation"
-msgstr ""
+msgstr "Opération d’action"
 
 #: actionconf.php:271
 msgid "Action updated"
@@ -687,7 +684,7 @@ msgstr "Actif depuis"
 #: include/views/configuration.maintenance.list.php:88 maintenance.php:47
 #: maintenance.php:143
 msgid "Active till"
-msgstr "Actif jusqu'à"
+msgstr "Actif jusqu’à"
 
 #: app/controllers/CControllerAuditLogList.php:194
 #: app/partials/configuration.host.edit.html.php:248
@@ -838,7 +835,7 @@ msgstr "Ajouter"
 
 #: app/views/js/administration.mediatype.edit.js.php:133
 msgid "Add (message type limit reached)"
-msgstr ""
+msgstr "Ajouter (limite de type de message atteinte)"
 
 #: jsLoader.php:147
 msgid "Add a new widget"
@@ -850,24 +847,24 @@ msgstr "Ajouter un élément enfant"
 
 #: app/partials/monitoring.service.list.edit.php:121
 msgid "Add child service"
-msgstr ""
+msgstr "Ajouter un service fils"
 
 #: app/views/js/popup.service.edit.js.php:508
 msgid "Add child services"
-msgstr ""
+msgstr "Ajouter des services fils"
 
 #: app/partials/configuration.valuemap.php:47
 msgid "Add from"
-msgstr ""
+msgstr "Ajouter depuis"
 
 #: include/actions.inc.php:686 include/actions.inc.php:1029
 msgid "Add host"
-msgstr "Ajouter hôte"
+msgstr "Ajouter un hôte"
 
 #: app/partials/massupdate.macros.tab.php:95
 #: app/partials/massupdate.valuemaps.tab.php:37
 msgid "Add missing"
-msgstr ""
+msgstr "Ajouter l’élément manquant"
 
 #: jsLoader.php:203
 msgid "Add multiple maps"
@@ -880,7 +877,7 @@ msgstr "Ajouter un nouvel ensemble de données"
 #: app/partials/configuration.host.edit.html.php:256
 #: include/views/configuration.host.prototype.edit.php:264
 msgid "Add new interface"
-msgstr ""
+msgstr "Ajouter une interface"
 
 #: include/classes/widgets/CWidgetHelper.php:751
 msgid "Add new override"
@@ -889,15 +886,15 @@ msgstr "Ajouter une nouvelle surcharge"
 #: app/views/js/configuration.dashboard.edit.js.php:202
 #: app/views/js/monitoring.dashboard.view.js.php:287
 msgid "Add page"
-msgstr ""
+msgstr "Ajouter une page"
 
 #: app/views/js/popup.service.edit.js.php:538 jsLoader.php:414
 msgid "Add parent services"
-msgstr ""
+msgstr "Ajouter des services parents"
 
 #: include/classes/helpers/CRoleHelper.php:418
 msgid "Add problem comments"
-msgstr ""
+msgstr "Ajouter des commentaires"
 
 #: app/views/popup.massupdate.trigger.php:102
 #: include/views/configuration.graph.edit.php:429
@@ -907,35 +904,35 @@ msgstr "Ajouter prototype"
 
 #: app/controllers/CControllerPopupScheduledReportEdit.php:127
 msgid "Add scheduled report"
-msgstr ""
+msgstr "Ajouter un rapport planifié"
 
 #: app/views/js/administration.userrole.edit.js.php:206
 msgid "Add services"
-msgstr ""
+msgstr "Ajouter des services"
 
 #: app/views/monitoring.widget.navtreeitem.edit.php:68
 msgid "Add submaps"
-msgstr "Ajouter des sous-cartes"
+msgstr "Ajouter des sous‐cartes"
 
 #: app/controllers/CControllerFavouriteDelete.php:70 include/html.inc.php:153
 msgid "Add to favorites"
-msgstr ""
+msgstr "Ajouter aux favoris"
 
 #: include/actions.inc.php:1033
 msgid "Add to host group"
-msgstr "Ajouter au groupe d'hôtes"
+msgstr "Ajouter au groupe d’hôtes"
 
 #: include/actions.inc.php:714
 msgid "Add to host groups"
-msgstr "Ajouter aux groupes d'hôtes"
+msgstr "Ajouter aux groupes d’hôtes"
 
 #: app/partials/scheduledreport.subscription.php:42
 msgid "Add user"
-msgstr ""
+msgstr "Ajouter un utilisateur"
 
 #: app/partials/scheduledreport.subscription.php:46
 msgid "Add user group"
-msgstr ""
+msgstr "Ajouter un groupe d’utilisateurs"
 
 #: app/views/js/configuration.dashboard.edit.js.php:198
 #: app/views/js/monitoring.dashboard.view.js.php:283
@@ -946,7 +943,7 @@ msgstr "Ajouter un widget"
 #: app/controllers/CControllerAuditLogList.php:355
 #: app/controllers/CControllerPopupImportCompare.php:161
 msgid "Added"
-msgstr ""
+msgstr "Ajout effectué"
 
 #: jsLoader.php:338
 #, c-format
@@ -956,15 +953,15 @@ msgstr "Ajouté, %1$s"
 
 #: app/views/popup.service.statusrule.edit.php:93
 msgid "Additional rule"
-msgstr ""
+msgstr "Règle additionnelle"
 
 #: app/views/popup.service.edit.php:161
 msgid "Additional rules"
-msgstr ""
+msgstr "Règles additionnelles"
 
 #: app/partials/administration.ha.nodes.php:28
 msgid "Address"
-msgstr ""
+msgstr "Adresse"
 
 #: include/hosts.inc.php:63 include/users.inc.php:53
 msgid "Admin"
@@ -977,7 +974,7 @@ msgstr "Administration"
 
 #: app/views/popup.service.edit.php:137
 msgid "Advanced configuration"
-msgstr ""
+msgstr "Configuration avancée"
 
 #: include/views/monitoring.sysmap.edit.php:158
 msgid "Advanced labels"
@@ -999,51 +996,51 @@ msgstr "Agent"
 
 #: include/classes/data/CItemData.php:840
 msgid "Agent availability check. Returns nothing - unavailable; 1 - available"
-msgstr "Vérification de la disponibilité de l'agent. Aucun retour - indisponible ; 1 - disponible"
+msgstr "Vérification de la disponibilité de l’agent. Aucun retour — indisponible ; 1 — disponible"
 
 #: app/views/configuration.host.list.php:194
 msgid "Agent encryption"
-msgstr "Chiffrement sur l'agent"
+msgstr "Chiffrement sur l’agent"
 
 #: include/classes/data/CItemData.php:832
 msgid "Agent host metadata. Returns string"
-msgstr ""
+msgstr "Métadonnées d’hôte de l’agent. Renvoie une chaîne de caractères"
 
 #: include/classes/data/CItemData.php:836
 msgid "Agent host name. Returns string"
-msgstr "Nom d'hôte de l'agent. Retourne une chaîne"
+msgstr "Nom d’hôte de l’agent. Retourne une chaîne"
 
 #: include/views/inventory.host.view.php:64
 msgid "Agent interfaces"
-msgstr "Interfaces de l'agent"
+msgstr "Interfaces de l’agent"
 
 #: include/classes/data/CItemData.php:844
 msgid "Agent variant check. Returns 1 - for Zabbix agent; 2 - for Zabbix agent 2"
-msgstr ""
+msgstr "Vérification de la variante de l’agent. Retourne : 1 — pour « Zabbix agent », 2 — pour « Zabbix agent 2 »"
 
 #: include/classes/widgets/CWidgetHelper.php:1163
 msgid "Aggregate"
-msgstr ""
+msgstr "Agréger"
 
 #: app/views/popup.triggerexpr.php:108
 msgid "Aggregate functions"
-msgstr ""
+msgstr "Fonctions d’agrégation"
 
 #: include/classes/widgets/CWidgetHelper.php:1135
 msgid "Aggregation function"
-msgstr ""
+msgstr "Fonction d’agrégation"
 
 #: include/classes/widgets/CWidgetHelper.php:1154
 msgid "Aggregation interval"
-msgstr ""
+msgstr "Intervalle d’agrégation"
 
 #: include/actions.inc.php:2106
 msgid "Alert message"
-msgstr "Message d'alerte"
+msgstr "Message d’alerte"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1070
 msgid "Algorithm"
-msgstr ""
+msgstr "Algorithme"
 
 #: include/hosts.inc.php:114
 msgid "Alias"
@@ -1088,7 +1085,7 @@ msgstr "Tous les hôtes"
 
 #: jsLoader.php:282
 msgid "All links should have \"Name\" and \"URL\" specified"
-msgstr "Tous liens doivent avoir \"Nom\" et \"URL\" spécifiés"
+msgstr "Tous les liens doivent avoir « Nom » et « URL » spécifiés"
 
 #: include/html.inc.php:513
 msgid "All maps"
@@ -1102,15 +1099,15 @@ msgstr "Tous les problèmes"
 #: include/views/configuration.trigger.prototype.edit.php:503
 #: include/views/configuration.triggers.edit.php:530
 msgid "All problems if tag values match"
-msgstr "Tous les problèmes si les valeurs de tag correspondent"
+msgstr "Tous les problèmes si les valeurs d’étiquette correspondent"
 
 #: app/controllers/CControllerServiceListGeneral.php:145
 msgid "All services"
-msgstr ""
+msgstr "Tous les services"
 
 #: app/partials/administration.usergroup.tagfilters.html.php:47
 msgid "All tags"
-msgstr "Tous les tags"
+msgstr "Toutes les étiquettes"
 
 #: include/html.inc.php:267
 msgid "All templates"
@@ -1118,7 +1115,7 @@ msgstr "Tous les modèles"
 
 #: app/views/administration.userrole.edit.php:289
 msgid "Allow list"
-msgstr ""
+msgstr "Liste d’autoristation"
 
 #: app/views/popup.massupdate.trigger.php:61 include/triggers.inc.php:994
 #: include/views/configuration.trigger.prototype.edit.php:515
@@ -1135,19 +1132,19 @@ msgstr "Hôtes autorisés"
 
 #: app/views/administration.user.edit.php:623
 msgid "Allowed methods"
-msgstr ""
+msgstr "Méthodes autorisées"
 
 #: include/classes/setup/CSetupWizard.php:854
 msgid "Alternatively, you can install it manually:"
-msgstr "Alternativement, vous pouvez l'installer manuellement :"
+msgstr "Vous pouvez également l’installer manuellement :"
 
 #: include/classes/data/CItemData.php:1464
 msgid "Amount of guest physical memory that is swapped out to the swap space, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr ""
+msgstr "Quantité de mémoire physique de l’invité qui est échangée vers l’espace d’échange, <url>— URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1484
 msgid "Amount of host physical memory consumed for backing up guest physical memory pages, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr ""
+msgstr "Quantité de mémoire physique de l’hôte utilisée pour la sauvegarde des pages de mémoire physique de l’invité, <url>— URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: app/partials/popup.operations.php:240
 #: app/views/configuration.correlation.edit.php:114
@@ -1198,8 +1195,7 @@ msgstr "Et/Ou"
 #: app/views/monitoring.service.list.php:82
 #: app/views/reports.scheduledreport.list.php:60
 #: include/classes/widgets/forms/CWidgetFormTrigOver.php:36
-#: include/triggers.inc.php:1597
-#: include/views/configuration.action.list.php:75
+#: include/triggers.inc.php:1597 include/views/configuration.action.list.php:75
 #: include/views/configuration.maintenance.list.php:65
 msgid "Any"
 msgstr "Tous"
@@ -1207,11 +1203,11 @@ msgstr "Tous"
 #: app/views/js/administration.regex.edit.js.php:164
 #: include/classes/helpers/CRegexHelper.php:27
 msgid "Any character string included"
-msgstr "Toute chaîne de caractères inclue"
+msgstr "Toute chaîne de caractères incluse"
 
 #: include/classes/core/CJsonRpc.php:196
 msgid "Application error."
-msgstr "Erreur d'application."
+msgstr "Erreur d’application."
 
 #: app/partials/timeselector.filter.php:104
 #: app/views/dashboard.page.properties.edit.php:64
@@ -1231,7 +1227,7 @@ msgstr "Appliquer"
 
 #: include/views/configuration.hostgroups.edit.php:46
 msgid "Apply permissions and tag filters to all subgroups"
-msgstr "Appliquer les permissions et les filtres de tag à tous les sous-groupes"
+msgstr "Appliquer les permissions et les filtres d’étiquette à tous les sous‐groupes"
 
 #: include/views/configuration.maintenance.list.php:67
 #: include/views/configuration.maintenance.list.php:101
@@ -1241,23 +1237,23 @@ msgstr "Proche de"
 
 #: include/func.inc.php:223
 msgid "Apr"
-msgstr "Avr"
+msgstr "avr."
 
 #: include/func.inc.php:103 include/func.inc.php:240 jsLoader.php:234
 msgid "April"
-msgstr "Avril"
+msgstr "avril"
 
 #: app/views/popup.tabfilter.edit.php:76
 msgid "Are you sure you want to delete this filter?"
-msgstr ""
+msgstr "Êtes‐vous sûr de vouloir supprimer ce filtre ?"
 
 #: app/views/js/administration.macros.edit.js.php:86
 msgid "Are you sure you want to delete?"
-msgstr ""
+msgstr "Confirmez‐vous cette suppression ?"
 
 #: include/classes/html/CButtonQMessage.php:52
 msgid "Are you sure you want to perform this action?"
-msgstr ""
+msgstr "Êtes‐vous sûr de vouloir effectuer cette action ?"
 
 #: include/views/js/monitoring.sysmaps.js.php:116
 msgid "Area size"
@@ -1273,7 +1269,7 @@ msgstr "Arithmétique"
 
 #: include/classes/helpers/CServiceHelper.php:148
 msgid "As is"
-msgstr ""
+msgstr "En l’état"
 
 #: include/views/monitoring.history.php:102
 msgid "As plain text"
@@ -1282,35 +1278,35 @@ msgstr "Format texte"
 #: app/views/administration.authentication.edit.php:275
 #: app/views/administration.authentication.edit.php:309
 msgid "Assertions"
-msgstr ""
+msgstr "Assertions"
 
 #: include/hosts.inc.php:149
 msgid "Asset tag"
-msgstr "Tag caractéristique"
+msgstr "Étiquette caractéristique"
 
 #: include/maintenances.inc.php:70
 #, c-format
 msgid "At %1$s:%2$s %3$s of every week"
 msgid_plural "At %1$s:%2$s %3$s of every %4$s weeks"
-msgstr[0] "A %1$s:%2$s %3$s de chaque semaine"
-msgstr[1] "A %1$s:%2$s %3$s de chaque %4$s semaines"
+msgstr[0] "À %1$s h %2$s %3$s de chaque semaine"
+msgstr[1] "À %1$s h %2$s %3$s de chaque %4$s semaines"
 
 #: include/maintenances.inc.php:50
 #, c-format
 msgid "At %1$s:%2$s every day"
 msgid_plural "At %1$s:%2$s every %3$s days"
-msgstr[0] "À %1$s:%2$s tous les jours"
-msgstr[1] "À %1$s:%2$s tous les %3$s jours"
+msgstr[0] "À %1$s h %2$s tous les jours"
+msgstr[1] "À %1$s h %2$s tous les %3$s jours"
 
 #: include/maintenances.inc.php:112
 #, c-format
 msgid "At %1$s:%2$s on %3$s %4$s of every %5$s"
-msgstr "À %1$s:%2$s le %3$s %4$s de chaque %5$s"
+msgstr "À %1$s h %2$s le %3$s %4$s de chaque %5$s"
 
 #: include/maintenances.inc.php:121
 #, c-format
 msgid "At %1$s:%2$s on day %3$s of every %4$s"
-msgstr "À %1$s:%2$s le %3$sme jour de chaque %4$s"
+msgstr "À %1$s h %2$s le %3$sᵉ jour de chaque %4$s"
 
 #: app/views/popup.maintenance.period.php:154
 msgid "At (hour:minute)"
@@ -1318,22 +1314,22 @@ msgstr "À (heure:minute)"
 
 #: app/views/administration.userrole.edit.php:115
 msgid "At least one UI element must be checked."
-msgstr ""
+msgstr "Au moins un élément doit être coché."
 
 #: include/classes/api/services/CRole.php:487
 #, c-format
 msgid "At least one UI element must be enabled for user role \"%1$s\"."
-msgstr ""
+msgstr "Au moins un élément de l’interface doit être activé pour le rôle d’utilisateur « %1$s »."
 
 #: app/controllers/CControllerPopupLldOperation.php:122
 msgid "At least one action is mandatory."
-msgstr ""
+msgstr "Au moins une action est obligatoire."
 
 #: include/classes/api/services/CUser.php:614
 #: include/classes/api/services/CUser.php:1286
 #, c-format
 msgid "At least one active user must exist with role \"%1$s\"."
-msgstr ""
+msgstr "Au moins un utilisateur actif doit avoir le rôle « %1$s »."
 
 #: include/classes/api/services/CMaintenance.php:286
 #: include/classes/api/services/CMaintenance.php:713
@@ -1344,7 +1340,7 @@ msgstr "Au moins un groupe hôte ou un hôte doit être sélectionné."
 #: include/classes/api/services/CHostGroup.php:1088
 #: include/classes/api/services/CHostGroup.php:1245
 msgid "At least one host or template must be specified."
-msgstr ""
+msgstr "Au moins un hôte ou un modèle doit être spécifié."
 
 #: include/classes/api/services/CMaintenance.php:380
 #: include/classes/api/services/CMaintenance.php:388
@@ -1355,11 +1351,11 @@ msgstr "Au moins une période de maintenance doit être créée."
 
 #: include/classes/setup/CFrontendSetup.php:241
 msgid "At least one of MySQL, PostgreSQL or Oracle should be supported."
-msgstr ""
+msgstr "Au moins MySQL, PostgreSQL et Oracle devraient être pris en charge."
 
 #: app/views/configuration.correlation.edit.php:156
 msgid "At least one operation must be selected."
-msgstr ""
+msgstr "Au moins une opération doit être sélectionnée."
 
 #: include/views/configuration.action.edit.php:511
 msgid "At least one operation must exist."
@@ -1367,7 +1363,7 @@ msgstr "Au moins une opération doit exister."
 
 #: app/controllers/CControllerPopupAcknowledgeCreate.php:172
 msgid "At least one update operation or message is mandatory"
-msgstr ""
+msgstr "Au moins une opération ou un message de mise à jour est obligatoire"
 
 #: app/views/popup.acknowledge.edit.php:105
 msgid "At least one update operation or message must exist."
@@ -1375,11 +1371,11 @@ msgstr "Au moins une opération de mise à jour ou un message doit exister."
 
 #: app/partials/popup.operations.php:75
 msgid "At least one user or user group must be selected."
-msgstr "Au moins un utilisateur ou un groupe d'utilisateurs doit être sélectionné."
+msgstr "Au moins un utilisateur ou un groupe d’utilisateurs doit être sélectionné."
 
 #: include/classes/api/services/CReport.php:343
 msgid "At least one user or user group must be specified."
-msgstr ""
+msgstr "Au moins un utilisateur ou un groupe d’utilisateurs doit être sélectionné."
 
 #: app/views/administration.mediatype.edit.php:340
 msgid "Attempt interval"
@@ -1393,7 +1389,7 @@ msgstr "Tentatives"
 
 #: app/views/administration.geomaps.edit.php:88
 msgid "Attribution"
-msgstr ""
+msgstr "Attribution"
 
 #: app/views/administration.housekeeping.edit.php:178
 #: include/classes/helpers/CMenuHelper.php:119
@@ -1407,28 +1403,28 @@ msgstr "Audit"
 #: app/views/reports.auditlog.list.php:78
 #: include/classes/helpers/CMenuHelper.php:229 include/html.inc.php:889
 msgid "Audit log"
-msgstr "Journal d'audit"
+msgstr "Journal d’audit"
 
 #: app/views/administration.housekeeping.edit.php:179
 msgid "Audit settings"
-msgstr ""
+msgstr "Paramètres d’audit"
 
 #: include/func.inc.php:227
 msgid "Aug"
-msgstr "Aoû"
+msgstr "août"
 
 #: include/func.inc.php:107 include/func.inc.php:244 jsLoader.php:238
 msgid "August"
-msgstr "Août"
+msgstr "août"
 
 #: app/views/administration.token.view.php:38
 #: app/views/administration.user.token.view.php:37
 msgid "Auth token"
-msgstr ""
+msgstr "Jeton d’authentification"
 
 #: app/views/administration.authentication.edit.php:281
 msgid "AuthN requests"
-msgstr ""
+msgstr "Requêtes d’authentification"
 
 #: app/controllers/CControllerAuditLogList.php:211
 #: app/views/administration.authentication.edit.php:323
@@ -1445,12 +1441,12 @@ msgstr "Authentification"
 #: app/views/popup.massupdate.host.php:150
 #: include/views/configuration.host.prototype.edit.php:303
 msgid "Authentication algorithm"
-msgstr "Algorithme d'authentification"
+msgstr "Algorithme d’authentification"
 
 #: include/classes/api/services/CUser.php:2047
 #, c-format
 msgid "Authentication failed: %1$s."
-msgstr "L'authentification a échoué: %1$s."
+msgstr "L’authentification a échoué : %1$s."
 
 #: app/views/administration.script.edit.php:129
 #: app/views/popup.massupdate.item.php:170
@@ -1458,32 +1454,32 @@ msgstr "L'authentification a échoué: %1$s."
 #: include/views/configuration.item.edit.php:630
 #: include/views/configuration.item.prototype.edit.php:614
 msgid "Authentication method"
-msgstr "Méthode d'authentification"
+msgstr "Méthode d’authentification"
 
 #: app/partials/configuration.host.interface.row.php:154
 #: app/views/popup.discovery.check.php:103
 #: app/views/popup.itemtestedit.view.php:202
 msgid "Authentication passphrase"
-msgstr "Phrase d'authentification"
+msgstr "Phrase d’authentification"
 
 #: app/partials/configuration.host.interface.row.php:143
 #: app/views/popup.discovery.check.php:96
 #: app/views/popup.itemtestedit.view.php:191
 msgid "Authentication protocol"
-msgstr "Protocole d'authentification"
+msgstr "Protocole d’authentification"
 
 #: app/controllers/CControllerAuthenticationUpdate.php:393
 msgid "Authentication settings updated"
-msgstr "Paramètres d'authentification mis à jour"
+msgstr "Paramètres d’authentification mis à jour"
 
 #: app/views/administration.module.edit.php:40
 #: app/views/administration.module.list.php:76
 msgid "Author"
-msgstr ""
+msgstr "Auteur"
 
 #: app/views/administration.miscconfig.edit.php:86
 msgid "Authorization"
-msgstr ""
+msgstr "Autorisation"
 
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:48
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:150
@@ -1498,29 +1494,29 @@ msgstr "Connexion automatique"
 
 #: include/classes/api/services/CUser.php:1012
 msgid "Auto-login and auto-logout options cannot be enabled together."
-msgstr "Les options d'auto-connexion et d'auto-déconnexion ne peuvent pas être activées en même temps."
+msgstr "Les options d’auto‐connexion et d’auto‐déconnexion ne peuvent pas être activées en même temps."
 
 #: app/views/administration.user.edit.php:260
 msgid "Auto-logout"
-msgstr "Auto-déconnexion"
+msgstr "Auto‐déconnexion"
 
 #: app/partials/configuration.host.edit.html.php:360
 #: app/partials/popup.operations.php:228
 #: app/views/administration.miscconfig.edit.php:61
-#: app/views/popup.lldoperation.php:282
-#: app/views/popup.massupdate.host.php:185 include/hosts.inc.php:1128
+#: app/views/popup.lldoperation.php:282 app/views/popup.massupdate.host.php:185
+#: include/hosts.inc.php:1128
 #: include/views/configuration.host.prototype.edit.php:362
 msgid "Automatic"
 msgstr "Automatique"
 
 #: include/views/monitoring.sysmap.edit.php:138
 msgid "Automatic icon mapping"
-msgstr "Correspondance d'icône automatique"
+msgstr "Correspondance d’icône automatique"
 
 #: include/views/js/monitoring.sysmaps.js.php:255
 #: include/views/js/monitoring.sysmaps.js.php:670
 msgid "Automatic icon selection"
-msgstr "Sélection automatique d'icône"
+msgstr "Sélection automatique d’icône"
 
 #: app/controllers/CControllerAuditLogList.php:212
 #: app/controllers/CControllerAutoregEdit.php:67
@@ -1530,16 +1526,16 @@ msgstr "Sélection automatique d'icône"
 #: include/classes/helpers/CMediatypeHelper.php:183
 #: include/classes/helpers/CMenuHelper.php:225 include/html.inc.php:887
 msgid "Autoregistration"
-msgstr ""
+msgstr "Enregistrement automatique"
 
 #: include/classes/helpers/CMenuHelper.php:185
 #: include/views/configuration.action.list.php:30
 msgid "Autoregistration actions"
-msgstr ""
+msgstr "Actions d’enregistrement automatique"
 
 #: app/views/administration.housekeeping.edit.php:86
 msgid "Autoregistration data storage period"
-msgstr ""
+msgstr "Durée de stockage de l’enregistrement automatique"
 
 #: app/partials/monitoring.host.view.html.php:31
 #: app/views/configuration.host.list.php:193
@@ -1564,15 +1560,15 @@ msgstr "Moyen"
 
 #: include/classes/data/CItemData.php:1544
 msgid "Average number of outstanding read requests to the virtual disk during the collection interval , <url> - VMware service URL, <uuid> - VMware virtual machine host name, <instance> - disk device instance"
-msgstr ""
+msgstr "Nombre moyen de requêtes de lecture en attente sur le disque virtuel pendant l’intervalle de collecte <url>— URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware, <instance> — instance du périphérique disque"
 
 #: include/classes/data/CItemData.php:1564
 msgid "Average number of outstanding write requests to the virtual disk during the collection interval, <url> - VMware service URL, <uuid> - VMware virtual machine host name, <instance> - disk device instance"
-msgstr ""
+msgstr "Nombre moyen de requêtes d’écriture en attente sur le disque virtuel pendant l’intervalle de collecte <url>— URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware, <instance> — instance du périphérique disque"
 
 #: app/views/administration.authentication.edit.php:93
 msgid "Avoid easy-to-guess passwords"
-msgstr ""
+msgstr "Évitez les mots de passe trop simples"
 
 #: include/classes/widgets/views/widget.svggraph.form.view.php:294
 msgid "Axes"
@@ -1591,7 +1587,7 @@ msgstr "Fond"
 
 #: include/views/js/monitoring.sysmaps.js.php:565
 msgid "Background color"
-msgstr ""
+msgstr "Couleur de fond"
 
 #: include/views/monitoring.sysmap.edit.php:121
 msgid "Background image"
@@ -1601,7 +1597,7 @@ msgstr "Image de fond"
 #: include/classes/widgets/CWidgetHelper.php:816
 #: include/classes/widgets/CWidgetHelper.php:1065
 msgid "Bar"
-msgstr ""
+msgstr "En barres"
 
 #: app/views/administration.authentication.edit.php:175
 msgid "Base DN"
@@ -1610,7 +1606,7 @@ msgstr "DN de base"
 #: include/classes/widgets/CWidgetHelper.php:799
 #: include/classes/widgets/CWidgetHelper.php:1056
 msgid "Base color"
-msgstr ""
+msgstr "Couleur de base"
 
 #: include/httptest.inc.php:28
 msgid "Basic"
@@ -1627,11 +1623,11 @@ msgstr "Mot de passe de lien"
 #: app/controllers/CControllerPopupTriggerExpr.php:397
 #: app/controllers/CControllerPopupTriggerExpr.php:430
 msgid "Bits to shift"
-msgstr ""
+msgstr "Bits à décaler"
 
 #: app/views/popup.triggerexpr.php:109
 msgid "Bitwise functions"
-msgstr ""
+msgstr "Fonctions binaires"
 
 #: app/views/administration.user.list.php:143
 msgid "Blocked"
@@ -1653,7 +1649,7 @@ msgstr "Corps"
 #: include/views/configuration.item.edit.php:433
 #: include/views/configuration.item.prototype.edit.php:418
 msgid "Body and headers"
-msgstr "Corps et en-tête"
+msgstr "Corps et en‐tête"
 
 #: include/graphs.inc.php:59 include/views/js/monitoring.sysmaps.js.php:781
 #: include/views/js/monitoring.sysmaps.js.php:871
@@ -1670,7 +1666,7 @@ msgstr "Bordure"
 
 #: include/views/js/monitoring.sysmaps.js.php:596
 msgid "Border color"
-msgstr ""
+msgstr "Couleur de la bordure"
 
 #: include/views/js/monitoring.sysmaps.js.php:574
 msgid "Border type"
@@ -1682,7 +1678,7 @@ msgstr "Largeur de bordure"
 
 #: app/controllers/CControllerUserUpdateGeneral.php:106
 msgid "Both passwords must be equal."
-msgstr ""
+msgstr "Les deux mots de passe doivent être identiques."
 
 #: include/views/js/monitoring.sysmaps.js.php:42
 #: include/views/js/monitoring.sysmaps.js.php:146
@@ -1693,11 +1689,11 @@ msgstr "Bas"
 
 #: jsLoader.php:274
 msgid "Bring forward"
-msgstr "Amener vers l'avant"
+msgstr "Amener vers l’avant"
 
 #: jsLoader.php:273
 msgid "Bring to front"
-msgstr "Amener à l'avant"
+msgstr "Amener à l’avant"
 
 #: include/locales.inc.php:47
 msgid "Bulgarian (bg_BG)"
@@ -1729,7 +1725,7 @@ msgstr "FERMETURE"
 
 #: include/classes/data/CItemData.php:1088
 msgid "CPU information. Returns string or integer"
-msgstr "Informations du CPU. Retourne une chaîne ou un entier"
+msgstr "Informations du processeur. Retourne une chaîne ou un entier"
 
 #: include/classes/data/CItemData.php:1064
 msgid "CPU load. Returns float"
@@ -1737,36 +1733,36 @@ msgstr "Charge processeur. Retourne un flottant"
 
 #: include/classes/data/CItemData.php:1444
 msgid "CPU time spent waiting for swap-in, <url> - VMware service URL, <uuid> - VMware virtual machine host name, <instance> - CPU instance"
-msgstr ""
+msgstr "Temps processeur passé à attendre la lecture du fichier d’échange mémoire, <url>— URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware, <instance> — instance processeur"
 
 #: include/classes/data/CItemData.php:1296
 msgid "CPU usage as a percentage during the interval depends on power management or HT, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr ""
+msgstr "Le pourcentage d’utilisation du temps processeur durant l’intervalle dépend de la gestion de la consommation énergétique, <url>— URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1288
 msgid "CPU usage as a percentage during the interval, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr ""
+msgstr "Pourcentage d’utilisation du temps processeur durant l’intervalle, <url>— URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1448
 msgid "CPU usage as a percentage during the interval, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr ""
+msgstr "Pourcentage d’utilisation du temps processeur durant l’intervalle, <url>— URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1076
 msgid "CPU utilization percentage. Returns float"
-msgstr ""
+msgstr "Pourcentage d’utilisation du processeur. Revoie un flottant"
 
 #: app/views/popup.itemtestedit.view.php:300
 msgid "CRLF"
-msgstr ""
+msgstr "CRLF"
 
 #: include/items.inc.php:1831
 msgid "CSV to JSON"
-msgstr ""
+msgstr "CSV vers JSON"
 
 #: include/classes/validators/CApiInputValidator.php:2678
 #: include/classes/validators/CNewValidator.php:310
 msgid "CUID is expected"
-msgstr ""
+msgstr "Un CUID est attendu"
 
 #: include/items.inc.php:100 include/views/configuration.graph.edit.php:176
 #: include/views/configuration.graph.edit.php:263
@@ -1812,207 +1808,207 @@ msgstr "Rappel"
 #: app/views/monitoring.dashboard.view.php:147
 #: app/views/popup.import.compare.php:162
 #: include/classes/html/CButtonCancel.php:25
-#: include/classes/setup/CSetupWizard.php:310 jsLoader.php:205
-#: jsLoader.php:215 jsLoader.php:330 jsLoader.php:402
+#: include/classes/setup/CSetupWizard.php:310 jsLoader.php:205 jsLoader.php:215
+#: jsLoader.php:330 jsLoader.php:402
 msgid "Cancel"
 msgstr "Annuler"
 
 #: app/controllers/CControllerTokenCreate.php:44
 #: app/controllers/CControllerTokenCreate.php:105
 msgid "Cannot add API token"
-msgstr ""
+msgstr "Impossible d’ajouter le jeton d’API"
 
 #: include/classes/api/services/CGraph.php:517
 #: include/classes/api/services/CGraph.php:531
 #: include/classes/api/services/CGraph.php:545
 #, c-format
 msgid "Cannot add a non-numeric item \"%1$s\" to graph \"%2$s\"."
-msgstr "Impossible d'ajouter un élément non-numérique \"%1$s\" au graphique \"%2$s\"."
+msgstr "Impossible d’ajouter un élément non numérique « %1$s » au graphique « %2$s »."
 
 #: include/classes/api/services/CGraphPrototype.php:471
 #: include/classes/api/services/CGraphPrototype.php:535
 #, c-format
 msgid "Cannot add a non-numeric item \"%1$s\" to graph prototype \"%2$s\"."
-msgstr "Impossible d'ajouter un élément non numérique \"%1$s\" au prototype de graphique \"%2$s\"."
+msgstr "Impossible d’ajouter un élément « %1$s »  non numérique au prototype de graphique « %2$s »."
 
 #: actionconf.php:280
 msgid "Cannot add action"
-msgstr "Impossible d'ajouter l'action"
+msgstr "Impossible d’ajouter l’action"
 
 #: app/controllers/CControllerCorrelationCreate.php:115
 msgid "Cannot add correlation"
-msgstr "Impossible d'ajouter la corrélation"
+msgstr "Impossible d’ajouter la corrélation"
 
 #: jsLoader.php:131
 #, c-format
 msgid "Cannot add dashboard page: maximum number of %1$d dashboard pages has been added."
-msgstr ""
+msgstr "Impossible d’ajouter une page tableau de bord : le nombre maximum de %1$d pages de tableau de bord est atteint."
 
 #: include/classes/api/services/CTrigger.php:966
 #: include/classes/api/services/CTriggerPrototype.php:773
 msgid "Cannot add dependency from a host to a template."
-msgstr "Impossible d'ajouter une dépendance d'un hôte à un modèle."
+msgstr "Impossible d’ajouter une dépendance d’un hôte à un modèle."
 
 #: include/classes/api/services/CDiscoveryRule.php:885
 #: include/triggers.inc.php:371
 #, c-format
 msgid "Cannot add dependency from trigger \"%1$s:%2$s\" to non existing trigger \"%3$s:%4$s\"."
-msgstr "Impossible d'ajouter la dépendance du déclencheur \"%1$s:%2$s\" au déclencheur non existant \"%3$s:%4$s\"."
+msgstr "Impossible d’ajouter une dépendance au déclencheur « %1$s:%2$s » à un déclencheur inexistant « %3$s:%4$s »."
 
 #: host_discovery.php:715
 msgid "Cannot add discovery rule"
-msgstr "Impossible d'ajouter la règle de découverte"
+msgstr "Impossible d’ajouter la règle de découverte"
 
 #: graphs.php:249
 msgid "Cannot add graph"
-msgstr "Impossible d'ajouter le graphique"
+msgstr "Impossible d’ajouter le graphique"
 
 #: graphs.php:231
 msgid "Cannot add graph prototype"
-msgstr "Impossible d'ajouter le prototype de graphique"
+msgstr "Impossible d’ajouter le prototype de graphique"
 
 #: hostgroups.php:114
 msgid "Cannot add group"
-msgstr "Impossible d'ajouter le groupe"
+msgstr "Impossible d’ajouter le groupe"
 
 #: app/controllers/CControllerHostCreate.php:34
 #: app/controllers/CControllerHostCreate.php:136
 msgid "Cannot add host"
-msgstr "Impossible d'ajouter l'hôte"
+msgstr "Impossible d’ajouter l’hôte"
 
 #: host_prototypes.php:288
 msgid "Cannot add host prototype"
-msgstr "Impossible d'ajouter un prototype d'hôte"
+msgstr "Impossible d’ajouter un prototype d’hôte"
 
 #: app/controllers/CControllerImageCreate.php:41
 #: app/controllers/CControllerImageCreate.php:101
 #: app/controllers/CControllerImageCreate.php:132
 msgid "Cannot add image"
-msgstr "Impossible d'ajouter l'image"
+msgstr "Impossible d’ajouter l’image"
 
 #: items.php:931
 msgid "Cannot add item"
-msgstr "Impossible d'ajouter l'élément"
+msgstr "Impossible d’ajouter l’élément"
 
 #: disc_prototypes.php:608
 msgid "Cannot add item prototype"
-msgstr "Impossible d'ajouter le prototype d'élément"
+msgstr "Impossible d’ajouter le prototype d’élément"
 
 #: maintenance.php:123
 msgid "Cannot add maintenance"
-msgstr "Impossible d'ajouter une maintenance"
+msgstr "Impossible d’ajouter une maintenance"
 
 #: include/classes/api/services/CMap.php:1559
 #, c-format
 msgid "Cannot add map element of the map \"%1$s\" due to circular reference."
-msgstr "Impossible d'ajouter un élément de carte sur la carte \"%1$s\" en raison d'une référence circulaire."
+msgstr "Impossible d’ajouter un élément à la carte « %1$s » en raison d’une référence circulaire."
 
 #: app/controllers/CControllerMediatypeCreate.php:76
 #: app/controllers/CControllerMediatypeCreate.php:165
 msgid "Cannot add media type"
-msgstr "Impossible d'ajouter un type de média"
+msgstr "Impossible d’ajouter un type de média"
 
 #: app/controllers/CControllerModuleScan.php:103
 #, c-format
 msgid "Cannot add module: %1$s."
 msgid_plural "Cannot add modules: %1$s."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible d’ajouter le module : %1$s."
+msgstr[1] "Impossible d’ajouter les modules : %1$s."
 
 #: include/classes/api/services/CGraph.php:40
 #, c-format
 msgid "Cannot add more than one item with type \"Graph sum\" on graph \"%1$s\"."
-msgstr "Impossible d'ajouter plus d'un élément de type \"Somme du graphique\" sur le graphique \"%1$s\"."
+msgstr "Impossible d’ajouter plus d’un élément de type « Somme du graphique » au graphique « %1$s »."
 
 #: include/classes/api/services/CGraphPrototype.php:40
 #, c-format
 msgid "Cannot add more than one item with type \"Graph sum\" on graph prototype \"%1$s\"."
-msgstr "Impossible d'ajouter plus d'un élément de type \"Somme de graphique\" sur le prototype de graphique \"%1$s\"."
+msgstr "Impossible d’ajouter plus d’un élément de type « Somme de graphique » sur le prototype de graphique « %1$s »."
 
 #: sysmaps.php:214
 msgid "Cannot add network map"
-msgstr "Impossible d'ajouter une carte réseau"
+msgstr "Impossible d’ajouter une carte réseau"
 
 #: app/controllers/CControllerProxyCreate.php:58
 #: app/controllers/CControllerProxyCreate.php:121
 msgid "Cannot add proxy"
-msgstr "Impossible d'ajouter le proxy"
+msgstr "Impossible d’ajouter le proxy"
 
 #: app/controllers/CControllerRegExCreate.php:41
 #: app/controllers/CControllerRegExCreate.php:72
 msgid "Cannot add regular expression"
-msgstr "Impossible d'ajouter l'expression régulière"
+msgstr "Impossible d’ajouter l’expression rationnelle"
 
 #: app/controllers/CControllerScheduledReportCreate.php:152
 msgid "Cannot add scheduled report"
-msgstr ""
+msgstr "Impossible d’ajouter le rapport planifié"
 
 #: app/controllers/CControllerScriptCreate.php:60
 #: app/controllers/CControllerScriptCreate.php:155
 msgid "Cannot add script"
-msgstr "Impossible d'ajouter le script"
+msgstr "Impossible d’ajouter le script"
 
 #: app/views/monitoring.widget.navtreeitem.edit.php:63
 msgid "Cannot add submaps. Max depth reached."
-msgstr "Impossible d'ajouter des sous-cartes. La profondeur maximum est atteinte."
+msgstr "Impossible d’ajouter des sous‐cartes. La profondeur maximum est atteinte."
 
 #: templates.php:205
 msgid "Cannot add template"
-msgstr "Impossible d'ajouter le modèle"
+msgstr "Impossible d’ajouter le modèle"
 
 #: app/controllers/CControllerPopupTriggerWizard.php:213 triggers.php:296
 msgid "Cannot add trigger"
-msgstr "Impossible d'ajouter le déclencheur"
+msgstr "Impossible d’ajouter le déclencheur"
 
 #: trigger_prototypes.php:247
 msgid "Cannot add trigger prototype"
-msgstr "Impossible d'ajouter le prototype de déclencheur"
+msgstr "Impossible d’ajouter le prototype de déclencheur"
 
 #: app/controllers/CControllerUserCreate.php:63
 #: app/controllers/CControllerUserCreate.php:119
 msgid "Cannot add user"
-msgstr "Impossible d'ajouter l'utilisateur"
+msgstr "Impossible d’ajouter l’utilisateur"
 
 #: app/controllers/CControllerUsergroupCreate.php:51
 #: app/controllers/CControllerUsergroupCreate.php:101
 msgid "Cannot add user group"
-msgstr ""
+msgstr "Impossible d’ajouter le groupe d’utilisateurs"
 
 #: httpconf.php:198
 msgid "Cannot add web scenario"
-msgstr "Impossible d'ajouter le scénario web"
+msgstr "Impossible d’ajouter le scénario Web"
 
 #: jsLoader.php:132
 msgid "Cannot add widget: not enough free space on the dashboard."
-msgstr ""
+msgstr "Impossible d’ajouter le widget : plus assez d’espace disponible sur le tableau de bord."
 
 #: jsLoader.php:341
 msgctxt "screen reader"
 msgid "Cannot be removed"
-msgstr ""
+msgstr "Suppression impossible"
 
 #: include/classes/validators/CLdapAuthValidator.php:79
 msgid "Cannot bind anonymously to LDAP server."
-msgstr "Impossible d'établir une liaison anonyme au serveur LDAP."
+msgstr "Impossible d’établir une liaison anonyme au serveur LDAP."
 
 #: include/classes/validators/CLdapAuthValidator.php:78
 msgid "Cannot bind to LDAP server."
-msgstr "Impossible d'établir une liaison avec le serveur LDAP."
+msgstr "Impossible d’établir une liaison avec le serveur LDAP."
 
 #: include/forms.inc.php:1866 include/forms.inc.php:1873
 #: include/forms.inc.php:1883 include/forms.inc.php:1917
 #: include/forms.inc.php:1924 include/forms.inc.php:1934
 #, c-format
 msgid "Cannot build expression tree: %1$s."
-msgstr ""
+msgstr "Impossible de construire l’arbre d’expression : %1$s."
 
 #: include/classes/api/services/CRole.php:792
 msgid "Cannot change the user type of own role."
-msgstr ""
+msgstr "Impossible de modifier le type d’utilisateur de son propre rôle."
 
 #: httpconf.php:189 httpconf.php:433 items.php:956 items.php:1036
 msgid "Cannot clear history"
-msgstr "Impossible de nettoyer l'historique"
+msgstr "Impossible de nettoyer l’historique"
 
 #: include/classes/api/services/CDiscoveryRule.php:2510
 msgid "Cannot clone graph prototypes."
@@ -2020,13 +2016,13 @@ msgstr "Impossible de cloner les prototypes de graphiques."
 
 #: include/classes/api/services/CDiscoveryRule.php:2566
 msgid "Cannot clone host prototypes."
-msgstr "Impossible de cloner des prototypes d'hôtes."
+msgstr "Impossible de cloner des prototypes d’hôtes."
 
 #: include/classes/api/services/CDiscoveryRule.php:2313
 #: include/classes/api/services/CDiscoveryRule.php:2369
 #: include/classes/api/services/CDiscoveryRule.php:2387
 msgid "Cannot clone item prototypes."
-msgstr "Impossible de cloner les prototypes d'éléments."
+msgstr "Impossible de cloner les prototypes d’éléments."
 
 #: include/classes/api/services/CDiscoveryRule.php:798
 msgid "Cannot clone trigger prototypes."
@@ -2035,7 +2031,7 @@ msgstr "Impossible de cloner les prototypes de déclencheurs."
 #: include/classes/api/services/CEvent.php:848
 #, c-format
 msgid "Cannot close problem: %1$s."
-msgstr "Impossible de fermer le problème : %1$s."
+msgstr "Impossible de fermer le problème : %1$s."
 
 #: include/classes/validators/CLdapAuthValidator.php:77
 msgid "Cannot connect to LDAP server."
@@ -2047,7 +2043,7 @@ msgstr "Impossible de se connecter à la base de données."
 
 #: include/views/js/configuration.httpconf.edit.js.php:106
 msgid "Cannot convert POST data:"
-msgstr ""
+msgstr "Impossible de convertir les données POST :"
 
 #: graphs.php:392
 msgid "Cannot copy graph"
@@ -2058,7 +2054,7 @@ msgstr[1] "Impossible de copier les graphiques"
 #: items.php:1020
 msgid "Cannot copy item"
 msgid_plural "Cannot copy items"
-msgstr[0] "Impossible de copier l'élément"
+msgstr[0] "Impossible de copier l’élément"
 msgstr[1] "Impossible de copier les éléments"
 
 #: triggers.php:509
@@ -2070,12 +2066,12 @@ msgstr[1] "Impossible de copier les déclencheurs"
 #: include/triggers.inc.php:226
 #, c-format
 msgid "Cannot copy trigger \"%1$s:%2$s\", because it has multiple hosts in the expression."
-msgstr "Impossible de copier le déclencheur \"%1$s:%2$s\" parce qu'il contient plusieurs hôtes dans l'expression."
+msgstr "Impossible de copier le déclencheur « %1$s:%2$s » parce qu’il contient plusieurs hôtes dans l’expression."
 
 #: include/classes/api/services/CHostPrototype.php:291
 #, c-format
 msgid "Cannot create a host prototype on a discovered host \"%1$s\"."
-msgstr "Impossible de créer un prototype d'hôte sur un hôte découvert \"%1$s\"."
+msgstr "Impossible de créer un prototype d’hôte sur un hôte découvert « %1$s »."
 
 #: include/db.inc.php:34
 msgid "Cannot create another database connection."
@@ -2088,11 +2084,11 @@ msgstr "Impossible de créer des dépendances circulaires."
 
 #: include/classes/api/services/CTrigger.php:972
 msgid "Cannot create dependency on trigger itself."
-msgstr "Impossible de créer une dépendance sur le déclencheur lui-même."
+msgstr "Impossible de créer une dépendance sur le déclencheur lui‐même."
 
 #: include/classes/api/services/CTriggerPrototype.php:743
 msgid "Cannot create dependency on trigger prototype itself."
-msgstr "Impossible de créer une dépendance sur le prototype de déclencheur lui-même."
+msgstr "Impossible de créer une dépendance sur le prototype de déclencheur lui‐même."
 
 #: app/controllers/CControllerDiscoveryCreate.php:47
 #: app/controllers/CControllerDiscoveryCreate.php:92
@@ -2101,17 +2097,17 @@ msgstr "Impossible de créer une règle de découverte"
 
 #: app/controllers/CControllerIconMapCreate.php:56
 msgid "Cannot create icon map"
-msgstr "Impossible de créer la correspondance d'icône"
+msgstr "Impossible de créer la correspondance d’icône"
 
 #: app/controllers/CControllerScheduledReportCreate.php:59
 msgid "Cannot create scheduled report"
-msgstr ""
+msgstr "Impossible de créer le rapport planifié"
 
 #: include/classes/api/services/CService.php:2546
 #: include/classes/api/services/CService.php:2570
 #, c-format
 msgid "Cannot create service \"%1$s\": %2$s."
-msgstr ""
+msgstr "Impossible de créer le service « %1$s » : %2$s."
 
 #: include/classes/setup/CSetupWizard.php:850
 msgid "Cannot create the configuration file."
@@ -2120,34 +2116,33 @@ msgstr "Impossible de créer le fichier de configuration."
 #: app/controllers/CControllerUserroleCreate.php:99
 #: app/controllers/CControllerUserroleCreate.php:146
 msgid "Cannot create user role"
-msgstr ""
+msgstr "Impossible de créer le rôle d’utilisateur"
 
 #: app/controllers/CControllerTokenDelete.php:64
 msgid "Cannot delete API token"
 msgid_plural "Cannot delete API tokens"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible de supprimer le jeton d’API"
+msgstr[1] "Impossible de supprimer les jetons d’API"
 
 #: include/classes/api/services/CUser.php:1257
 #, c-format
 msgid "Cannot delete Zabbix internal user \"%1$s\", try disabling that user."
-msgstr "Impossible de supprimer l'utilisateur interne Zabbix \"%1$s\", essayez de désactiver cet utilisateur."
+msgstr "Impossible de supprimer l’utilisateur interne Zabbix « %1$s », essayez de désactiver cet utilisateur."
 
 #: actionconf.php:301
 msgid "Cannot delete action"
-msgstr "Impossible de supprimer l'action"
+msgstr "Impossible de supprimer l’action"
 
 #: include/classes/api/services/CRole.php:375
 #, c-format
 msgid "Cannot delete assigned user role \"%1$s\"."
-msgstr ""
+msgstr "Impossible de supprimer le rôle d’utilisateur assigné « %1$s »."
 
 #: app/controllers/CControllerCorrelationDelete.php:68
-#, fuzzy
 msgid "Cannot delete correlation"
 msgid_plural "Cannot delete correlations"
 msgstr[0] "Impossible de supprimer la corrélation"
-msgstr[1] "Impossible de supprimer la corrélation"
+msgstr[1] "Impossible de supprimer les corrélations"
 
 #: app/controllers/CControllerDashboardDelete.php:63
 #: app/controllers/CControllerTemplateDashboardDelete.php:61
@@ -2162,11 +2157,10 @@ msgid "Cannot delete dependency"
 msgstr "Impossible de supprimer la dépendance"
 
 #: app/controllers/CControllerDiscoveryDelete.php:69 host_discovery.php:410
-#, fuzzy
 msgid "Cannot delete discovery rule"
 msgid_plural "Cannot delete discovery rules"
 msgstr[0] "Impossible de supprimer la règle de découverte"
-msgstr[1] "Impossible de supprimer la règle de découverte"
+msgstr[1] "Impossible de supprimer les règles de découverte"
 
 #: host_discovery.php:758
 msgid "Cannot delete discovery rules"
@@ -2196,54 +2190,54 @@ msgstr[1] "Impossible de supprimer les groupes"
 
 #: app/controllers/CControllerHostMassDelete.php:74
 msgid "Cannot delete host"
-msgstr "Impossible de supprimer l'hôte"
+msgstr "Impossible de supprimer l’hôte"
 
 #: include/classes/api/services/CHost.php:1355
 #, c-format
 msgid "Cannot delete host because maintenance \"%1$s\" must contain at least one host or host group."
 msgid_plural "Cannot delete selected hosts because maintenance \"%1$s\" must contain at least one host or host group."
-msgstr[0] "Impossible de supprimer l'hôte car la maintenance \"%1$s\" doit contenir au moins un hôte ou un groupe d'hôtes."
-msgstr[1] "Impossible de supprimer les hôtes sélectionnés car la maintenance \"%1$s\" doit contenir au moins un hôte ou un groupe d'hôtes."
+msgstr[0] "Impossible de supprimer l’hôte car la maintenance « %1$s » doit contenir au moins un hôte ou un groupe d’hôtes."
+msgstr[1] "Impossible de supprimer les hôtes sélectionnés car la maintenance « %1$s » doit contenir au moins un hôte ou un groupe d’hôtes."
 
 #: include/classes/api/services/CHostGroup.php:826
 #, c-format
 msgid "Cannot delete host group because maintenance \"%1$s\" must contain at least one host or host group."
 msgid_plural "Cannot delete selected host groups because maintenance \"%1$s\" must contain at least one host or host group."
-msgstr[0] "Impossible de supprimer le groupe d'hôtes car la maintenance \"%1$s\" doit contenir au moins un hôte ou un groupe d'hôtes."
-msgstr[1] "Impossible de supprimer les groupes d'hôtes sélectionnés car la maintenance \"%1$s\" doit contenir au moins un hôte ou un groupe d'hôtes."
+msgstr[0] "Impossible de supprimer le groupe d’hôtes car la maintenance « %1$s » doit contenir au moins un hôte ou un groupe d’hôtes."
+msgstr[1] "Impossible de supprimer les groupes d’hôtes sélectionnés car la maintenance « %1$s » doit contenir au moins un hôte ou un groupe d’hôtes."
 
 #: host_prototypes.php:147 host_prototypes.php:340
 msgid "Cannot delete host prototypes"
-msgstr "Impossible de supprimer des prototypes d'hôtes"
+msgstr "Impossible de supprimer des prototypes d’hôtes"
 
 #: app/controllers/CControllerIconMapDelete.php:65
 msgid "Cannot delete icon map"
-msgstr "Impossible de supprimer la correspondance d'icône"
+msgstr "Impossible de supprimer la correspondance d’icône"
 
 #: app/controllers/CControllerImageDelete.php:71
 msgid "Cannot delete image"
-msgstr "Impossible de supprimer l'image"
+msgstr "Impossible de supprimer l’image"
 
 #: include/classes/api/services/CHostInterface.php:636
 #, c-format
 msgid "Cannot delete interface for discovered host \"%1$s\"."
-msgstr ""
+msgstr "Impossible de supprimer l’interface pour l’hôte découvert « %1$s »."
 
 #: include/classes/api/services/CHost.php:1142
 msgid "Cannot delete inventory."
-msgstr "Impossible de supprimer l'inventaire."
+msgstr "Impossible de supprimer l’inventaire."
 
 #: items.php:516
 msgid "Cannot delete item"
-msgstr "Impossible de supprimer l'élément"
+msgstr "Impossible de supprimer l’élément"
 
 #: disc_prototypes.php:310
 msgid "Cannot delete item prototype"
-msgstr "Impossible de supprimer le prototype d'élément"
+msgstr "Impossible de supprimer le prototype d’élément"
 
 #: disc_prototypes.php:651
 msgid "Cannot delete item prototypes"
-msgstr "Impossible de supprimer les prototypes d'éléments"
+msgstr "Impossible de supprimer les prototypes d’éléments"
 
 #: items.php:1046
 msgid "Cannot delete items"
@@ -2263,8 +2257,8 @@ msgstr[1] "Impossible de supprimer les types de média"
 #, c-format
 msgid "Cannot delete module: %1$s."
 msgid_plural "Cannot delete modules: %1$s."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible de supprimer le module : %1$s."
+msgstr[1] "Impossible de supprimer les modules : %1$s."
 
 #: sysmaps.php:261
 msgid "Cannot delete network map"
@@ -2279,19 +2273,19 @@ msgstr[1] "Impossible de supprimer les proxy"
 #: include/classes/api/services/CRole.php:369
 #, c-format
 msgid "Cannot delete readonly user role \"%1$s\"."
-msgstr ""
+msgstr "Impossible de supprimer le rôle d’utilisateur en lecteur seule « %1$s »."
 
 #: app/controllers/CControllerRegExDelete.php:55
 msgid "Cannot delete regular expression"
 msgid_plural "Cannot delete regular expressions"
-msgstr[0] "Impossible de supprimer l'expression régulière"
-msgstr[1] "Impossible de supprimer les expressions régulières"
+msgstr[0] "Impossible de supprimer l’expression rationnelle"
+msgstr[1] "Impossible de supprimer les expressions rationnelles"
 
 #: app/controllers/CControllerScheduledReportDelete.php:71
 msgid "Cannot delete scheduled report"
 msgid_plural "Cannot delete scheduled reports"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible de supprimer le rapport planifié"
+msgstr[1] "Impossible de supprimer les rapports planifiés"
 
 #: app/controllers/CControllerScriptDelete.php:69
 msgid "Cannot delete script"
@@ -2302,24 +2296,23 @@ msgstr[1] "Impossible de supprimer les scripts"
 #: include/classes/api/services/CScript.php:875
 #, c-format
 msgid "Cannot delete scripts. Script \"%1$s\" is used in action operation \"%2$s\"."
-msgstr "Impossible de supprimer les scripts. Le script \"%1$s\" est utilisé dans l'opération de l'action \"%2$s\"."
+msgstr "Impossible de supprimer des scripts. Le script « %1$s » est utilisé dans l’opération de l’action « %2$s »."
 
 #: actionconf.php:488
 msgid "Cannot delete selected actions"
 msgstr "Impossible de supprimer les actions sélectionnées"
 
 #: app/controllers/CControllerServiceDelete.php:72
-#, fuzzy
 msgid "Cannot delete service"
 msgid_plural "Cannot delete services"
 msgstr[0] "Impossible de supprimer le service"
-msgstr[1] "Impossible de supprimer le service"
+msgstr[1] "Impossible de supprimer les services"
 
 #: include/classes/api/services/CService.php:477
 #: include/classes/api/services/CService.php:492
 #, c-format
 msgid "Cannot delete service \"%1$s\": %2$s."
-msgstr ""
+msgstr "Impossible de supprimer le service « %1$s » : %2$s."
 
 #: templates.php:426 templates.php:440 templates.php:473
 msgid "Cannot delete template"
@@ -2335,34 +2328,34 @@ msgstr "Impossible de supprimer le graphique basé sur un modèle."
 
 #: include/classes/api/services/CHostPrototype.php:1313
 msgid "Cannot delete templated host prototype."
-msgstr "Impossible de supprimer un prototype d'hôte provenant d'un modèle."
+msgstr "Impossible de supprimer un prototype d’hôte provenant d’un modèle."
 
 #: include/classes/api/services/CItemPrototype.php:655
 msgid "Cannot delete templated item prototype."
-msgstr "Impossible de supprimer le prototype d'élément basé sur un modèle."
+msgstr "Impossible de supprimer le prototype d’élément basé sur un modèle."
 
 #: include/classes/api/services/CItem.php:770
 msgid "Cannot delete templated item."
-msgstr "Impossible de supprimer un élément provenant d'un modèle."
+msgstr "Impossible de supprimer un élément provenant d’un modèle."
 
 #: include/classes/api/services/CDiscoveryRule.php:581
 msgid "Cannot delete templated items."
-msgstr "Impossible de supprimer des éléments provenant d'un modèle."
+msgstr "Impossible de supprimer des éléments provenant d’un modèle."
 
 #: include/classes/api/services/CTrigger.php:657
 #, c-format
 msgid "Cannot delete templated trigger \"%1$s:%2$s\"."
-msgstr "Impossible de supprimer le déclencheur d'un modèle \"%1$s:%2$s\"."
+msgstr "Impossible de supprimer le déclencheur d’un modèle « %1$s:%2$s »."
 
 #: include/classes/api/services/CTriggerPrototype.php:523
 #, c-format
 msgid "Cannot delete templated trigger prototype \"%1$s:%2$s\"."
-msgstr "Impossible de supprimer le prototype de déclencheur basé sur un modèle \"%1$s:%2$s\"."
+msgstr "Impossible de supprimer le prototype de déclencheur basé sur un modèle « %1$s:%2$s »."
 
 #: include/classes/api/services/CHttpTest.php:610
 #, c-format
 msgid "Cannot delete templated web scenario \"%1$s\"."
-msgstr "Impossible de supprimer le scénario web \"%1$s\" provenant d'un modèle."
+msgstr "Impossible de supprimer le scénario Web « %1$s » provenant d’un modèle."
 
 #: triggers.php:416
 msgid "Cannot delete trigger"
@@ -2383,35 +2376,35 @@ msgstr "Impossible de supprimer les déclencheurs"
 #: app/controllers/CControllerUserDelete.php:59
 msgid "Cannot delete user"
 msgid_plural "Cannot delete users"
-msgstr[0] "Impossible de supprimer l'utilisateur"
-msgstr[1] ""
+msgstr[0] "Impossible de supprimer l’utilisateur"
+msgstr[1] "Impossible de supprimer les utilisateurs"
 
 #: app/controllers/CControllerUsergroupDelete.php:59
 msgid "Cannot delete user group"
 msgid_plural "Cannot delete user groups"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible de supprimer le groupe d’utilisateurs"
+msgstr[1] "Impossible de supprimer les groupes d’utilisateurs"
 
 #: app/controllers/CControllerUserroleDelete.php:59
 msgid "Cannot delete user role"
 msgid_plural "Cannot delete user roles"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible de supprimer le rôle d’utilisateur"
+msgstr[1] "Impossible de supprimer les rôles d’utilisateur"
 
 #: httpconf.php:177 httpconf.php:442
 msgid "Cannot delete web scenario"
-msgstr "Impossible de supprimer le scénario web"
+msgstr "Impossible de supprimer le scénario Web"
 
 #: app/controllers/CControllerTokenDisable.php:66
 msgid "Cannot disable API token"
 msgid_plural "Cannot disable API tokens"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible de désactiver le jeton d’API"
+msgstr[1] "Impossible de désactiver les jetons d’API"
 
 #: actionconf.php:477
 msgid "Cannot disable action"
 msgid_plural "Cannot disable actions"
-msgstr[0] "Impossible de désactiver l'action"
+msgstr[0] "Impossible de désactiver l’action"
 msgstr[1] "Impossible de désactiver les actions"
 
 #: app/controllers/CControllerCorrelationDisable.php:75
@@ -2430,13 +2423,13 @@ msgstr[1] "Impossible de désactiver les règles de découverte"
 #: app/controllers/CControllerProxyHostDisable.php:80 hostgroups.php:197
 msgid "Cannot disable host"
 msgid_plural "Cannot disable hosts"
-msgstr[0] "Impossible de désactiver l'hôte"
+msgstr[0] "Impossible de désactiver l’hôte"
 msgstr[1] "Impossible de désactiver les hôtes"
 
 #: items.php:980
 msgid "Cannot disable item"
 msgid_plural "Cannot disable items"
-msgstr[0] "Impossible de désactiver l'élément"
+msgstr[0] "Impossible de désactiver l’élément"
 msgstr[1] "Impossible de désactiver les éléments"
 
 #: app/controllers/CControllerMediatypeDisable.php:75
@@ -2449,14 +2442,14 @@ msgstr[1] "Impossible de désactiver les types de média"
 #, c-format
 msgid "Cannot disable module: %1$s."
 msgid_plural "Cannot disable modules: %1$s."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible de désactiver le module : %1$s."
+msgstr[1] "Impossible de désactiver les modules : %1$s."
 
 #: app/controllers/CControllerScheduledReportDisable.php:78
 msgid "Cannot disable scheduled report"
 msgid_plural "Cannot disable scheduled reports"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible de désactiver le rapport planifié"
+msgstr[1] "Impossible de désactiver les rapports planifiés"
 
 #: triggers.php:461
 msgid "Cannot disable trigger"
@@ -2467,94 +2460,94 @@ msgstr[1] "Impossible de désactiver les déclencheurs"
 #: httpconf.php:416
 msgid "Cannot disable web scenario"
 msgid_plural "Cannot disable web scenarios"
-msgstr[0] "Impossible de désactiver le scénario web"
-msgstr[1] "Impossible de désactiver les scénarios web"
+msgstr[0] "Impossible de désactiver le scénario Web"
+msgstr[1] "Impossible de désactiver les scénarios Web"
 
 #: app/controllers/CControllerQueueDetails.php:55
 #: app/controllers/CControllerQueueOverview.php:53
 #: app/controllers/CControllerQueueOverviewProxy.php:53
 msgid "Cannot display item queue."
-msgstr "Impossible d'afficher la file d'attente des éléments."
+msgstr "Impossible d’afficher la file d’attente des éléments."
 
 #: chart7.php:91
 msgid "Cannot display more than one item with type \"Graph sum\"."
-msgstr "Impossible d'afficher plus d'un élément de type \"Somme de graphique\"."
+msgstr "Impossible d’afficher plus d’un élément de type « Somme de graphique »."
 
 #: app/controllers/CControllerTokenEnable.php:66
 msgid "Cannot enable API token"
 msgid_plural "Cannot enable API tokens"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible d’activer le jeton d’API"
+msgstr[1] "Impossible d’activer les jetons d’API"
 
 #: actionconf.php:476
 msgid "Cannot enable action"
 msgid_plural "Cannot enable actions"
-msgstr[0] "Impossible d'activer l'action"
-msgstr[1] "Impossible d'activer les actions"
+msgstr[0] "Impossible d’activer l’action"
+msgstr[1] "Impossible d’activer les actions"
 
 #: app/controllers/CControllerCorrelationEnable.php:76
 msgid "Cannot enable correlation"
 msgid_plural "Cannot enable correlations"
-msgstr[0] "Impossible d'activer la corrélation"
-msgstr[1] "Impossible d'activer les corrélations"
+msgstr[0] "Impossible d’activer la corrélation"
+msgstr[1] "Impossible d’activer les corrélations"
 
 #: app/controllers/CControllerDiscoveryEnable.php:75 host_discovery.php:747
 msgid "Cannot enable discovery rule"
 msgid_plural "Cannot enable discovery rules"
-msgstr[0] "Impossible d'activer la règle de découverte"
-msgstr[1] "Impossible d'activer les règles de découverte"
+msgstr[0] "Impossible d’activer la règle de découverte"
+msgstr[1] "Impossible d’activer les règles de découverte"
 
 #: app/controllers/CControllerPopupMassupdateHost.php:442
 #: app/controllers/CControllerProxyHostEnable.php:80 hostgroups.php:196
 msgid "Cannot enable host"
 msgid_plural "Cannot enable hosts"
-msgstr[0] "Impossible d'activer l'hôte"
-msgstr[1] "Impossible d'activer les hôtes"
+msgstr[0] "Impossible d’activer l’hôte"
+msgstr[1] "Impossible d’activer les hôtes"
 
 #: items.php:979
 msgid "Cannot enable item"
 msgid_plural "Cannot enable items"
-msgstr[0] "Impossible d'activer l'élément"
-msgstr[1] "Impossible d'activer les éléments"
+msgstr[0] "Impossible d’activer l’élément"
+msgstr[1] "Impossible d’activer les éléments"
 
 #: app/controllers/CControllerMediatypeEnable.php:75
 msgid "Cannot enable media type"
 msgid_plural "Cannot enable media types"
-msgstr[0] "Impossible d'activer le type de média"
-msgstr[1] "Impossible d'activer les types de média"
+msgstr[0] "Impossible d’activer le type de média"
+msgstr[1] "Impossible d’activer les types de média"
 
 #: app/controllers/CControllerModuleUpdate.php:160
 #, c-format
 msgid "Cannot enable module: %1$s."
 msgid_plural "Cannot enable modules: %1$s."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible d’activer le module : %1$s."
+msgstr[1] "Impossible d’activer les modules : %1$s."
 
 #: app/controllers/CControllerScheduledReportEnable.php:78
 msgid "Cannot enable scheduled report"
 msgid_plural "Cannot enable scheduled reports"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible d’activer le rapport planifié"
+msgstr[1] "Impossible d’activer les rapports planifiés"
 
 #: triggers.php:460
 msgid "Cannot enable trigger"
 msgid_plural "Cannot enable triggers"
-msgstr[0] "Impossible d'activer le déclencheur"
-msgstr[1] "Impossible d'activer les déclencheurs"
+msgstr[0] "Impossible d’activer le déclencheur"
+msgstr[1] "Impossible d’activer les déclencheurs"
 
 #: httpconf.php:415
 msgid "Cannot enable web scenario"
 msgid_plural "Cannot enable web scenarios"
-msgstr[0] "Impossible d'activer le scénario web"
-msgstr[1] "Impossible d'activer les scénarios web"
+msgstr[0] "Impossible d’activer le scénario Web"
+msgstr[1] "Impossible d’activer les scénarios Web"
 
 #: app/controllers/CControllerPopupTestTriggerExpr.php:199
 msgid "Cannot evaluate expression"
-msgstr ""
+msgstr "Impossible d’interprèter l’expression"
 
 #: app/controllers/CControllerPopupScriptExec.php:123
 msgid "Cannot execute script."
-msgstr ""
+msgstr "Impossible d’exécuter le script."
 
 #: jsLoader.php:285
 msgid "Cannot expand macros."
@@ -2563,32 +2556,32 @@ msgstr "Substitution des macros impossible."
 #: include/classes/import/importers/CMapImporter.php:270
 #, c-format
 msgid "Cannot find background image \"%1$s\" used in map \"%2$s\"."
-msgstr "Impossible de trouver l'image de fond \"%1$s\" utilisée dans la carte \"%2$s\"."
+msgstr "Impossible de trouver l’image de fond « %1$s » utilisée par la carte « %2$s »."
 
 #: include/classes/import/importers/CTemplateDashboardImporter.php:170
 #, c-format
 msgid "Cannot find graph \"%1$s\" used in dashboard \"%2$s\"."
-msgstr ""
+msgstr "Impossible de trouver le graphique « %1$s » utilisé sur le tableau de bord « %2$s »."
 
 #: include/classes/import/importers/CMapImporter.php:152
 #, c-format
 msgid "Cannot find group \"%1$s\" used in map \"%2$s\"."
-msgstr "Impossible de trouver le groupe \"%1$s\" utilisé dans la carte \"%2$s\"."
+msgstr "Impossible de trouver le groupe « %1$s » utilisé par la carte « %2$s »."
 
 #: include/classes/import/importers/CTemplateDashboardImporter.php:140
 #, c-format
 msgid "Cannot find host \"%1$s\" used in dashboard \"%2$s\"."
-msgstr ""
+msgstr "Impossible de trouver l’hôte « %1$s » utilisé sur le tableau de bord « %2$s »."
 
 #: include/classes/import/importers/CMapImporter.php:164
 #, c-format
 msgid "Cannot find host \"%1$s\" used in map \"%2$s\"."
-msgstr "Impossible de trouver l'hôte \"%1$s\" utilisé dans la carte \"%2$s\"."
+msgstr "Impossible de trouver l’hôte « %1$s » utilisé dans la carte « %2$s »."
 
 #: include/classes/import/CConfigurationImport.php:1206
 #, c-format
 msgid "Cannot find host group \"%1$s\" for host prototype \"%2$s\" of discovery rule \"%3$s\" on \"%4$s\"."
-msgstr "Impossible de trouver le groupe d'hôtes \"%1$s\" pour le prototype d'hôte \"%2$s\" de la règle de découverte \"%3$s\" sur \"%4$s\"."
+msgstr "Impossible de trouver le groupe d’hôtes « %1$s » pour le prototype d’hôte « %2$s » de la règle de découverte « %3$s » sur « %4$s »."
 
 #: include/classes/api/services/CDiscoveryRule.php:2142
 #: include/classes/api/services/CDiscoveryRule.php:2346
@@ -2596,98 +2589,98 @@ msgstr "Impossible de trouver le groupe d'hôtes \"%1$s\" pour le prototype d'h�
 #: include/items.inc.php:701
 #, c-format
 msgid "Cannot find host interface on \"%1$s\" for item key \"%2$s\"."
-msgstr "Impossible de trouver l'interface de l'hôte sur \"%1$s\" pour la clé d'élément \"%2$s\"."
+msgstr "Impossible de trouver l’interface de l’hôte sur « %1$s » pour la clef d’élément « %2$s »."
 
 #: include/classes/import/importers/CMapImporter.php:207
 #, c-format
 msgid "Cannot find icon \"%1$s\" used in map \"%2$s\"."
-msgstr "Impossible de trouver l'icône \"%1$s\" utilisée dans la carte \"%2$s\"."
+msgstr "Impossible de trouver l’icône « %1$s » utilisée dans la carte « %2$s »."
 
 #: include/classes/import/importers/CMapImporter.php:258
 #, c-format
 msgid "Cannot find icon map \"%1$s\" used in map \"%2$s\"."
-msgstr "Impossible de trouver la correspondance d'icône \"%1$s\" utilisée dans la carte \"%2$s\"."
+msgstr "Impossible de trouver la carte d’icônes « %1$s » utilisée dans la carte « %2$s »."
 
 #: include/classes/import/CConfigurationImport.php:948
 #, c-format
 msgid "Cannot find interface \"%1$s\" used for discovery rule \"%2$s\" on \"%3$s\"."
-msgstr ""
+msgstr "Impossible de trouver l’interface « %1$s » utilisée comme règle de découverte « %2$s » de « %3$s »."
 
 #: include/classes/import/CConfigurationImport.php:717
 #, c-format
 msgid "Cannot find interface \"%1$s\" used for item \"%2$s\" on \"%3$s\"."
-msgstr ""
+msgstr "Impossible de trouver l’interface « %1$s » utilisée comme élément « %2$s » de « %3$s »."
 
 #: include/classes/import/CConfigurationImport.php:1100
 #, c-format
 msgid "Cannot find interface \"%1$s\" used for item prototype \"%2$s\" of discovery rule \"%3$s\" on \"%4$s\"."
-msgstr ""
+msgstr "Impossible de trouver l’interface « %1$s » utilisée comme prototype « %2$s » de règle de découverte « %3$s » de « %4$s »."
 
 #: include/classes/import/CConfigurationImport.php:1631
 #, c-format
 msgid "Cannot find item \"%1$s\" on \"%2$s\" used as the Y axis MAX value for graph \"%3$s\"."
-msgstr "Impossible de trouver l'élément \"%1$s\" sur \"%2$s\" utilisé comme valeur MAX de l'axe Y du graphique \"%3$s\"."
+msgstr "Impossible de trouver l’élément « %1$s » sur « %2$s » utilisé comme valeur maximum de l’axe Y du graphique « %3$s »."
 
 #: include/classes/import/CConfigurationImport.php:1403
 #, c-format
 msgid "Cannot find item \"%1$s\" on \"%2$s\" used as the Y axis MAX value for graph prototype \"%3$s\" of discovery rule \"%4$s\" on \"%5$s\"."
-msgstr "Impossible de trouver l'élément \"%1$s\" sur \"%2$s\" utilisé comme valeur MAX de l'axe Y du prototype de graphique \"%3$s\" de la règle de découverte \"%4$s\" sur \"%5$s\"."
+msgstr "Impossible de trouver l’élément « %1$s » sur « %2$s » utilisé comme valeur MAX de l’axe Y du prototype de graphique « %3$s » de la règle de découverte « %4$s » sur « %5$s »."
 
 #: include/classes/import/CConfigurationImport.php:1613
 #, c-format
 msgid "Cannot find item \"%1$s\" on \"%2$s\" used as the Y axis MIN value for graph \"%3$s\"."
-msgstr "Impossible de trouver l'élément \"%1$s\" sur \"%2$s\" utilisé comme valeur MIN de l'axe Y du graphique \"%3$s\"."
+msgstr "Impossible de trouver l’élément « %1$s » sur « %2$s » utilisé comme valeur MIN de l’axe Y du graphique « %3$s »."
 
 #: include/classes/import/CConfigurationImport.php:1382
 #, c-format
 msgid "Cannot find item \"%1$s\" on \"%2$s\" used as the Y axis MIN value for graph prototype \"%3$s\" of discovery rule \"%4$s\" on \"%5$s\"."
-msgstr "Impossible de trouver l'élément \"%1$s\" sur \"%2$s\" utilisé comme valeur MIN de l'axe Y du prototype de graphique \"%3$s\" de la règle de découverte \"%4$s\" sur \"%5$s\"."
+msgstr "Impossible de trouver l’élément « %1$s » sur « %2$s » utilisé comme valeur MIN de l’axe Y du prototype de graphique « %3$s » de la règle de découverte « %4$s » sur « %5$s »."
 
 #: include/classes/import/CConfigurationImport.php:1651
 #, c-format
 msgid "Cannot find item \"%1$s\" on \"%2$s\" used in graph \"%3$s\"."
-msgstr "Impossible de trouver l'élément \"%1$s\" sur \"%2$s\" utilisé dans le graphique \"%3$s\"."
+msgstr "Impossible de trouver l’élément « %1$s » sur « %2$s » utilisé dans le graphique « %3$s »."
 
 #: include/classes/import/CConfigurationImport.php:1424
 #, c-format
 msgid "Cannot find item \"%1$s\" on \"%2$s\" used in graph prototype \"%3$s\" of discovery rule \"%4$s\" on \"%5$s\"."
-msgstr "Impossible de trouver l'élément \"%1$s\" sur \"%2$s\" utilisé dans le prototype de graphique \"%3$s\" de la règle de découverte \"%4$s\" sur \"%5$s\"."
+msgstr "Impossible de trouver l’élément « %1$s » sur « %2$s » utilisé dans le prototype de graphique « %3$s » de la règle de découverte « %4$s » sur « %5$s »."
 
 #: include/classes/import/importers/CTemplateDashboardImporter.php:155
 #, c-format
 msgid "Cannot find item \"%1$s\" used in dashboard \"%2$s\"."
-msgstr ""
+msgstr "Impossible de trouver l’élément « %1$s » utilisé sur le tableau de bord « %2$s »."
 
 #: include/classes/import/importers/CMapImporter.php:140
 #, c-format
 msgid "Cannot find map \"%1$s\" used in map \"%2$s\"."
-msgstr "Impossible de trouver la carte \"%1$s\" utilisée dans la carte \"%2$s\"."
+msgstr "Impossible de trouver la carte « %1$s » utilisée dans la carte « %2$s »."
 
 #: include/classes/import/CConfigurationImport.php:1229
 #, c-format
 msgid "Cannot find template \"%1$s\" for host prototype \"%2$s\" of discovery rule \"%3$s\" on \"%4$s\"."
-msgstr "Impossible de trouver le modèle \"%1$s\" pour le prototype d'hôte \"%2$s\" de la règle de découverte \"%3$s\" sur \"%4$s\"."
+msgstr "Impossible de trouver le modèle « %1$s » pour le prototype d’hôte « %2$s » de la règle de découverte « %3$s » sur « %4$s »."
 
 #: include/classes/import/CConfigurationImport.php:998
 #, c-format
 msgid "Cannot find template \"%1$s\" for override \"%2$s\" of discovery rule \"%3$s\" on \"%4$s\"."
-msgstr ""
+msgstr "Impossible de trouver le modèle « %1$s » à utiliser pour remplacer « %2$s » dans la règle de découverte « %3$s » de « %4$s »."
 
 #: include/classes/import/importers/CMapImporter.php:179
 #: include/classes/import/importers/CMapImporter.php:229
 #, c-format
 msgid "Cannot find trigger \"%1$s\" used in map \"%2$s\"."
-msgstr "Impossible de trouver le déclencheur \"%1$s\" utilisé dans la carte \"%2$s\"."
+msgstr "Impossible de trouver le déclencheur « %1$s » utilisé dans la carte « %2$s »."
 
 #: include/classes/import/CConfigurationImport.php:730
 #, c-format
 msgid "Cannot find value map \"%1$s\" used for item \"%2$s\" on \"%3$s\"."
-msgstr "Impossible de trouver la table de correspondances \"%1$s\" utilisée pour l'élément \"%2$s\" sur \"%3$s\"."
+msgstr "Impossible de trouver la table de correspondances « %1$s » utilisée pour l’élément « %2$s » sur « %3$s »."
 
 #: include/classes/import/CConfigurationImport.php:1116
 #, c-format
 msgid "Cannot find value map \"%1$s\" used for item prototype \"%2$s\" of discovery rule \"%3$s\" on \"%4$s\"."
-msgstr "Impossible de trouver la table de correspondances \"%1$s\" utilisée pour le prototype d'élément \"%2$s\" de la règle de découverte \"%3$s\" sur \"%4$s\"."
+msgstr "Impossible de trouver la table de correspondances « %1$s » utilisée pour le prototype d’élément « %2$s » de la règle de découverte « %3$s » sur « %4$s »."
 
 #: include/classes/api/services/CTemplate.php:971
 msgid "Cannot have empty visible template name."
@@ -2699,25 +2692,25 @@ msgstr "Le nom visible du modèle ne peut pas être vide."
 #: include/classes/api/services/CRole.php:683
 #, c-format
 msgid "Cannot have non-default \"%2$s\" rule while having \"%3$s\" set to %4$d for user role \"%1$s\"."
-msgstr ""
+msgstr "Impossible d’avoir une règle « %2$s » différente de celle par défaut en ayant « %3$s » défini à « %4$d » pour le rôle d’utilisateur « %1$s »."
 
 #: include/classes/api/services/CRole.php:569
 #: include/classes/api/services/CRole.php:645
 #, c-format
 msgid "Cannot have non-empty tag value while having empty tag in rule \"%2$s\" for user role \"%1$s\"."
-msgstr ""
+msgstr "Impossible d’avoir une valeur d’étiquette non vide en ayant une étiquette vide dans la règle « %2$s » pour le rôle d’utilisateur « %1$s »."
 
 #: include/classes/import/importers/CTemplateImporter.php:253
 #: include/classes/import/importers/CTemplateImporter.php:405
 #, c-format
 msgid "Cannot import template \"%1$s\", linked template \"%2$s\" does not exist."
 msgid_plural "Cannot import template \"%1$s\", linked templates \"%2$s\" do not exist."
-msgstr[0] "Impossible d'importer le modèle \"%1$s\", le modèle lié \"%2$s\" n'existe pas."
-msgstr[1] "Impossible d'importer le modèle \"%1$s\", les modèles liés \"%2$s\" n'existent pas."
+msgstr[0] "Impossible d’importer le modèle « %1$s », le modèle lié « %2$s » n’existe pas."
+msgstr[1] "Impossible d’importer le modèle « %1$s », les modèles liés « %2$s » n’existent pas."
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1527
 msgid "Cannot insert trigger expression"
-msgstr "Impossible d'insérer l'expression de déclencheur"
+msgstr "Impossible d’insérer l’expression de déclencheur"
 
 #: include/classes/api/services/CHost.php:1120
 msgid "Cannot link template"
@@ -2733,16 +2726,16 @@ msgstr "Impossible de lier le modèle."
 #, c-format
 msgid "Cannot load module at: %1$s."
 msgid_plural "Cannot load modules at: %1$s."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible de charger le module : %1$s."
+msgstr[1] "Impossible de charger les modules : %1$s."
 
 #: include/classes/api/services/CUser.php:1449
 msgid "Cannot log out."
-msgstr ""
+msgstr "Déconnexion impossible."
 
 #: include/classes/api/services/CHost.php:986
 msgid "Cannot mass update host name."
-msgstr "Impossible de réaliser une mise à jour collective du nom d'hôte."
+msgstr "Impossible de réaliser une mise à jour collective du nom d’hôte."
 
 #: include/classes/api/services/CTemplate.php:1196
 msgid "Cannot mass update template name."
@@ -2750,7 +2743,7 @@ msgstr "Impossible de réaliser une mise à jour collective du nom de modèle."
 
 #: include/classes/api/services/CHost.php:972
 msgid "Cannot mass update visible host name."
-msgstr "Impossible de réaliser une mise à jour collective du nom d'hôte visible."
+msgstr "Impossible de réaliser une mise à jour collective du nom d’hôte visible."
 
 #: include/classes/api/services/CTemplate.php:1161
 msgid "Cannot mass update visible template name."
@@ -2759,111 +2752,111 @@ msgstr "Impossible de réaliser une mise à jour collective du nom visible de mo
 #: include/classes/api/services/CHostBase.php:68
 #, c-format
 msgid "Cannot pass duplicate template IDs for the linkage: %1$s."
-msgstr ""
+msgstr "Impossible de transmettre les identifiants du modèle dupliqué pour la liaison : %1$s."
 
 #: include/classes/db/DB.php:958
 #, c-format
 msgid "Cannot perform delete statement on table \"%1$s\" without where condition."
-msgstr "Impossible d'effectuer une suppression sur la table \"%1$s\" sans condition \"where\"."
+msgstr "Impossible d’effectuer une suppression sur la table « %1$s » sans condition « where »."
 
 #: include/classes/db/DB.php:671
 #, c-format
 msgid "Cannot perform update statement on table \"%1$s\" without values."
-msgstr "Impossible d'effectuer une mise à jour sur la table \"%1$s\" sans valeur."
+msgstr "Impossible d’effectuer une mise à jour sur la table « %1$s » sans valeur."
 
 #: include/classes/db/DB.php:684
 #, c-format
 msgid "Cannot perform update statement on table \"%1$s\" without where condition."
-msgstr "Impossible d'effectuer une mise à jour sur la table \"%1$s\" sans condition \"where\"."
+msgstr "Impossible d’effectuer une mise à jour sur la table « %1$s » sans condition « where »."
 
 #: include/classes/import/readers/CJsonImportReader.php:35
 #, c-format
 msgid "Cannot read JSON: %1$s."
-msgstr "Impossible de lire le JSON: %1$s."
+msgstr "Impossible de lire le JSON : %1$s."
 
 #: include/classes/import/readers/CXmlImportReader.php:35
 #: include/classes/import/readers/CXmlImportReader.php:46
 #, c-format
 msgid "Cannot read XML: %1$s."
-msgstr "Impossible de lire du XML : %1$s."
+msgstr "Impossible de lire du XML : %1$s."
 
 #: include/classes/import/readers/CYamlImportReader.php:52
 #: include/classes/import/readers/CYamlImportReader.php:55
 #, c-format
 msgid "Cannot read YAML: %1$s."
-msgstr ""
+msgstr "Impossible de lire le YAML : %1$s."
 
 #: include/classes/server/CZabbixServer.php:543
 #, c-format
 msgid "Cannot read the response, check connection with the Zabbix server \"%1$s\"."
-msgstr "Impossible de lire la réponse, veuillez vérifier la connexion avec le serveur Zabbix \"%1$s\"."
+msgstr "Impossible de lire la réponse, veuillez vérifier la connexion avec le serveur Zabbix « %1$s »."
 
 #: include/classes/api/services/CUser.php:556
 msgid "Cannot rename guest user."
-msgstr "Impossible de renommer l'utilisateur invité."
+msgstr "Impossible de renommer l’utilisateur invité."
 
 #: include/classes/api/services/CDRule.php:264
 #: include/classes/api/services/CDRule.php:414
 msgid "Cannot save discovery rule without checks."
-msgstr "Impossible d'enregistrer une règle de découverte sans vérifications."
+msgstr "Impossible d’enregistrer une règle de découverte sans vérifications."
 
 #: include/classes/helpers/CDashboardHelper.php:436
 #, c-format
 msgid "Cannot save widget \"%1$s\"."
-msgstr "Impossible de sauvegarder un widget: %1$s."
+msgstr "Impossible de sauvegarder un widget : %1$s."
 
 #: include/classes/server/CZabbixServer.php:484
 #, c-format
 msgid "Cannot send command, check connection with Zabbix server \"%1$s\"."
-msgstr "Impossible d'envoyer une commande, veuillez vérifier la connexion avec le serveur Zabbix \"%1$s\"."
+msgstr "Impossible d’envoyer une commande, veuillez vérifier la connexion avec le serveur Zabbix « %1$s »."
 
 #: host_discovery.php:422 host_discovery.php:778 items.php:950 items.php:1066
 msgid "Cannot send request"
-msgstr "Impossible d'envoyer la requête"
+msgstr "Impossible d’envoyer la requête"
 
 #: include/classes/api/services/CTask.php:441
 #: include/classes/api/services/CTask.php:454
 #, c-format
 msgid "Cannot send request: %1$s."
-msgstr "Impossible d'envoyer la requête : %1$s."
+msgstr "Impossible d’envoyer la requête : %1$s."
 
 #: include/classes/api/services/CGraphGeneral.php:535
 #, c-format
 msgid "Cannot set \"%1$s\" for graph \"%2$s\"."
-msgstr "Impossible de configurer \"%1$s\" pour le graphique \"%2$s\"."
+msgstr "Impossible de configurer « %1$s » pour le graphique « %2$s »."
 
 #: include/classes/api/services/CGraphGeneral.php:542
 #, c-format
 msgid "Cannot set \"%1$s\" for graph prototype \"%2$s\"."
-msgstr "Impossible de configurer \"%1$s\" pour le prototype de graphique \"%2$s\"."
+msgstr "Impossible de configurer « %1$s » pour le prototype de graphique « %2$s »."
 
 #: include/classes/api/services/CItemGeneral.php:337
 #, c-format
 msgid "Cannot set \"%1$s\" for item \"%2$s\"."
-msgstr "Impossible de configurer \"%1$s\" pour l'élément \"%2$s\"."
+msgstr "Impossible de configurer « %1$s » pour l’élément « %2$s »."
 
 #: include/classes/api/services/CHost.php:1037
 #: include/classes/api/services/CHost.php:1997
 #: include/classes/api/services/CHost.php:2200
 msgid "Cannot set inventory fields for disabled inventory."
-msgstr "Impossible de configurer les champs d'inventaire pour un inventaire désactivé."
+msgstr "Impossible de configurer les champs d’inventaire pour un inventaire désactivé."
 
 #: include/classes/core/CCookieSession.php:127
 msgid "Cannot set session cookie."
-msgstr ""
+msgstr "Impossible de définir le cookie de session."
 
 #: include/classes/api/services/CService.php:1412
 #, c-format
 msgid "Cannot specify \"propagation_rule\" parameter without specifying \"propagation_value\" parameter for service \"%1$s\"."
-msgstr ""
+msgstr "Impossible de spécifier le paramètre « propagation_rule » sans définir le paramètre « propagation_value » du service « %1$s »."
 
 #: jsLoader.php:293
 msgid "Cannot support notification audio for this device."
-msgstr ""
+msgstr "La prise en charge des notifications audio pour cet appareil est indisponible."
 
 #: include/classes/api/services/CHostInterface.php:306
 msgid "Cannot switch host for interface."
-msgstr "Impossible de changer d'hôte pour l'interface."
+msgstr "Impossible de changer d’hôte pour l’interface."
 
 #: app/controllers/CControllerPopupMediatypeTestEdit.php:71
 #: app/controllers/CControllerPopupMediatypeTestSend.php:81
@@ -2873,12 +2866,12 @@ msgstr "Impossible de tester le type de média désactivé."
 #: app/controllers/CControllerUserUnblock.php:68
 msgid "Cannot unblock user"
 msgid_plural "Cannot unblock users"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible de débloquer l’utilisateur"
+msgstr[1] "Impossible de débloquer les utilisateurs"
 
 #: include/classes/api/services/CHostGeneral.php:620
 msgid "Cannot unlink and clear Web scenarios."
-msgstr "Impossible de délier et effacer les scénarios web."
+msgstr "Impossible de délier et effacer les scénarios Web."
 
 #: include/classes/api/services/CHost.php:1095
 msgid "Cannot unlink template"
@@ -2892,59 +2885,59 @@ msgstr "Impossible de délier le modèle."
 #: include/classes/api/services/CHostGeneral.php:301
 #, c-format
 msgid "Cannot unlink trigger \"%1$s\", it has items from template that is left linked to host."
-msgstr ""
+msgstr "Impossible de déconnecter le déclencheur « %1$s », il possède des éléments du modèle toujours liés à l’hôte."
 
 #: include/classes/api/services/CAction.php:2626
 #, c-format
 msgid "Cannot update \"%1$s\" for action \"%2$s\"."
-msgstr "Impossible de mettre à jour \"%1$s\" pour l'action \"%2$s\"."
+msgstr "Impossible de mettre à jour « %1$s » pour l’action « %2$s »."
 
 #: include/classes/api/services/CGraphGeneral.php:721
 #, c-format
 msgid "Cannot update \"%1$s\" for graph \"%2$s\"."
-msgstr "Impossible de mettre à jour \"%1$s\" pour le graphique \"%2$s\"."
+msgstr "Impossible de mettre à jour « %1$s » pour le graphique « %2$s »."
 
 #: include/classes/api/services/CGraphGeneral.php:726
 #, c-format
 msgid "Cannot update \"%1$s\" for graph prototype \"%2$s\"."
-msgstr "Impossible de mettre à jour \"%1$s\" pour le prototype de graphique \"%2$s\"."
+msgstr "Impossible de mettre à jour « %1$s » pour le prototype de graphique « %2$s »."
 
 #: include/classes/api/services/CItemGeneral.php:287
 #, c-format
 msgid "Cannot update \"%1$s\" for item \"%2$s\"."
-msgstr "Impossible de mettre à jour \"%1$s\" pour l'élément \"%2$s\"."
+msgstr "Impossible de mettre à jour « %1$s » pour l’élément « %2$s »."
 
 #: include/classes/api/services/CTriggerGeneral.php:1018
 #, c-format
 msgid "Cannot update \"%1$s\" for templated trigger \"%2$s\"."
-msgstr "Impossible de mettre à jour \"%1$s\" pour le déclencheur de modèle \"%2$s\"."
+msgstr "Impossible de mettre à jour « %1$s » pour le déclencheur de modèle « %2$s »."
 
 #: include/classes/api/services/CTriggerGeneral.php:1029
 #, c-format
 msgid "Cannot update \"%1$s\" for templated trigger prototype \"%2$s\"."
-msgstr "Impossible de mettre à jour \"%1$s\" pour le prototype de déclencheur de modèle \"%2$s\"."
+msgstr "Impossible de mettre à jour « %1$s » pour le prototype de déclencheur de modèle « %2$s »."
 
 #: include/classes/api/services/CHost.php:2177
 #, c-format
 msgid "Cannot update \"%2$s\" for a discovered host \"%1$s\"."
-msgstr "Impossible de mettre à jour \"%2$s\" pour un hôte découvert \"%1$s\"."
+msgstr "Impossible de mettre à jour « %2$s » pour un hôte découvert « %1$s »."
 
 #: include/classes/api/services/CItemGeneral.php:215
 #, c-format
 msgid "Cannot update \"%2$s\" for a discovered item \"%1$s\"."
-msgstr "Impossible de mettre à jour \"%2$s\" pour un élément découvert \"%1$s\"."
+msgstr "Impossible de mettre à jour « %2$s » pour un élément découvert « %1$s »."
 
 #: include/classes/api/services/CTriggerGeneral.php:1024
 #: include/classes/api/services/CTrigger.php:701
 #: include/classes/api/services/CTrigger.php:830
 #, c-format
 msgid "Cannot update \"%2$s\" for a discovered trigger \"%1$s\"."
-msgstr "Impossible de mettre à jour \"%2$s\" pour un déclencheur découvert \"%1$s\"."
+msgstr "Impossible de mettre à jour « %2$s » pour un déclencheur découvert « %1$s »."
 
 #: app/controllers/CControllerTokenUpdate.php:47
 #: app/controllers/CControllerTokenUpdate.php:122
 msgid "Cannot update API token"
-msgstr ""
+msgstr "Impossible de mettre à jour le jeton d’API"
 
 #: include/classes/api/services/CGraphGeneral.php:67
 msgid "Cannot update a discovered graph."
@@ -2953,20 +2946,20 @@ msgstr "Impossible de mettre à jour un graphique découvert."
 #: include/classes/api/services/CHostGroup.php:792
 #, c-format
 msgid "Cannot update a discovered host group \"%1$s\"."
-msgstr ""
+msgstr "Impossible de mettre à jour le groupe « %1$s » d’un hôte découvert."
 
 #: include/classes/api/services/CHttpTest.php:514
 #, c-format
 msgid "Cannot update a templated web scenario \"%1$s\": %2$s."
-msgstr "Impossible de mettre à jour un scénario web de modèle \"%1$s\": %2$s."
+msgstr "Impossible de mettre à jour un scénario Web de modèle « %1$s » : %2$s."
 
 #: actionconf.php:272
 msgid "Cannot update action"
-msgstr "Impossible de mettre à jour l'action"
+msgstr "Impossible de mettre à jour l’action"
 
 #: app/controllers/CControllerAuthenticationUpdate.php:397
 msgid "Cannot update authentication"
-msgstr "Impossible de mettre à jour l'authentification"
+msgstr "Impossible de mettre à jour l’authentification"
 
 #: app/controllers/CControllerAuditSettingsUpdate.php:45
 #: app/controllers/CControllerAuditSettingsUpdate.php:82
@@ -2999,7 +2992,7 @@ msgstr "Impossible de mettre à jour la règle de découverte"
 #: app/controllers/CControllerPopupAcknowledgeCreate.php:173
 msgid "Cannot update event"
 msgid_plural "Cannot update events"
-msgstr[0] "Impossible de mettre à jour l'événement"
+msgstr[0] "Impossible de mettre à jour l’événement"
 msgstr[1] "Impossible de mettre à jour les événements"
 
 #: graphs.php:243 graphs.php:296
@@ -3017,22 +3010,22 @@ msgstr "Impossible de mettre à jour le groupe"
 #: include/classes/api/services/CHostGroup.php:1314
 #, c-format
 msgid "Cannot update groups for discovered host \"%1$s\"."
-msgstr "Impossible de mettre à jour les groupes pour l'hôte découvert \"%1$s\"."
+msgstr "Impossible de mettre à jour les groupes pour l’hôte découvert « %1$s »."
 
 #: app/controllers/CControllerHostUpdate.php:34
 #: app/controllers/CControllerHostUpdate.php:153
 msgid "Cannot update host"
-msgstr "Impossible de mettre à jour l'hôte"
+msgstr "Impossible de mettre à jour l’hôte"
 
 #: include/classes/api/services/CHost.php:934
 msgid "Cannot update host encryption settings. Connection settings for both directions should be specified."
-msgstr "Impossible de mettre à jour les paramètres de chiffrement de l'hôte. Les paramètres de connexion doivent être spécifiés pour les deux directions."
+msgstr "Impossible de mettre à jour les paramètres de chiffrement de l’hôte. Les paramètres de connexion doivent être spécifiés pour les deux directions."
 
 #: host_prototypes.php:274 host_prototypes.php:304 host_prototypes.php:325
 msgid "Cannot update host prototype"
 msgid_plural "Cannot update host prototypes"
-msgstr[0] "Impossible de mettre à jour le prototype d'hôte"
-msgstr[1] "Impossible de mettre à jour les prototypes d'hôtes"
+msgstr[0] "Impossible de mettre à jour le prototype d’hôte"
+msgstr[1] "Impossible de mettre à jour les prototypes d’hôtes"
 
 #: app/controllers/CControllerPopupMassupdateHost.php:461
 msgid "Cannot update hosts"
@@ -3040,32 +3033,32 @@ msgstr "Impossible de mettre à jour les hôtes"
 
 #: app/controllers/CControllerIconMapUpdate.php:73
 msgid "Cannot update icon map"
-msgstr "Impossible de mettre à jour la table de correspondance d'icônes"
+msgstr "Impossible de mettre à jour la table de correspondance d’icônes"
 
 #: app/controllers/CControllerImageUpdate.php:43
 #: app/controllers/CControllerImageUpdate.php:111
 #: app/controllers/CControllerImageUpdate.php:157
 msgid "Cannot update image"
-msgstr "Impossible de mettre à jour l'image"
+msgstr "Impossible de mettre à jour l’image"
 
 #: include/classes/api/services/CHostInterface.php:385
 #, c-format
 msgid "Cannot update interface for discovered host \"%1$s\"."
-msgstr "Impossible de mettre à jour l'interface de l'hôte découvert \"%1$s\"."
+msgstr "Impossible de mettre à jour l’interface de l’hôte découvert « %1$s »."
 
 #: items.php:934
 msgid "Cannot update item"
-msgstr "Impossible de mettre à jour l'élément"
+msgstr "Impossible de mettre à jour l’élément"
 
 #: disc_prototypes.php:611 disc_prototypes.php:638 disc_prototypes.php:672
 msgid "Cannot update item prototype"
 msgid_plural "Cannot update item prototypes"
-msgstr[0] "Impossible de mettre à jour le prototype d'élément"
-msgstr[1] "Impossible de mettre à jour les prototypes d'éléments"
+msgstr[0] "Impossible de mettre à jour le prototype d’élément"
+msgstr[1] "Impossible de mettre à jour les prototypes d’éléments"
 
 #: app/controllers/CControllerPopupMassupdateItem.php:370
 msgid "Cannot update item prototypes"
-msgstr "Impossible de mettre à jour les prototypes d'éléments"
+msgstr "Impossible de mettre à jour les prototypes d’éléments"
 
 #: app/controllers/CControllerPopupMassupdateItem.php:370
 msgid "Cannot update items"
@@ -3087,7 +3080,7 @@ msgstr "Impossible de mettre à jour le type de média"
 #: app/controllers/CControllerModuleUpdate.php:157
 #, c-format
 msgid "Cannot update module: %1$s."
-msgstr ""
+msgstr "Impossible de mettre à jour le module : %1$s."
 
 #: sysmaps.php:184
 msgid "Cannot update network map"
@@ -3101,22 +3094,22 @@ msgstr "Impossible de mettre à jour le proxy"
 #: include/classes/api/services/CProxy.php:654
 #, c-format
 msgid "Cannot update proxy for discovered host \"%1$s\"."
-msgstr "Impossible de mettre à jour le proxy pour l'hôte découvert \"%1$s\"."
+msgstr "Impossible de mettre à jour le proxy pour l’hôte découvert « %1$s »."
 
 #: include/classes/api/services/CRole.php:775
 #, c-format
 msgid "Cannot update readonly user role \"%1$s\"."
-msgstr ""
+msgstr "Impossible de mettre à jour de rôle utilisateur en lecture seul « %1$s »."
 
 #: app/controllers/CControllerRegExUpdate.php:44
 #: app/controllers/CControllerRegExUpdate.php:89
 msgid "Cannot update regular expression"
-msgstr "Impossible de mettre à jour l'expression régulière"
+msgstr "Impossible de mettre à jour l’expression rationnelle"
 
 #: app/controllers/CControllerScheduledReportUpdate.php:63
 #: app/controllers/CControllerScheduledReportUpdate.php:156
 msgid "Cannot update scheduled report"
-msgstr ""
+msgstr "Impossible de mettre à jour le rapport planifié"
 
 #: app/controllers/CControllerScriptUpdate.php:61
 #: app/controllers/CControllerScriptUpdate.php:170
@@ -3128,7 +3121,7 @@ msgstr "Impossible de mettre à jour le script"
 #: include/classes/api/services/CScript.php:443
 #, c-format
 msgid "Cannot update script scope. Script \"%1$s\" is used in action \"%2$s\"."
-msgstr ""
+msgstr "Impossible de mettre à jour la visibilité du script. Le script « %1$s » est utilisé par l’action « %2$s »."
 
 #: include/classes/api/services/CService.php:2483
 #: include/classes/api/services/CService.php:2545
@@ -3136,17 +3129,17 @@ msgstr ""
 #: include/classes/api/services/CService.php:2603
 #, c-format
 msgid "Cannot update service \"%1$s\": %2$s."
-msgstr ""
+msgstr "Impossible de mettre à jour le service « %1$s » : %2$s."
 
 #: app/controllers/CControllerPopupMassupdateService.php:157
 msgid "Cannot update services"
-msgstr ""
+msgstr "Impossible de mettre à jour les services"
 
 #: include/classes/api/services/CHttpTest.php:538
 #: include/classes/api/services/CHttpTest.php:743
 #, c-format
 msgid "Cannot update step for a templated web scenario \"%1$s\": %2$s."
-msgstr "Impossible de mettre à jour une étape pour un scénario web de modèle \"%1$s\": %2$s."
+msgstr "Impossible de mettre à jour une étape pour un scénario Web de modèle « %1$s » : %2$s."
 
 #: templates.php:209
 msgid "Cannot update template"
@@ -3160,7 +3153,7 @@ msgstr "Impossible de mettre à jour les modèles"
 #: include/classes/api/services/CTemplate.php:1257
 #, c-format
 msgid "Cannot update templates on discovered host \"%1$s\"."
-msgstr "Impossible de mettre à jour les modèles sur l'hôte découvert \"%1$s\"."
+msgstr "Impossible de mettre à jour les modèles sur l’hôte découvert « %1$s »."
 
 #: app/controllers/CControllerPopupMassupdateTrigger.php:210
 #: app/controllers/CControllerPopupTriggerWizard.php:198 triggers.php:401
@@ -3170,7 +3163,7 @@ msgstr "Impossible de mettre à jour le déclencheur"
 #: include/classes/api/services/CTriggerGeneral.php:1886
 #, c-format
 msgid "Cannot update trigger \"%1$s\": %2$s."
-msgstr "Impossible de mettre à jour le déclencheur \"%1$s\": %2$s."
+msgstr "Impossible de mettre à jour le déclencheur « %1$s » : %2$s."
 
 #: trigger_prototypes.php:350 trigger_prototypes.php:411
 #: trigger_prototypes.php:459
@@ -3182,7 +3175,7 @@ msgstr[1] "Impossible de mettre à jour les prototypes de déclencheurs"
 #: include/classes/api/services/CTriggerGeneral.php:1721
 #, c-format
 msgid "Cannot update trigger prototype \"%1$s\": %2$s."
-msgstr "Impossible de mettre à jour le prototype de déclencheur \"%1$s\": %2$s."
+msgstr "Impossible de mettre à jour le prototype de déclencheur « %1$s » : %2$s."
 
 #: app/controllers/CControllerPopupMassupdateTrigger.php:210
 msgid "Cannot update trigger prototypes"
@@ -3193,24 +3186,24 @@ msgstr "Impossible de mettre à jour les prototypes de déclencheurs"
 #: app/controllers/CControllerUserUpdate.php:67
 #: app/controllers/CControllerUserUpdate.php:131
 msgid "Cannot update user"
-msgstr "Impossible de mettre à jour l'utilisateur"
+msgstr "Impossible de mettre à jour l’utilisateur"
 
 #: app/controllers/CControllerUsergroupMassUpdate.php:69
 #: app/controllers/CControllerUsergroupUpdate.php:53
 #: app/controllers/CControllerUsergroupUpdate.php:105
 msgid "Cannot update user group"
 msgid_plural "Cannot update user groups"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impossible de mettre à jour le groupe d’utilisateurs"
+msgstr[1] "Impossible de mettre à jour les groupes d’utilisateurs"
 
 #: app/controllers/CControllerUserroleUpdate.php:102
 #: app/controllers/CControllerUserroleUpdate.php:172
 msgid "Cannot update user role"
-msgstr ""
+msgstr "Impossible de mettre à jour le rôle d’utilisateur"
 
 #: httpconf.php:194
 msgid "Cannot update web scenario"
-msgstr "Impossible de mettre à jour le scénario web"
+msgstr "Impossible de mettre à jour le scénario Web"
 
 #: app/views/administration.regex.edit.php:50
 msgid "Case sensitive"
@@ -3220,7 +3213,7 @@ msgstr "Sensible à la casse"
 #: app/views/administration.authentication.edit.php:192
 #: app/views/administration.authentication.edit.php:315
 msgid "Case-sensitive login"
-msgstr ""
+msgstr "Identifiant sensible à la casse"
 
 #: include/locales.inc.php:48
 msgid "Catalan (ca_ES)"
@@ -3228,15 +3221,15 @@ msgstr "Catalan (ca_ES)"
 
 #: include/classes/data/CItemData.php:1048
 msgid "Catches all SNMP traps that match regex. If regexp is unspecified, catches any trap."
-msgstr "Reçoit tous les traps SNMP qui correspondent à la regex. Si la regex n'est pas spécifiée, reçoit tous les traps."
+msgstr "Reçoit tous les traps SNMP qui correspondent à la regex. Si la regex n’est pas spécifiée, reçoit tous les traps."
 
 #: include/classes/data/CItemData.php:1044
 msgid "Catches all SNMP traps that were not caught by any of snmptrap[] items."
-msgstr "Reçoit tous les traps SNMP qui n'ont été reçus par aucun élément snmptrap[]."
+msgstr "Reçoit tous les traps SNMP qui n’ont été reçus par aucun élément snmptrap[]."
 
 #: include/views/js/monitoring.sysmaps.js.php:35
 msgid "Center"
-msgstr ""
+msgstr "Centre"
 
 #: app/partials/configuration.host.edit.html.php:433
 #: app/partials/configuration.host.edit.html.php:452
@@ -3268,7 +3261,7 @@ msgstr "Changer"
 #: app/views/administration.proxy.edit.php:126
 #: include/views/configuration.host.prototype.edit.php:396
 msgid "Change PSK"
-msgstr ""
+msgstr "Modifier la clef partagée (PSK)"
 
 #: app/views/administration.authentication.edit.php:149
 #: app/views/administration.mediatype.edit.php:137
@@ -3287,7 +3280,7 @@ msgstr "Changement de gravité"
 
 #: include/classes/html/CMacroValue.php:162
 msgid "Change type"
-msgstr ""
+msgstr "Modifier le type"
 
 #: app/partials/configuration.filter.items.php:139
 #: app/views/popup.massupdate.item.php:158 include/items.inc.php:127
@@ -3310,7 +3303,7 @@ msgstr "Chaîne de caractères non inclue"
 #: app/controllers/CControllerPopupTriggerExpr.php:921
 #: app/controllers/CControllerPopupTriggerExpr.php:1095
 msgid "Chars"
-msgstr ""
+msgstr "Caractères"
 
 #: include/hosts.inc.php:234
 msgid "Chassis"
@@ -3327,7 +3320,7 @@ msgstr "La vérification existe déjà."
 #: include/classes/parsers/C10TriggerExpression.php:542
 #, c-format
 msgid "Check expression part starting from \"%1$s\"."
-msgstr "Vérifiez la partie d'expression à partir de \"%1$s\"."
+msgstr "Vérifiez la partie d’expression à partir de « %1$s »."
 
 #: include/items.inc.php:1879
 msgid "Check for error in JSON"
@@ -3339,11 +3332,11 @@ msgstr "Rechercher une erreur dans le XML"
 
 #: include/items.inc.php:1887
 msgid "Check for error using regular expression"
-msgstr "Rechercher une erreur en utilisant une expression régulière"
+msgstr "Rechercher une erreur en utilisant une expression rationnelle"
 
 #: include/items.inc.php:1891
 msgid "Check for not supported value"
-msgstr ""
+msgstr "Vérifier les valeurs non prises en charge"
 
 #: include/classes/setup/CSetupWizard.php:58
 #: include/classes/setup/CSetupWizard.php:451
@@ -3354,7 +3347,7 @@ msgstr "Vérification des prérequis"
 #: include/classes/api/services/CItemGeneral.php:447
 #: include/classes/api/services/CItemGeneral.php:454
 msgid "Check the key, please. Default example was passed."
-msgstr "Veuillez vérifier la clé. L'exemple par défaut a été utilisé."
+msgstr "Veuillez vérifier la clef. L’exemple par défaut a été utilisé."
 
 #: app/views/popup.discovery.check.php:55
 msgid "Check type"
@@ -3367,43 +3360,43 @@ msgstr "Vérifications"
 
 #: include/classes/data/CItemData.php:936
 msgid "Checks if DNS service is up. Returns 0 - DNS is down (server did not respond or DNS resolution failed); 1 - DNS is up"
-msgstr "Vérifie si le service DNS est actif. Retourne 0 - le DNS est inactif (le serveur n'a pas répondu ou la résolution DNS a échoué) ; 1 - le DNS est actif"
+msgstr "Vérifie si le service DNS est actif. Retourne 0 — le DNS est inactif (le serveur n’a pas répondu ou la résolution DNS a échoué) ; 1 — le DNS est actif"
 
 #: include/classes/data/CItemData.php:1180
 msgid "Checks if file exists. Returns 0 - not found; 1 - file of the specified type exists"
-msgstr ""
+msgstr "Vérifie l’existence du fichier. Retourne 0 si introuvable, 1 s’il existe un fichier du type spécifié"
 
 #: include/classes/data/CItemData.php:868
 msgid "Checks if host is accessible by ICMP ping. 0 - ICMP ping fails. 1 - ICMP ping successful."
-msgstr ""
+msgstr "Vérifie que l’hôte répond à une requête ICMP ping. Retourne 0 en cas de non réponse, 1 pour une réponse positive."
 
 #: include/classes/data/CItemData.php:968
 msgid "Checks if it is possible to make TCP connection to specified port. Returns 0 - cannot connect; 1 - can connect"
-msgstr "Vérifie s'il est possible d'effectuer une connexion TCP au port spécifié. Retourne 0 - impossible de se connecter ; 1 - connexion possible"
+msgstr "Vérifie s’il est possible d’effectuer une connexion TCP au port spécifié. Retourne 0 — impossible de se connecter ; 1 — connexion possible"
 
 #: include/classes/data/CItemData.php:976
 msgid "Checks if service is running and accepting TCP connections. Returns 0 - service is down; 1 - service is running"
-msgstr "Vérifie si un service fonctionne et accepte des connexions TCP. Retourne 0 - le service est inactif ; 1 - le service fonctionne"
+msgstr "Vérifie si un service fonctionne et accepte des connexions TCP. Retourne 0 — le service est inactif ; 1 — le service fonctionne"
 
 #: include/classes/data/CItemData.php:992
 msgid "Checks if service is running and responding to UDP requests. Returns 0 - service is down; 1 - service is running"
-msgstr "Vérifie si un service fonctionne et répond aux requêtes UDP. Retourne 0 - le service est inactif ; 1 - le service fonctionne"
+msgstr "Vérifie si un service fonctionne et répond aux requêtes UDP. Retourne 0 — le service est inactif ; 1 — le service fonctionne"
 
 #: include/classes/data/CItemData.php:964
 msgid "Checks if this TCP port is in LISTEN state. Returns 0 - it is not in LISTEN state; 1 - it is in LISTEN state"
-msgstr "Vérifie si ce port TCP est en ÉCOUTE. Retourne 0 - le port n'est pas en écoute ; 1 - le port est en écoute"
+msgstr "Vérifie si ce port TCP est en ÉCOUTE. Retourne 0 — le port n’est pas en écoute ; 1 — le port est en écoute"
 
 #: include/classes/data/CItemData.php:984
 msgid "Checks if this UDP port is in LISTEN state. Returns 0 - it is not in LISTEN state; 1 - it is in LISTEN state"
-msgstr "Vérifie si ce port UDP est en ÉCOUTE. Retourne 0 - le port n'est pas en écoute ; 1 - le port est en écoute"
+msgstr "Vérifie si ce port UDP est en ÉCOUTE. Retourne 0 — le port n’est pas en écoute ; 1 — le port est en écoute"
 
 #: include/classes/data/CItemData.php:972
 msgid "Checks performance of TCP service. Returns 0 - service is down; seconds - the number of seconds spent while connecting to the service"
-msgstr "Vérifie la performance du service TCP. Retourne 0 - le service est inactif - le nombre de secondes passées à se connecter au service"
+msgstr "Vérifie la performance du service TCP. Retourne 0 — le service est inactif — le nombre de secondes passées à se connecter au service"
 
 #: include/classes/data/CItemData.php:988
 msgid "Checks performance of UDP service. Returns 0 - service is down; seconds - the number of seconds spent waiting for response from the service"
-msgstr "Vérifie la performance du service UDP. Retourne 0 - le service est inactif - le nombre de secondes passées à attendre une réponse du service"
+msgstr "Vérifie la performance du service UDP. Retourne 0 — le service est inactif — le nombre de secondes passées à attendre une réponse du service"
 
 #: include/classes/api/services/CDRule.php:658
 msgid "Checks should be unique."
@@ -3411,7 +3404,7 @@ msgstr "Les vérifications doivent être uniques."
 
 #: app/views/popup.service.edit.php:333 app/views/popup.service.edit.php:347
 msgid "Child services"
-msgstr ""
+msgstr "Services fils"
 
 #: include/locales.inc.php:49
 msgid "Chinese (zh_CN)"
@@ -3424,27 +3417,27 @@ msgstr "Chinois (zh_TW)"
 #: include/classes/import/importers/CTemplateImporter.php:288
 #, c-format
 msgid "Circular reference in templates: %1$s."
-msgstr "Référence circulaire dans les modèles : %1$s."
+msgstr "Référence circulaire dans les modèles : %1$s."
 
 #: include/classes/api/services/CHostBase.php:220
 msgid "Circular template linkage is not allowed."
-msgstr "La liaison circulaire de modèle n'est pas autorisée."
+msgstr "La liaison circulaire de modèle n’est pas autorisée."
 
 #: include/classes/core/ZBase.php:494
 #, c-format
 msgid "Class %1$s not found for action %2$s."
-msgstr ""
+msgstr "La classe %1$s est introuvable pour l’action %2$s."
 
 #: include/views/configuration.httpconf.list.php:217
 #: include/views/configuration.item.list.php:291
 msgid "Clear history"
-msgstr "Effacer l'historique"
+msgstr "Effacer l’historique"
 
 #: include/views/configuration.httpconf.edit.php:261
 #: include/views/configuration.item.edit.php:1029
 #: include/views/configuration.item.edit.php:1032
 msgid "Clear history and trends"
-msgstr "Effacer l'historique et les tendances"
+msgstr "Effacer l’historique et les tendances"
 
 #: app/views/popup.massupdate.host.php:70
 #: app/views/popup.massupdate.template.php:73
@@ -3453,7 +3446,7 @@ msgstr "Effacer en déliant"
 
 #: jsLoader.php:148
 msgid "Click and drag to desired size."
-msgstr "Cliquez et faites glisser jusqu'à la taille désirée."
+msgstr "Cliquez et faites glisser jusqu’à la taille désirée."
 
 #: jsLoader.php:328
 msgid "Click to view or edit"
@@ -3507,7 +3500,7 @@ msgstr "Fermer"
 #: include/views/configuration.triggers.edit.php:311
 #: include/views/configuration.triggers.edit.php:509
 msgid "Close expression constructor"
-msgstr "Fermer le constructeur d'expression"
+msgstr "Fermer le constructeur d’expression"
 
 #: app/views/configuration.correlation.edit.php:152
 #: include/classes/helpers/CCorrelationHelper.php:71
@@ -3525,7 +3518,7 @@ msgstr "Fermer le problème"
 
 #: include/classes/helpers/CRoleHelper.php:421
 msgid "Close problems"
-msgstr ""
+msgstr "Clore les problèmes"
 
 #: include/classes/html/CCollapsibleUiWidget.php:55
 #: include/classes/widgets/CWidgetHelper.php:997 jsLoader.php:306
@@ -3536,7 +3529,7 @@ msgstr "Replier"
 #: app/partials/layout.htmlpage.aside.php:39
 #: app/partials/layout.htmlpage.aside.php:41
 msgid "Collapse sidebar"
-msgstr ""
+msgstr "Réduire la barre latérale"
 
 #: include/views/configuration.graph.edit.php:379
 #: include/views/js/monitoring.sysmaps.js.php:381
@@ -3544,16 +3537,16 @@ msgstr ""
 #: include/views/js/monitoring.sysmaps.js.php:422
 #: include/views/js/monitoring.sysmaps.js.php:792
 msgid "Color"
-msgstr ""
+msgstr "Couleur"
 
 #: include/classes/validators/CColorValidator.php:32 jsLoader.php:287
 #, c-format
 msgid "Color \"%1$s\" is not correct: expecting hexadecimal color code (6 symbols)."
-msgstr ""
+msgstr "La couleur « %1$s » est incorrecte : un nombre hexadécimal (à 6 chiffres) est attendu."
 
 #: include/views/js/monitoring.sysmaps.js.php:786
 msgid "Color (OK)"
-msgstr ""
+msgstr "Couleur (OK)"
 
 #: include/classes/widgets/forms/CWidgetForm.php:71
 msgid "Columns"
@@ -3565,7 +3558,7 @@ msgstr "Résultat combiné"
 
 #: include/classes/widgets/forms/CWidgetFormGeoMap.php:77
 msgid "Comma separated center coordinates to display when the widget is initially loaded."
-msgstr ""
+msgstr "Coordonnées centrales, séparées par des virgules, à afficher lorsque le widget est initialement chargé."
 
 #: app/views/administration.script.edit.php:173 include/actions.inc.php:1943
 #: include/views/administration.auditacts.list.php:103
@@ -3579,12 +3572,12 @@ msgstr "Commandes"
 
 #: app/views/administration.miscconfig.edit.php:132
 msgid "Communication with Zabbix server"
-msgstr ""
+msgstr "Communication avec le serveur Zabbix"
 
 #: include/items.inc.php:1321
 msgctxt "SNMP Community"
 msgid "Community"
-msgstr ""
+msgstr "Communauté"
 
 #: app/partials/monitoring.problem.filter.php:263
 msgid "Compact view"
@@ -3593,16 +3586,16 @@ msgstr "Vue compacte"
 #: include/classes/core/CComponentRegistry.php:53
 #, c-format
 msgid "Component %1$s already registered."
-msgstr ""
+msgstr "Le composant %1$s est déjà référencé."
 
 #: include/classes/core/CComponentRegistry.php:37
 #, c-format
 msgid "Component %1$s is not registered."
-msgstr ""
+msgstr "Le composant %1$s n’est pas référencé."
 
 #: app/views/administration.housekeeping.edit.php:165
 msgid "Compress records older than"
-msgstr ""
+msgstr "Compresser les enregistrements plus vieux de"
 
 #: app/views/administration.proxy.list.php:79
 msgid "Compression"
@@ -3621,22 +3614,22 @@ msgstr "Condition"
 #: include/classes/api/services/CDiscoveryRule.php:1809
 #, c-format
 msgid "Condition \"%2$s\" is not used in formula \"%3$s\" for discovery rule \"%1$s\"."
-msgstr "La condition \"%2$s\" n'est pas utilisée dans la formule \"%3$s\" pour la règle de découverte \"%1$s\"."
+msgstr "La condition « %2$s » n’est pas utilisée dans la formule « %3$s » pour la règle de découverte « %1$s »."
 
 #: include/classes/api/services/CDiscoveryRule.php:1601
 #, c-format
 msgid "Condition \"%2$s\" is not used in formula \"%3$s\" for override \"%1$s\"."
-msgstr ""
+msgstr "La condition « %2$s » n’est pas utilisée dans la formule « %3$s » du remplacement « %1$s »."
 
 #: include/classes/api/services/CDiscoveryRule.php:1808
 #, c-format
 msgid "Condition \"%2$s\" used in formula \"%3$s\" for discovery rule \"%1$s\" is not defined."
-msgstr "La condition \"%2$s\" utilisée dans la formule \"%3$s\" pour la règle de découverte \"%1$s\" n'est pas définie."
+msgstr "La condition « %2$s » utilisée dans la formule « %3$s » pour la règle de découverte « %1$s » n’est pas définie."
 
 #: include/classes/api/services/CDiscoveryRule.php:1600
 #, c-format
 msgid "Condition \"%2$s\" used in formula \"%3$s\" for override \"%1$s\" is not defined."
-msgstr ""
+msgstr "La condition « %2$s » utilisée dans la formule « %3$s » du remplacement « %1$s » n’est pas définie."
 
 #: app/partials/popup.operations.php:254
 #: app/views/configuration.correlation.edit.php:126
@@ -3655,12 +3648,12 @@ msgstr "Configuration"
 
 #: include/classes/data/CItemData.php:1704
 msgid "Configuration cache statistics. Cache - buffer (modes: pfree, total, used, free)."
-msgstr "Statistiques du cache de configuration. Cache - buffer (modes: pfree, total, used, free)."
+msgstr "Statistiques du cache de configuration. Cache — tampon (modes : pfree, total, used, free)."
 
 #: include/classes/setup/CSetupWizard.php:872
 #, c-format
 msgid "Configuration file \"%1$s\" created."
-msgstr "Fichier de configuration \"%1$s\" créé."
+msgstr "Fichier de configuration « %1$s » créé."
 
 #: app/controllers/CControllerGuiEdit.php:96
 msgid "Configuration of GUI"
@@ -3672,16 +3665,16 @@ msgstr "Configuration des actions"
 
 #: app/controllers/CControllerAuditSettingsEdit.php:60
 msgid "Configuration of audit log"
-msgstr ""
+msgstr "Configuration des journaux d’audit"
 
 #: app/controllers/CControllerAuthenticationEdit.php:196
 msgid "Configuration of authentication"
-msgstr "Configuration de l'authentification"
+msgstr "Configuration de l’authentification"
 
 #: app/controllers/CControllerTemplateDashboardEdit.php:102
 #: app/controllers/CControllerTemplateDashboardList.php:93
 msgid "Configuration of dashboards"
-msgstr ""
+msgstr "Configuration des tableaux de bord"
 
 #: app/controllers/CControllerDiscoveryEdit.php:137
 #: app/controllers/CControllerDiscoveryList.php:128 host_discovery.php:27
@@ -3698,15 +3691,15 @@ msgstr "Configuration des graphiques"
 
 #: app/controllers/CControllerHostEdit.php:263
 msgid "Configuration of host"
-msgstr ""
+msgstr "Configuration de l’hôte"
 
 #: hostgroups.php:25
 msgid "Configuration of host groups"
-msgstr "Configuration des groupes d'hôtes"
+msgstr "Configuration des groupes d’hôtes"
 
 #: host_prototypes.php:27
 msgid "Configuration of host prototypes"
-msgstr "Configuration des prototypes d'hôte"
+msgstr "Configuration des prototypes d’hôte"
 
 #: app/controllers/CControllerHostList.php:358
 msgid "Configuration of hosts"
@@ -3719,7 +3712,7 @@ msgstr "Configuration du nettoyage"
 #: app/controllers/CControllerIconMapEdit.php:98
 #: app/controllers/CControllerIconMapList.php:75
 msgid "Configuration of icon mapping"
-msgstr "Configuration des correspondances d'icônes"
+msgstr "Configuration des correspondances d’icônes"
 
 #: app/controllers/CControllerImageEdit.php:75
 #: app/controllers/CControllerImageList.php:57
@@ -3728,7 +3721,7 @@ msgstr "Configuration des images"
 
 #: disc_prototypes.php:27
 msgid "Configuration of item prototypes"
-msgstr "Configuration des prototypes d'éléments"
+msgstr "Configuration des prototypes d’éléments"
 
 #: items.php:27
 msgid "Configuration of items"
@@ -3759,7 +3752,7 @@ msgstr "Configuration des proxies"
 #: app/controllers/CControllerRegExEdit.php:111
 #: app/controllers/CControllerRegExList.php:53
 msgid "Configuration of regular expressions"
-msgstr "Configuration des expressions régulières"
+msgstr "Configuration des expressions rationnelles"
 
 #: app/controllers/CControllerScriptEdit.php:208
 #: app/controllers/CControllerScriptList.php:197
@@ -3772,7 +3765,7 @@ msgstr "Configuration des modèles"
 
 #: app/controllers/CControllerTrigDisplayEdit.php:132
 msgid "Configuration of trigger displaying options"
-msgstr "Configuration des options d'affichage des déclencheurs"
+msgstr "Configuration des options d’affichage des déclencheurs"
 
 #: trigger_prototypes.php:27
 msgid "Configuration of trigger prototypes"
@@ -3785,12 +3778,12 @@ msgstr "Configuration des déclencheurs"
 #: app/controllers/CControllerUsergroupEdit.php:130
 #: app/controllers/CControllerUsergroupList.php:120
 msgid "Configuration of user groups"
-msgstr "Configuration des groupes d'utilisateurs"
+msgstr "Configuration des groupes d’utilisateurs"
 
 #: app/controllers/CControllerUserroleEdit.php:183
 #: app/controllers/CControllerUserroleList.php:130
 msgid "Configuration of user roles"
-msgstr ""
+msgstr "Configuration des rôles d’utilisateur"
 
 #: app/controllers/CControllerUserEdit.php:243
 #: app/controllers/CControllerUserList.php:170
@@ -3799,7 +3792,7 @@ msgstr "Configuration des utilisateurs"
 
 #: httpconf.php:27
 msgid "Configuration of web monitoring"
-msgstr "Configuration de la supervision web"
+msgstr "Configuration de la supervision Web"
 
 #: app/controllers/CControllerAuditSettingsUpdate.php:78
 #: app/controllers/CControllerAutoregUpdate.php:69
@@ -3822,7 +3815,7 @@ msgstr "Texte de confirmation"
 
 #: include/classes/setup/CSetupWizard.php:870
 msgid "Congratulations! You have successfully installed Zabbix frontend."
-msgstr "Félicitations ! Vous avez installé l'interface Zabbix avec succès."
+msgstr "Félicitations ! Vous avez installé l’interface Zabbix avec succès."
 
 #: app/views/administration.proxy.edit.php:49 include/hosts.inc.php:1223
 #: include/views/inventory.host.view.php:81
@@ -3843,12 +3836,12 @@ msgstr "Sécurité de la connexion"
 
 #: app/views/administration.miscconfig.edit.php:140
 msgid "Connection timeout"
-msgstr ""
+msgstr "Expiration de la connexion"
 
 #: include/classes/server/CZabbixServer.php:497
 #, c-format
 msgid "Connection timeout of %1$s seconds exceeded when connecting to Zabbix server \"%2$s\"."
-msgstr "Délai d'attente de %1$s secondes dépassé lors de la connexion au serveur Zabbix \"%2$s\"."
+msgstr "Délai d’attente de %1$s secondes dépassé lors de la connexion au serveur Zabbix « %2$s »."
 
 #: include/classes/server/CZabbixServer.php:609
 #, c-format
@@ -3857,6 +3850,9 @@ msgid ""
 "1. Incorrect server IP/DNS in the \"zabbix.conf.php\";\n"
 "2. Incorrect DNS server configuration.\n"
 msgstr ""
+"La connexion au serveur Zabbix « %1$s » a échoué. Les raisons possibles sont :\n"
+" 1. un nom d’hôte DNS ou une adresse IP incorrects dans le fichier de configuration « zabbix.conf.php » ;\n"
+" 2. une configuration de serveur DNS incorrecte.\n"
 
 #: include/classes/server/CZabbixServer.php:597
 #, c-format
@@ -3867,6 +3863,11 @@ msgid ""
 "3. Zabbix server daemon not running;\n"
 "4. Firewall is blocking TCP connection.\n"
 msgstr ""
+"La connexion au serveur Zabbix « %1$s » a échoué. Les raisons possibles sont :\n"
+" 1. un nom d’hôte DNS ou une adresse IP incorrects dans le fichier de configuration « zabbix.conf.php » ;\n"
+" 2. l’environnement de sécurité (p. ex., SELinux) bloque la connexion ;\n"
+" 3. le service serveur Zabbix n’est pas en cours d’exécution ;\n"
+" 4. le pare‑feu bloque la connexion TCP.\n"
 
 #: include/classes/server/CZabbixServer.php:605
 #, c-format
@@ -3875,14 +3876,17 @@ msgid ""
 "1. Incorrect server IP/DNS in the \"zabbix.conf.php\";\n"
 "2. Firewall is blocking TCP connection.\n"
 msgstr ""
+"La tentative de connexion au serveur Zabbix « %1$s » a atteint le délai de grâce. Les raisons possibles sont :\n"
+" 1. un nom d’hôte DNS ou une adresse IP incorrects dans le fichier de configuration « zabbix.conf.php » ;\n"
+" 2. le pare‑feu bloque la connexion TCP.\n"
 
 #: include/classes/server/CZabbixServer.php:590
 msgid "Connection to Zabbix server failed. Incorrect configuration."
-msgstr ""
+msgstr "La connexion au serveur Zabbix a échoué. Configuration incorrecte."
 
 #: include/classes/setup/CSetupWizard.php:538
 msgid "Connection will not be encrypted because it uses a socket file (on Unix) or shared memory (Windows)."
-msgstr ""
+msgstr "La connexion ne sera pas chiffrée parce qu’elle utilise soit un fichier socket (sous UNIX), soit de la mémoire partagée (sous Windows)."
 
 #: app/views/popup.massupdate.host.php:277
 msgid "Connections"
@@ -3892,7 +3896,7 @@ msgstr "Connexions"
 #: app/views/popup.massupdate.host.php:238
 #: include/views/configuration.host.prototype.edit.php:379
 msgid "Connections from host"
-msgstr "Connexion de l'hôte"
+msgstr "Connexion de l’hôte"
 
 #: app/views/administration.proxy.edit.php:100
 msgid "Connections from proxy"
@@ -3902,7 +3906,7 @@ msgstr "Connexions du proxy"
 #: app/views/popup.massupdate.host.php:230
 #: include/views/configuration.host.prototype.edit.php:371
 msgid "Connections to host"
-msgstr "Connexion à l'hôte"
+msgstr "Connexion à l’hôte"
 
 #: app/views/administration.proxy.edit.php:93
 msgid "Connections to proxy"
@@ -3956,8 +3960,7 @@ msgstr "Contient"
 #: app/views/monitoring.discovery.view.php:40
 #: app/views/monitoring.host.dashboard.view.php:86
 #: app/views/monitoring.host.view.php:52
-#: app/views/monitoring.latest.view.php:39
-#: app/views/monitoring.map.view.php:71
+#: app/views/monitoring.latest.view.php:39 app/views/monitoring.map.view.php:71
 #: app/views/monitoring.problem.view.php:103
 #: app/views/monitoring.service.list.edit.php:146
 #: app/views/monitoring.service.list.php:120
@@ -3985,7 +3988,7 @@ msgstr "Contrôles du contenu"
 
 #: include/classes/html/widget/CWidget.php:177
 msgid "Content controls: header"
-msgstr ""
+msgstr "Contrôles du contenu : en‑tête"
 
 #: include/html.inc.php:316
 msgid "Content menu"
@@ -3999,7 +4002,7 @@ msgstr "Nom de contexte"
 
 #: app/views/popup.lldoverride.php:56
 msgid "Continue overrides"
-msgstr ""
+msgstr "Continuer les remplacements"
 
 #: include/hosts.inc.php:254
 msgid "Contract number"
@@ -4026,7 +4029,7 @@ msgstr "Copier"
 #: app/views/administration.token.view.php:45
 #: app/views/administration.user.token.view.php:44
 msgid "Copy to clipboard"
-msgstr ""
+msgstr "Copier dans le presse‐papiers"
 
 #: app/views/configuration.correlation.edit.php:164
 msgid "Correlation"
@@ -4035,18 +4038,17 @@ msgstr "Corrélation"
 #: include/classes/api/services/CCorrelation.php:536
 #, c-format
 msgid "Correlation \"%1$s\" already exists."
-msgstr "La corrélation \"%1$s\" existe déjà."
+msgstr "La corrélation « %1$s » existe déjà."
 
 #: app/controllers/CControllerCorrelationCreate.php:108
 msgid "Correlation added"
 msgstr "Corrélation ajoutée"
 
 #: app/controllers/CControllerCorrelationDelete.php:65
-#, fuzzy
 msgid "Correlation deleted"
 msgid_plural "Correlations deleted"
 msgstr[0] "Corrélation supprimée"
-msgstr[1] "Corrélation supprimée"
+msgstr[1] "Corrélations supprimées"
 
 #: app/controllers/CControllerCorrelationDisable.php:72
 msgid "Correlation disabled"
@@ -4081,11 +4083,11 @@ msgstr "Nombre de bascules de contexte. Retourne un entier"
 
 #: include/classes/data/CItemData.php:1160
 msgid "Count of directory entries, recursively. Returns integer"
-msgstr "Nombre d'entrées de répertoire, récursif. Renvoie un entier"
+msgstr "Nombre d’entrées de répertoire, récursif. Renvoie un entier"
 
 #: include/classes/data/CItemData.php:916
 msgid "Count of matched lines in log file monitoring with log rotation support. Returns integer"
-msgstr "Nombre de lignes correspondantes dans la supervision de fichier de log avec le support de la rotation des logs. Retourne un entier"
+msgstr "Nombre de lignes correspondantes dans la supervision de fichiers journaux avec gestion de la rotation des journaux. Retourne un entier"
 
 #: include/classes/data/CItemData.php:908
 msgid "Count of matched lines in log file monitoring. Returns integer"
@@ -4093,16 +4095,16 @@ msgstr "Nombre de lignes correspondantes dans la supervision de fichier de log. 
 
 #: include/classes/data/CItemData.php:1680
 msgid "Count of values enqueued in the low-level discovery processing queue."
-msgstr ""
+msgstr "Nombre d’éléments dans la file d’attente de traitement de la découverte de bas niveau."
 
 #: include/classes/data/CItemData.php:1684
 msgid "Count of values enqueued in the preprocessing queue."
-msgstr ""
+msgstr "Nombre d’éléments dans la file d’attente de prétraitement."
 
 #: app/views/administration.token.list.php:105
 #: app/views/administration.user.token.list.php:71
 msgid "Create API token"
-msgstr ""
+msgstr "Créer un jeton d’API"
 
 #: include/views/configuration.action.list.php:57
 msgid "Create action"
@@ -4110,15 +4112,15 @@ msgstr "Créer une action"
 
 #: include/classes/helpers/CRoleHelper.php:409
 msgid "Create and edit dashboards"
-msgstr ""
+msgstr "Créer et modifier des tableaux de bord"
 
 #: include/classes/helpers/CRoleHelper.php:414
 msgid "Create and edit maintenance"
-msgstr ""
+msgstr "Créer et modifier des opérations de maintenance"
 
 #: include/classes/helpers/CRoleHelper.php:410
 msgid "Create and edit maps"
-msgstr ""
+msgstr "Créer et modifier des cartes"
 
 #: app/views/administration.image.list.php:61
 msgid "Create background"
@@ -4154,11 +4156,11 @@ msgstr "Créer une règle de découverte"
 
 #: include/views/configuration.host.discovery.list.php:43
 msgid "Create discovery rule (select host first)"
-msgstr ""
+msgstr "Créer une règle de découverte (sélectionner d’abord un hôte)"
 
 #: include/views/configuration.host.discovery.list.php:44
 msgid "Create discovery rule (select template first)"
-msgstr ""
+msgstr "Créer une règle de découverte (sélectionner d’abord un modèle)"
 
 #: app/views/popup.lldoperation.php:80 app/views/popup.massupdate.item.php:325
 #: include/views/configuration.host.prototype.edit.php:286
@@ -4179,11 +4181,11 @@ msgstr "Créer un graphique"
 
 #: include/views/configuration.graph.list.php:49
 msgid "Create graph (select host first)"
-msgstr "Créer un graphique (sélectionner l'hôte d'abord)"
+msgstr "Créer un graphique (sélectionner l’hôte d’abord)"
 
 #: include/views/configuration.graph.list.php:50
 msgid "Create graph (select template first)"
-msgstr ""
+msgstr "Créer un graphique (sélectionner d’abord un modèle)"
 
 #: include/views/configuration.graph.list.php:31
 msgid "Create graph prototype"
@@ -4197,19 +4199,19 @@ msgstr "Créer un hôte"
 #: include/views/configuration.hostgroups.list.php:32
 #: include/views/configuration.hostgroups.list.php:36
 msgid "Create host group"
-msgstr "Créer un groupe d'hôtes"
+msgstr "Créer un groupe d’hôtes"
 
 #: include/views/configuration.host.prototype.list.php:30
 msgid "Create host prototype"
-msgstr "Créer un prototype d'hôte"
+msgstr "Créer un prototype d’hôte"
 
 #: include/views/configuration.host.prototype.list.php:191
 msgid "Create hosts from selected prototypes as disabled?"
-msgstr "Créer les hôtes à partir des prototypes sélectionnés comme désactivés ?"
+msgstr "Créer les hôtes à partir des prototypes sélectionnés comme désactivés ?"
 
 #: include/views/configuration.host.prototype.list.php:188
 msgid "Create hosts from selected prototypes as enabled?"
-msgstr "Créer les hôtes à partir des prototypes sélectionnés comme activés ?"
+msgstr "Créer les hôtes à partir des prototypes sélectionnés comme activés ?"
 
 #: app/views/administration.image.list.php:60
 msgid "Create icon"
@@ -4217,7 +4219,7 @@ msgstr "Créer une icône"
 
 #: app/views/administration.iconmap.list.php:32
 msgid "Create icon map"
-msgstr "Créer une table de correspondance d'icônes"
+msgstr "Créer une table de correspondance d’icônes"
 
 #: include/views/configuration.item.list.php:34
 msgid "Create item"
@@ -4225,23 +4227,23 @@ msgstr "Créer un élément"
 
 #: include/views/configuration.item.list.php:42
 msgid "Create item (select host first)"
-msgstr "Créer un élément (sélectionner un hôte d'abord)"
+msgstr "Créer un élément (sélectionner un hôte d’abord)"
 
 #: include/views/configuration.item.list.php:43
 msgid "Create item (select template first)"
-msgstr ""
+msgstr "Créer un élément (sélectionner d’abord un modèle)"
 
 #: include/views/configuration.item.prototype.list.php:30
 msgid "Create item prototype"
-msgstr "Créer un prototype d'élément"
+msgstr "Créer un prototype d’élément"
 
 #: include/views/configuration.item.prototype.list.php:193
 msgid "Create items from selected prototypes as disabled?"
-msgstr "Créer les éléments à partir des prototypes sélectionnés comme désactivés ?"
+msgstr "Créer les éléments à partir des prototypes sélectionnés comme désactivés ?"
 
 #: include/views/configuration.item.prototype.list.php:190
 msgid "Create items from selected prototypes as enabled?"
-msgstr "Créer les éléments à partir des prototypes sélectionnés comme activés ?"
+msgstr "Créer les éléments à partir des prototypes sélectionnés comme activés ?"
 
 #: include/views/configuration.maintenance.list.php:30
 msgid "Create maintenance period"
@@ -4265,7 +4267,7 @@ msgstr "Créer un proxy"
 
 #: app/views/reports.scheduledreport.list.php:35
 msgid "Create report"
-msgstr ""
+msgstr "Créer un rapport"
 
 #: app/views/administration.script.list.php:34
 msgid "Create script"
@@ -4273,7 +4275,7 @@ msgstr "Créer un script"
 
 #: app/views/monitoring.service.list.edit.php:132
 msgid "Create service"
-msgstr ""
+msgstr "Créer un service"
 
 #: include/views/configuration.template.list.php:90
 msgid "Create template"
@@ -4285,11 +4287,11 @@ msgstr "Créer un déclencheur"
 
 #: include/views/configuration.triggers.list.php:157
 msgid "Create trigger (select host first)"
-msgstr "Créer un déclencheur (sélectionner un hôte d'abord)"
+msgstr "Créer un déclencheur (sélectionner un hôte d’abord)"
 
 #: include/views/configuration.triggers.list.php:158
 msgid "Create trigger (select template first)"
-msgstr ""
+msgstr "Créer un déclencheur (sélectionner d’abord un modèle)"
 
 #: include/views/configuration.trigger.prototype.list.php:30
 msgid "Create trigger prototype"
@@ -4297,11 +4299,11 @@ msgstr "Créer un prototype de déclencheur"
 
 #: include/views/configuration.trigger.prototype.list.php:199
 msgid "Create triggers from selected prototypes as disabled?"
-msgstr "Créer les déclencheurs à partir des prototypes sélectionnés comme désactivés ?"
+msgstr "Créer les déclencheurs à partir des prototypes sélectionnés comme désactivés ?"
 
 #: include/views/configuration.trigger.prototype.list.php:196
 msgid "Create triggers from selected prototypes as enabled?"
-msgstr "Créer les déclencheurs à partir des prototypes sélectionnés comme activés ?"
+msgstr "Créer les déclencheurs à partir des prototypes sélectionnés comme activés ?"
 
 #: app/views/administration.user.list.php:53
 msgid "Create user"
@@ -4309,41 +4311,41 @@ msgstr "Créer un utilisateur"
 
 #: app/views/administration.usergroup.list.php:34
 msgid "Create user group"
-msgstr "Créer un groupe d'utilisateurs"
+msgstr "Créer un groupe d’utilisateurs"
 
 #: app/views/administration.userrole.list.php:34
 msgid "Create user role"
-msgstr ""
+msgstr "Créer un rôle d’utilisateur"
 
 #: include/views/configuration.httpconf.list.php:95
 msgid "Create web scenario"
-msgstr "Créer un scénario web"
+msgstr "Créer un scénario Web"
 
 #: include/views/configuration.httpconf.list.php:103
 msgid "Create web scenario (select host first)"
-msgstr "Créer un scénario web (sélectionner un hôte d'abord)"
+msgstr "Créer un scénario Web (sélectionner un hôte d’abord)"
 
 #: include/views/configuration.httpconf.list.php:104
 msgid "Create web scenario (select template first)"
-msgstr ""
+msgstr "Créer un scénario Web (sélectionner d’abord un modèle)"
 
 #: app/views/administration.token.list.php:137
 #: app/views/administration.user.token.list.php:98
 msgid "Created at"
-msgstr ""
+msgstr "Créé le"
 
 #: app/views/monitoring.dashboard.list.php:66
 #: app/views/reports.scheduledreport.list.php:55
 msgid "Created by me"
-msgstr ""
+msgstr "Créé par moi"
 
 #: app/views/administration.token.list.php:138
 msgid "Created by user"
-msgstr ""
+msgstr "Créé par l’utilisateur"
 
 #: app/views/administration.token.list.php:74
 msgid "Created by users"
-msgstr ""
+msgstr "Créé par les utilisateurs"
 
 #: app/controllers/CControllerPopupMediatypeTestSend.php:172
 #: include/items.inc.php:41
@@ -4356,7 +4358,7 @@ msgstr "Hôte actuel"
 
 #: app/views/popup.scheduledreport.subscription.php:103
 msgid "Current user"
-msgstr ""
+msgstr "Utilisateur courant"
 
 #: include/classes/setup/CSetupWizard.php:409
 msgid "Current value"
@@ -4373,14 +4375,13 @@ msgstr "Personnalisé"
 #: include/views/configuration.action.edit.php:125
 #: include/views/configuration.host.discovery.edit.php:726
 msgid "Custom expression"
-msgstr "Personnaliser l'expression"
+msgstr "Personnaliser l’expression"
 
 #: app/controllers/CControllerChartsView.php:190
 msgid "Custom graphs"
 msgstr "Graphiques personnalisés"
 
-#: app/views/popup.lldoperation.php:169
-#: app/views/popup.massupdate.item.php:276
+#: app/views/popup.lldoperation.php:169 app/views/popup.massupdate.item.php:276
 #: include/views/configuration.host.discovery.edit.php:675
 #: include/views/configuration.item.edit.php:790
 #: include/views/configuration.item.prototype.edit.php:757
@@ -4395,12 +4396,12 @@ msgstr "Étiquette personnalisée"
 #: include/classes/api/services/CMap.php:1361
 #, c-format
 msgid "Custom label for map \"%2$s\" elements of type \"%1$s\" may not be empty."
-msgstr "L'étiquette personnalisée pour les éléments de la carte \"%2$s\" de type \"%1$s\" ne doit pas être vide."
+msgstr "L’étiquette personnalisée pour les éléments de la carte « %2$s » de type « %1$s » ne doit pas être vide."
 
 #: app/controllers/CControllerActionOperationValidate.php:121
 #: app/partials/popup.operations.php:145
 msgid "Custom message"
-msgstr ""
+msgstr "Message personnalisé"
 
 #: include/items.inc.php:1839
 msgid "Custom multiplier"
@@ -4409,7 +4410,7 @@ msgstr "Multiplicateur personnalisé"
 #: app/views/js/popup.itemtestedit.view.js.php:381 include/forms.inc.php:1221
 #: include/forms.inc.php:1436 include/views/js/item.preprocessing.js.php:64
 msgid "Custom on fail"
-msgstr "Personnalisé en cas d'échec"
+msgstr "Personnalisé en cas d’échec"
 
 #: include/items.inc.php:1862
 msgid "Custom scripts"
@@ -4417,7 +4418,7 @@ msgstr "Scripts personnalisés"
 
 #: app/views/administration.trigdisplay.edit.php:155
 msgid "Custom severity names affect all locales and require manual translation!"
-msgstr "Le nom de la sévérité personnalisée affecte toutes les locales et nécessite une traduction manuelle !"
+msgstr "Le nom de la sévérité personnalisée affecte toutes les locales et nécessite une traduction manuelle !"
 
 #: include/views/js/monitoring.sysmaps.js.php:112
 msgid "Custom size"
@@ -4425,7 +4426,7 @@ msgstr "Taille personnalisée"
 
 #: app/partials/scheduledreport.formgrid.html.php:95
 msgid "Cycle"
-msgstr ""
+msgstr "Cycle"
 
 #: include/locales.inc.php:51
 msgid "Czech (cs_CZ)"
@@ -4434,7 +4435,7 @@ msgstr "Tchèque (cs_CZ)"
 #: jsLoader.php:181
 msgctxt "abbreviation of severity level"
 msgid "D"
-msgstr ""
+msgstr "D"
 
 #: include/classes/import/validators/C10XmlValidator.php:321
 msgctxt "XML date format"
@@ -4478,12 +4479,12 @@ msgstr "Tableau de bord"
 #: include/classes/api/services/CTemplateDashboard.php:431
 #, c-format
 msgid "Dashboard \"%1$s\" already exists."
-msgstr "Le tableau de bord \"%1$s\" existe déjà."
+msgstr "Le tableau de bord « %1$s » existe déjà."
 
 #: include/classes/api/services/CDashboardGeneral.php:89
 #, c-format
 msgid "Dashboard \"%1$s\" is used in report \"%2$s\"."
-msgstr ""
+msgstr "Le tableau de bord « %1$s » est utilisé dans le rapport « %2$s »."
 
 #: app/controllers/CControllerDashboardUpdate.php:145
 #: app/controllers/CControllerTemplateDashboardUpdate.php:139
@@ -4499,7 +4500,7 @@ msgstr[1] "Tableaux de bord supprimés"
 
 #: app/views/dashboard.page.properties.edit.php:60
 msgid "Dashboard page properties"
-msgstr ""
+msgstr "Propriété de la page du tableau de bord"
 
 #: app/views/dashboard.properties.edit.php:88
 msgid "Dashboard properties"
@@ -4518,7 +4519,7 @@ msgstr "Tableau de bord mis à jour"
 #: include/classes/api/services/CReport.php:277
 #, c-format
 msgid "Dashboard with ID \"%1$s\" is not available."
-msgstr ""
+msgstr "Le tableau de bord avec l’identifiant « %1$s » n’est pas disponible."
 
 #: app/controllers/CControllerDashboardList.php:120
 #: app/controllers/CControllerHostDashboardView.php:122
@@ -4576,42 +4577,42 @@ msgstr "Période de stockage des données"
 #: include/classes/setup/CSetupWizard.php:703
 #: include/classes/setup/CSetupWizard.php:940
 msgid "Database TLS CA file"
-msgstr ""
+msgstr "Fichier de l’AC TLS de la base de données"
 
 #: include/classes/setup/CFrontendSetup.php:668
 #: include/classes/setup/CSetupWizard.php:561
 #: include/classes/setup/CSetupWizard.php:711
 #: include/classes/setup/CSetupWizard.php:948
 msgid "Database TLS certificate file"
-msgstr ""
+msgstr "Fichier certificat TLS de la base de données"
 
 #: include/classes/setup/CFrontendSetup.php:672
 msgid "Database TLS certificate files must be read-only"
-msgstr ""
+msgstr "Les fichiers certificats TLS doivent être en lecture seule"
 
 #: include/classes/setup/CSetupWizard.php:571
 #: include/classes/setup/CSetupWizard.php:721
 msgid "Database TLS cipher list"
-msgstr ""
+msgstr "Liste des algorithmes de chiffrement TLS de la base de données"
 
 #: include/classes/setup/CSetupWizard.php:534
 #: include/classes/setup/CSetupWizard.php:696
 msgid "Database TLS encryption"
-msgstr ""
+msgstr "Chiffrement TLS de la base de données"
 
 #: include/classes/setup/CSetupWizard.php:556
 #: include/classes/setup/CSetupWizard.php:707
 #: include/classes/setup/CSetupWizard.php:944
 msgid "Database TLS key file"
-msgstr ""
+msgstr "Fichier contenant la clef privée TLS de la base de données"
 
 #: app/partials/administration.system.info.php:121
-msgid "Database history $info_tables upgraded"
-msgstr ""
+msgid "Database history tables upgraded"
+msgstr "Tables d’historique de la base de données mises à jour"
 
 #: app/partials/administration.system.info.php:129
 msgid "Database history tables use primary key"
-msgstr ""
+msgstr "Les tables d’historique de la base de données utilisent la clef primaire"
 
 #: include/classes/setup/CSetupWizard.php:472
 msgid "Database host"
@@ -4620,7 +4621,7 @@ msgstr "Hôte base de données"
 #: include/classes/setup/CSetupWizard.php:566
 #: include/classes/setup/CSetupWizard.php:715
 msgid "Database host verification"
-msgstr ""
+msgstr "Vérification du serveur de base de données"
 
 #: include/items.inc.php:94
 msgid "Database monitor"
@@ -4665,23 +4666,23 @@ msgstr "Date"
 
 #: include/hosts.inc.php:329
 msgid "Date HW decommissioned"
-msgstr "Matériel - Date de retrait"
+msgstr "Date de mise hors service du matériel"
 
 #: include/hosts.inc.php:319
 msgid "Date HW installed"
-msgstr "Matériel - Date d'installation"
+msgstr "Date d’installation du matériel"
 
 #: include/hosts.inc.php:324
 msgid "Date HW maintenance expires"
-msgstr "Matériel - Date de fin de maintenance"
+msgstr "Date d’expiration de la maintenance matérielle"
 
 #: include/hosts.inc.php:314
 msgid "Date HW purchased"
-msgstr "Matériel - Date d'achat"
+msgstr "Date d’achat du matériel"
 
 #: app/views/popup.triggerexpr.php:110
 msgid "Date and time functions"
-msgstr ""
+msgstr "Fonctions d’horodatage"
 
 #: report4.php:175
 msgid "Day"
@@ -4689,7 +4690,7 @@ msgstr "Jour"
 
 #: include/func.inc.php:2400
 msgid "Day before yesterday"
-msgstr "Avant-hier"
+msgstr "Avant‐hier"
 
 #: app/views/popup.maintenance.period.php:114
 #: app/views/popup.maintenance.period.php:141
@@ -4708,30 +4709,30 @@ msgstr "Jours"
 
 #: app/controllers/CControllerPopupMediatypeTestSend.php:172 jsLoader.php:386
 msgid "Debug"
-msgstr "Debug"
+msgstr "Débogage"
 
 #: app/views/administration.usergroup.edit.php:98
 #: app/views/administration.usergroup.list.php:77
 #: app/views/administration.user.list.php:115
 msgid "Debug mode"
-msgstr "Mode debug"
+msgstr "Mode débogage"
 
 #: include/func.inc.php:231
 msgid "Dec"
-msgstr "Déc"
+msgstr "déc."
 
 #: include/func.inc.php:111 include/func.inc.php:248 jsLoader.php:242
 msgid "December"
-msgstr "Décembre"
+msgstr "décembre"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:908
 #: app/controllers/CControllerPopupTriggerExpr.php:1108
 msgid "Decimal places"
-msgstr ""
+msgstr "Nombre de décimales"
 
 #: include/classes/helpers/CServiceHelper.php:150
 msgid "Decrease by"
-msgstr ""
+msgstr "Diminuer de"
 
 #: app/views/administration.iconmap.edit.php:108
 #: include/classes/widgets/forms/CWidgetForm.php:54 include/hosts.inc.php:31
@@ -4746,19 +4747,19 @@ msgstr "Défaut"
 #: app/views/dashboard.page.properties.edit.php:48
 #, c-format
 msgid "Default (%1$s)"
-msgstr ""
+msgstr "Défaut (%1$s)"
 
 #: app/views/administration.userrole.edit.php:121
 msgid "Default access to new UI elements"
-msgstr ""
+msgstr "Accès par défaut aux nouveaux éléments d’interface"
 
 #: app/views/administration.userrole.edit.php:341
 msgid "Default access to new actions"
-msgstr ""
+msgstr "Accès par défaut aux nouvelles actions"
 
 #: app/views/administration.userrole.edit.php:260
 msgid "Default access to new modules"
-msgstr ""
+msgstr "Accès par défaut aux nouveaux modules"
 
 #: app/views/administration.authentication.edit.php:30
 msgid "Default authentication"
@@ -4766,12 +4767,12 @@ msgstr "Authentification par défaut"
 
 #: app/views/administration.miscconfig.edit.php:57
 msgid "Default host inventory mode"
-msgstr "Mode d'inventaire d'hôte par défaut"
+msgstr "Mode d’inventaire d’hôte par défaut"
 
 #: app/views/administration.gui.edit.php:70
 #: include/classes/setup/CSetupWizard.php:399
 msgid "Default language"
-msgstr ""
+msgstr "Langue par défaut"
 
 #: app/views/administration.authentication.edit.php:115
 msgid "Default login form"
@@ -4783,11 +4784,11 @@ msgstr "Type de média par défaut"
 
 #: actionconf.php:52 include/views/configuration.action.edit.php:155
 msgid "Default operation step duration"
-msgstr "Durée de l'étape d'opération par défaut"
+msgstr "Durée de l’étape d’opération par défaut"
 
 #: app/views/dashboard.properties.edit.php:79
 msgid "Default page display period"
-msgstr ""
+msgstr "Fréquence de rafraîchissement de la page par défaut"
 
 #: app/views/administration.gui.edit.php:82
 #: include/classes/setup/CSetupWizard.php:614
@@ -4797,10 +4798,9 @@ msgstr "Thème par défaut"
 #: app/views/administration.gui.edit.php:75
 #: include/classes/setup/CSetupWizard.php:607
 msgid "Default time zone"
-msgstr ""
+msgstr "Fuseau horaire par défaut"
 
-#: app/views/popup.lldoperation.php:105
-#: app/views/popup.massupdate.item.php:218
+#: app/views/popup.lldoperation.php:105 app/views/popup.massupdate.item.php:218
 msgid "Delay"
 msgstr "Délai"
 
@@ -4839,8 +4839,8 @@ msgstr "Retardé de"
 #: app/views/configuration.discovery.list.php:122
 #: app/views/configuration.host.edit.php:49
 #: app/views/configuration.host.list.php:522
-#: app/views/monitoring.dashboard.list.php:123
-#: app/views/popup.host.edit.php:82 app/views/popup.tabfilter.edit.php:71
+#: app/views/monitoring.dashboard.list.php:123 app/views/popup.host.edit.php:82
+#: app/views/popup.tabfilter.edit.php:71
 #: app/views/reports.scheduledreport.list.php:94
 #: include/classes/html/CButtonDelete.php:25
 #: include/classes/widgets/CWidgetHelper.php:690
@@ -4864,7 +4864,7 @@ msgstr "Supprimer"
 
 #: app/views/js/popup.import.js.php:47
 msgid "Delete all elements that are not present in the import file?"
-msgstr ""
+msgstr "Supprimer tous les éléments absents du fichier d’importation ?"
 
 #: include/views/configuration.template.edit.php:224
 #: include/views/configuration.template.list.php:285
@@ -4873,75 +4873,75 @@ msgstr "Supprimer et effacer"
 
 #: include/views/configuration.template.list.php:286
 msgid "Delete and clear selected templates? (Warning: all linked hosts will be cleared!)"
-msgstr "Supprimer et nettoyer les modèles sélectionnés ? (Attention : tous les hôtes liés seront nettoyés !)"
+msgstr "Supprimer et nettoyer les modèles sélectionnés (attention : tous les hôtes liés seront effacés !) ?"
 
 #: include/views/configuration.template.edit.php:225
 msgid "Delete and clear template? (Warning: all linked hosts will be cleared!)"
-msgstr "Supprimer et nettoyer le modèle ? (Attention : tous les hôtes liés seront nettoyés !)"
+msgstr "Supprimer et nettoyer le modèle (attention : tous les hôtes liés seront effacés !) ?"
 
 #: include/views/configuration.action.edit.php:492
 msgid "Delete current action?"
-msgstr "Effacer l'action actuelle ?"
+msgstr "Effacer l’action actuelle ?"
 
 #: app/views/configuration.correlation.edit.php:183
 msgid "Delete current correlation?"
-msgstr "Effacer la corrélation actuelle ?"
+msgstr "Effacer la corrélation actuelle ?"
 
 #: jsLoader.php:359
 msgid "Delete dashboard?"
-msgstr "Effacer le tableau de bord ?"
+msgstr "Effacer le tableau de bord ?"
 
 #: app/views/configuration.discovery.edit.php:159
 #: include/views/configuration.host.discovery.edit.php:972
 msgid "Delete discovery rule?"
-msgstr "Supprimer la règle de découverte ?"
+msgstr "Supprimer la règle de découverte ?"
 
 #: include/views/configuration.trigger.prototype.edit.php:247
 #: include/views/configuration.trigger.prototype.edit.php:443
 #: include/views/configuration.triggers.edit.php:270
 #: include/views/configuration.triggers.edit.php:468
 msgid "Delete expression?"
-msgstr "Supprimer l'expression ?"
+msgstr "Supprimer l’expression ?"
 
 #: include/views/configuration.graph.edit.php:496
 msgid "Delete graph prototype?"
-msgstr "Supprimer le prototype de graphique ?"
+msgstr "Supprimer le prototype de graphique ?"
 
 #: include/views/configuration.graph.edit.php:496
 msgid "Delete graph?"
-msgstr "Supprimer le graphique ?"
+msgstr "Supprimer le graphique ?"
 
 #: include/views/configuration.item.list.php:292
 msgid "Delete history of selected items?"
-msgstr "Supprimer l'historique des éléments sélectionnés ?"
+msgstr "Supprimer l’historique des éléments sélectionnés ?"
 
 #: include/views/configuration.httpconf.list.php:218
 msgid "Delete history of selected web scenarios?"
-msgstr "Supprimer l'historique des scénarios web sélectionnés ?"
+msgstr "Supprimer l’historique des scénarios Web sélectionnés ?"
 
 #: app/views/administration.iconmap.edit.php:143
 msgid "Delete icon map?"
-msgstr "Supprimer la correspondance d'icône ?"
+msgstr "Supprimer la correspondance d’icône ?"
 
 #: include/views/configuration.item.prototype.edit.php:903
 msgid "Delete item prototype?"
-msgstr "Supprimer le prototype d'élément ?"
+msgstr "Supprimer le prototype d’élément ?"
 
 #: include/views/configuration.item.edit.php:1037
 msgid "Delete item?"
-msgstr "Effacer l'élément ?"
+msgstr "Effacer l’élément ?"
 
 #: jsLoader.php:284
 msgid "Delete links between selected elements?"
-msgstr "Supprimer les liens entre les éléments sélectionnés ?"
+msgstr "Supprimer les liens entre les éléments sélectionnés ?"
 
 #: include/views/configuration.maintenance.edit.php:267
 msgid "Delete maintenance period?"
-msgstr "Supprimer la période de maintenance ?"
+msgstr "Supprimer la période de maintenance ?"
 
 #: app/views/administration.mediatype.edit.php:366
 msgid "Delete media type?"
-msgstr "Supprimer le type de média ?"
+msgstr "Supprimer le type de média ?"
 
 #: app/views/popup.import.php:131
 msgid "Delete missing"
@@ -4949,211 +4949,211 @@ msgstr "Supprimer les manquants"
 
 #: app/views/administration.proxy.edit.php:164
 msgid "Delete proxy?"
-msgstr "Supprimer le proxy ?"
+msgstr "Supprimer le proxy ?"
 
 #: app/views/administration.regex.edit.php:153
 msgid "Delete regular expression?"
-msgstr "Supprimer l'expression régulière ?"
+msgstr "Supprimer l’expression rationnelle ?"
 
 #: app/views/administration.script.edit.php:289
 msgid "Delete script?"
-msgstr "Supprimer script ?"
+msgstr "Supprimer script ?"
 
 #: app/views/administration.token.edit.php:115
 #: app/views/administration.user.token.edit.php:97
 msgid "Delete selected API token?"
-msgstr ""
+msgstr "Supprimer le jeton d’API sélectionné ?"
 
 #: app/views/administration.token.list.php:201
 #: app/views/administration.user.token.list.php:153
 msgid "Delete selected API tokens?"
-msgstr ""
+msgstr "Supprimer les jetons d’API sélectionnés ?"
 
 #: include/views/configuration.action.list.php:165
 msgid "Delete selected actions?"
-msgstr "Supprimer les actions sélectionnées ?"
+msgstr "Supprimer les actions sélectionnées ?"
 
 #: app/views/configuration.correlation.list.php:149
 msgid "Delete selected correlations?"
-msgstr "Supprimer les corrélations sélectionnées ?"
+msgstr "Supprimer les corrélations sélectionnées ?"
 
 #: app/views/configuration.dashboard.list.php:68
 #: app/views/monitoring.dashboard.list.php:124
 msgid "Delete selected dashboards?"
-msgstr "Effacer le tableau de bord sélectionné ?"
+msgstr "Effacer le tableau de bord sélectionné ?"
 
 #: app/views/configuration.discovery.list.php:122
 #: include/views/configuration.host.discovery.list.php:333
 msgid "Delete selected discovery rules?"
-msgstr "Supprimer les règles de découverte sélectionnées ?"
+msgstr "Supprimer les règles de découverte sélectionnées ?"
 
 #: jsLoader.php:271
 msgid "Delete selected elements?"
-msgstr "Supprimer les éléments sélectionnés ?"
+msgstr "Supprimer les éléments sélectionnés ?"
 
 #: include/views/configuration.graph.list.php:241
 msgid "Delete selected graph prototypes?"
-msgstr "Supprimer les prototypes de graphiques sélectionnés ?"
+msgstr "Supprimer les prototypes de graphiques sélectionnés ?"
 
 #: include/views/configuration.graph.list.php:242
 msgid "Delete selected graphs?"
-msgstr "Supprimer les graphiques sélectionnés ?"
+msgstr "Supprimer les graphiques sélectionnés ?"
 
 #: app/views/administration.usergroup.edit.php:225
 #: include/views/configuration.hostgroups.edit.php:63
 msgid "Delete selected group?"
-msgstr "Supprimer le groupe sélectionné ?"
+msgstr "Supprimer le groupe sélectionné ?"
 
 #: app/views/administration.usergroup.list.php:237
 msgid "Delete selected groups?"
-msgstr "Supprimer les groupes sélectionnés ?"
+msgstr "Supprimer les groupes sélectionnés ?"
 
 #: include/views/configuration.hostgroups.list.php:204
 msgid "Delete selected host groups?"
-msgstr "Supprimer les groupes d'hôtes sélectionnés ?"
+msgstr "Supprimer les groupes d’hôtes sélectionnés ?"
 
 #: include/views/configuration.host.prototype.edit.php:421
 msgid "Delete selected host prototype?"
-msgstr "Supprimer le prototype d'hôte sélectionné ?"
+msgstr "Supprimer le prototype d’hôte sélectionné ?"
 
 #: include/views/configuration.host.prototype.list.php:194
 msgid "Delete selected host prototypes?"
-msgstr "Supprimer les prototypes d'hôtes sélectionnés ?"
+msgstr "Supprimer les prototypes d’hôtes sélectionnés ?"
 
 #: app/views/configuration.host.edit.php:50 app/views/popup.host.edit.php:83
 msgid "Delete selected host?"
-msgstr "Supprimer hôte sélectionné ?"
+msgstr "Supprimer hôte sélectionné ?"
 
 #: app/views/configuration.host.list.php:523
 msgid "Delete selected hosts?"
-msgstr "Suppression des hôtes sélectionnés ?"
+msgstr "Suppression des hôtes sélectionnés ?"
 
 #: app/views/administration.image.edit.php:84
 msgid "Delete selected image?"
-msgstr "Supprimer l'image sélectionnée ?"
+msgstr "Supprimer l’image sélectionnée ?"
 
 #: include/views/configuration.item.prototype.list.php:202
 msgid "Delete selected item prototypes?"
-msgstr "Supprimer les prototypes d'éléments sélectionnés ?"
+msgstr "Supprimer les prototypes d’éléments sélectionnés ?"
 
 #: include/views/configuration.item.list.php:314
 msgid "Delete selected items?"
-msgstr "Supprimer les éléments sélectionnés ?"
+msgstr "Supprimer les éléments sélectionnés ?"
 
 #: include/views/configuration.maintenance.list.php:124
 msgid "Delete selected maintenance periods?"
-msgstr "Supprimer les périodes de maintenance sélectionnées ?"
+msgstr "Supprimer les périodes de maintenance sélectionnées ?"
 
 #: include/views/monitoring.sysmap.edit.php:423
 msgid "Delete selected map?"
-msgstr "Supprimer la carte sélectionnée ?"
+msgstr "Supprimer la carte sélectionnée ?"
 
 #: include/views/monitoring.sysmap.list.php:110
 msgid "Delete selected maps?"
-msgstr "Supprimer les cartes sélectionnées ?"
+msgstr "Supprimer les cartes sélectionnées ?"
 
 #: app/views/administration.mediatype.list.php:177
 msgid "Delete selected media types?"
-msgstr "Supprimer les types de media sélectionnés ?"
+msgstr "Supprimer les types de media sélectionnés ?"
 
 #: app/views/administration.proxy.list.php:189
 msgid "Delete selected proxies?"
-msgstr "Supprimer les proxies sélectionnés ?"
+msgstr "Supprimer les proxies sélectionnés ?"
 
 #: app/views/administration.regex.list.php:81
 msgid "Delete selected regular expressions?"
-msgstr "Supprimer les expressions régulières ?"
+msgstr "Supprimer les expressions rationnelles ?"
 
 #: app/views/administration.userrole.edit.php:366
 msgid "Delete selected role?"
-msgstr ""
+msgstr "Supprimer le rôle sélectionné ?"
 
 #: app/views/administration.userrole.list.php:127
 msgid "Delete selected roles?"
-msgstr ""
+msgstr "Supprimer les rôles sélectionnés ?"
 
 #: app/partials/scheduledreport.formgrid.html.php:234
 msgid "Delete selected scheduled report?"
-msgstr ""
+msgstr "Supprimer le rapport planifié sélectionné ?"
 
 #: app/views/reports.scheduledreport.list.php:95
 msgid "Delete selected scheduled reports?"
-msgstr ""
+msgstr "Supprimer les rapports planifiés sélectionnés ?"
 
 #: app/views/administration.script.list.php:198
 msgid "Delete selected scripts?"
-msgstr "Supprimer les scripts sélectionnés ?"
+msgstr "Supprimer les scripts sélectionnés ?"
 
 #: app/views/js/monitoring.service.list.js.php:90
 msgid "Delete selected service?"
-msgstr ""
+msgstr "Supprimer le service sélectionné ?"
 
 #: app/partials/monitoring.service.list.edit.php:145
 msgid "Delete selected services?"
-msgstr ""
+msgstr "Supprimer les services sélectionnés ?"
 
 #: jsLoader.php:272
 msgid "Delete selected shapes?"
-msgstr "Supprimer les formes sélectionnées ?"
+msgstr "Supprimer les formes sélectionnées ?"
 
 #: include/views/configuration.template.list.php:284
 msgid "Delete selected templates?"
-msgstr "Supprimer les modèles sélectionnés ?"
+msgstr "Supprimer les modèles sélectionnés ?"
 
 #: include/views/configuration.trigger.prototype.list.php:208
 msgid "Delete selected trigger prototypes?"
-msgstr "Supprimer les prototypes de déclencheurs sélectionnés ?"
+msgstr "Supprimer les prototypes de déclencheurs sélectionnés ?"
 
 #: include/views/configuration.triggers.list.php:350
 msgid "Delete selected triggers?"
-msgstr "Supprimer les déclencheurs sélectionnés ?"
+msgstr "Supprimer les déclencheurs sélectionnés ?"
 
 #: app/views/administration.user.edit.php:766
 msgid "Delete selected user?"
-msgstr "Supprimer l'utilisateur sélectionné ?"
+msgstr "Supprimer l’utilisateur sélectionné ?"
 
 #: app/views/administration.user.list.php:250
 msgid "Delete selected users?"
-msgstr "Supprimer les utilisateurs sélectionnés ?"
+msgstr "Supprimer les utilisateurs sélectionnés ?"
 
 #: include/views/configuration.httpconf.list.php:224
 msgid "Delete selected web scenarios?"
-msgstr "Supprimer les scénarios web sélectionnés ?"
+msgstr "Supprimer les scénarios Web sélectionnés ?"
 
 #: include/views/configuration.template.edit.php:221
 msgid "Delete template?"
-msgstr "Supprimer le modèle ?"
+msgstr "Supprimer le modèle ?"
 
 #: include/views/configuration.trigger.prototype.edit.php:645
 msgid "Delete trigger prototype?"
-msgstr "Supprimer le prototype de déclencheur ?"
+msgstr "Supprimer le prototype de déclencheur ?"
 
 #: include/views/configuration.triggers.edit.php:649
 msgid "Delete trigger?"
-msgstr "Supprimer le déclencheur ?"
+msgstr "Supprimer le déclencheur ?"
 
 #: include/views/configuration.httpconf.edit.php:266
 msgid "Delete web scenario?"
-msgstr "Supprimer le scénario web ?"
+msgstr "Supprimer le scénario Web ?"
 
 #: app/controllers/CControllerAuditLogList.php:358
 msgid "Deleted"
-msgstr ""
+msgstr "Supprimé"
 
 #: include/classes/api/services/CHost.php:1494
 #, c-format
 msgid "Deleted: Host \"%1$s\"."
-msgstr "Supprimé : Hôte \"%1$s\"."
+msgstr "Supprimé : hôte « %1$s »."
 
 #: include/classes/api/services/CHostPrototype.php:1181
 #, c-format
 msgid "Deleted: Host prototype \"%1$s\" on \"%2$s\"."
-msgstr "Supprimé : Prototype d'hôte \"%1$s\" sur \"%2$s\"."
+msgstr "Supprimé : prototype d’hôte « %1$s » sur « %2$s »."
 
 #: include/classes/api/services/CTemplate.php:888
 #, c-format
 msgid "Deleted: Template \"%1$s\"."
-msgstr "Supprimé : Modèle \"%1$s\"."
+msgstr "Supprimé : modèle « %1$s »."
 
 #: app/views/administration.regex.edit.php:49
 msgid "Delimiter"
@@ -5161,7 +5161,7 @@ msgstr "Délimiteur"
 
 #: app/views/administration.user.edit.php:623
 msgid "Denied methods"
-msgstr ""
+msgstr "Méthodes refusées"
 
 #: app/partials/administration.usergroup.grouprights.html.php:71
 #: app/views/administration.usergroup.edit.php:133 include/perm.inc.php:33
@@ -5171,7 +5171,7 @@ msgstr "Interdit"
 
 #: app/views/administration.userrole.edit.php:290
 msgid "Deny list"
-msgstr ""
+msgstr "Liste de refus"
 
 #: app/views/popup.massupdate.trigger.php:151
 #: include/views/configuration.trigger.prototype.edit.php:607
@@ -5181,7 +5181,7 @@ msgstr ""
 msgid "Dependencies"
 msgstr "Dépendances"
 
-#: include/triggers.inc.php:2398
+#: include/triggers.inc.php:2400
 msgid "Dependent"
 msgstr "Dépendant"
 
@@ -5189,7 +5189,7 @@ msgstr "Dépendant"
 msgid "Dependent item"
 msgstr "Élément dépendant"
 
-#: app/views/popup.generic.php:278 include/triggers.inc.php:2398
+#: app/views/popup.generic.php:278 include/triggers.inc.php:2400
 #: include/views/configuration.trigger.prototype.list.php:92
 #: include/views/configuration.triggers.list.php:238
 msgid "Depends on"
@@ -5246,15 +5246,15 @@ msgstr "Détails"
 
 #: httpdetails.php:27 httpdetails.php:185
 msgid "Details of web scenario"
-msgstr "Détails du scénario web"
+msgstr "Détails du scénario Web"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1055
 msgid "Detection period"
-msgstr ""
+msgstr "Période de détection"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1065
 msgid "Deviations"
-msgstr ""
+msgstr "Déviations"
 
 #: include/actions.inc.php:76
 msgid "Device"
@@ -5266,15 +5266,15 @@ msgstr "Interruptions du périphérique. Retourne un entier"
 
 #: app/views/configuration.discovery.edit.php:95
 msgid "Device uniqueness criteria"
-msgstr "Critère d'unicité de l'équipement"
+msgstr "Critère d’unicité de l’équipement"
 
 #: include/httptest.inc.php:31
 msgid "Digest"
-msgstr ""
+msgstr "Condensat"
 
 #: app/views/administration.module.edit.php:42
 msgid "Directory"
-msgstr ""
+msgstr "Répertoire"
 
 #: include/classes/data/CItemData.php:1168
 msgid "Directory size (in bytes). Returns integer"
@@ -5299,11 +5299,11 @@ msgstr "Désactiver"
 
 #: app/views/administration.usergroup.list.php:231
 msgid "Disable debug mode"
-msgstr "Désactiver le mode debug"
+msgstr "Désactiver le mode de débogage"
 
 #: app/views/administration.usergroup.list.php:231
 msgid "Disable debug mode in selected groups?"
-msgstr "Désactiver le mode debug des groupes sélectionnés ?"
+msgstr "Désactiver le mode de débogage des groupes sélectionnés ?"
 
 #: include/actions.inc.php:698 include/actions.inc.php:1032
 msgid "Disable host"
@@ -5311,7 +5311,7 @@ msgstr "Désactiver hôte"
 
 #: app/views/configuration.host.list.php:275
 msgid "Disable host?"
-msgstr "Désactiver l'hôte ?"
+msgstr "Désactiver l’hôte ?"
 
 #: app/views/administration.proxy.list.php:186
 #: include/views/configuration.hostgroups.list.php:201
@@ -5320,61 +5320,61 @@ msgstr "Désactiver les hôtes"
 
 #: include/views/configuration.hostgroups.list.php:202
 msgid "Disable hosts in the selected host groups?"
-msgstr "Désactiver les hôtes dans les groupes d'hôtes sélectionnés ?"
+msgstr "Désactiver les hôtes dans les groupes d’hôtes sélectionnés ?"
 
 #: app/views/administration.proxy.list.php:187
 msgid "Disable hosts monitored by selected proxies?"
-msgstr "Désactiver les hôtes surveillés par les proxies sélectionnés ?"
+msgstr "Désactiver les hôtes surveillés par les proxies sélectionnés ?"
 
 #: app/views/administration.token.list.php:200
 #: app/views/administration.user.token.list.php:152
 msgid "Disable selected API tokens?"
-msgstr ""
+msgstr "Désactiver les jetons d’API sélectionnés ?"
 
 #: include/views/configuration.action.list.php:164
 msgid "Disable selected actions?"
-msgstr "Désactiver les actions sélectionnées ?"
+msgstr "Désactiver les actions sélectionnées ?"
 
 #: app/views/configuration.correlation.list.php:148
 msgid "Disable selected correlations?"
-msgstr "Désactiver les corrélations sélectionnées ?"
+msgstr "Désactiver les corrélations sélectionnées ?"
 
 #: app/views/configuration.discovery.list.php:121
 #: include/views/configuration.host.discovery.list.php:325
 msgid "Disable selected discovery rules?"
-msgstr "Désactiver les règles de découverte sélectionnées ?"
+msgstr "Désactiver les règles de découverte sélectionnées ?"
 
 #: app/views/administration.usergroup.list.php:219
 msgid "Disable selected groups?"
-msgstr "Désactiver les groupes sélectionnés ?"
+msgstr "Désactiver les groupes sélectionnés ?"
 
 #: app/views/configuration.host.list.php:504
 msgid "Disable selected hosts?"
-msgstr "Désactiver les hôtes sélectionnés ?"
+msgstr "Désactiver les hôtes sélectionnés ?"
 
 #: include/views/configuration.item.list.php:286
 msgid "Disable selected items?"
-msgstr "Désactiver les éléments sélectionnés ?"
+msgstr "Désactiver les éléments sélectionnés ?"
 
 #: app/views/administration.mediatype.list.php:168
 msgid "Disable selected media types?"
-msgstr "Désactiver les types de média sélectionnés ?"
+msgstr "Désactiver les types de média sélectionnés ?"
 
 #: app/views/administration.module.list.php:124
 msgid "Disable selected modules?"
-msgstr ""
+msgstr "Désactiver les modules sélectionnés ?"
 
 #: app/views/reports.scheduledreport.list.php:90
 msgid "Disable selected scheduled reports?"
-msgstr ""
+msgstr "Désactiver les rapports planifiés sélectionnés ?"
 
 #: include/views/configuration.triggers.list.php:342
 msgid "Disable selected triggers?"
-msgstr "Désactiver les déclencheurs sélectionnés ?"
+msgstr "Désactiver les déclencheurs sélectionnés ?"
 
 #: include/views/configuration.httpconf.list.php:211
 msgid "Disable selected web scenarios?"
-msgstr "Désactiver les scénarios web sélectionnés ?"
+msgstr "Désactiver les scénarios Web sélectionnés ?"
 
 #: app/partials/administration.system.info.php:188
 #: app/partials/configuration.filter.items.php:188
@@ -5404,15 +5404,14 @@ msgstr "Désactiver les scénarios web sélectionnés ?"
 #: app/views/configuration.correlation.list.php:108
 #: app/views/configuration.discovery.list.php:57
 #: app/views/configuration.host.list.php:280
-#: app/views/popup.lldoperation.php:280
-#: app/views/popup.massupdate.host.php:141
+#: app/views/popup.lldoperation.php:280 app/views/popup.massupdate.host.php:141
 #: app/views/popup.massupdate.host.php:183
 #: app/views/reports.scheduledreport.list.php:62 include/discovery.inc.php:108
 #: include/hosts.inc.php:1126 include/html.inc.php:284
 #: include/httptest.inc.php:48 include/items.inc.php:138
-#: include/items.inc.php:141 include/items.inc.php:185
-#: include/maps.inc.php:325 include/triggers.inc.php:1871
-#: include/users.inc.php:84 include/views/configuration.action.list.php:77
+#: include/items.inc.php:141 include/items.inc.php:185 include/maps.inc.php:325
+#: include/triggers.inc.php:1873 include/users.inc.php:84
+#: include/views/configuration.action.list.php:77
 #: include/views/configuration.action.list.php:129
 #: include/views/configuration.host.discovery.list.php:167
 #: include/views/configuration.host.prototype.edit.php:360
@@ -5447,7 +5446,7 @@ msgstr "Ignorer la valeur"
 #: include/views/configuration.trigger.prototype.edit.php:537
 #: include/views/configuration.trigger.prototype.list.php:62
 msgid "Discover"
-msgstr ""
+msgstr "Découvrir"
 
 #: app/partials/configuration.filter.items.php:207
 #: include/discovery.inc.php:138 include/forms.inc.php:356
@@ -5485,7 +5484,7 @@ msgstr "Découverte"
 #: include/classes/helpers/CMenuHelper.php:180
 #: include/views/configuration.action.list.php:29
 msgid "Discovery actions"
-msgstr ""
+msgstr "Actions de découverte"
 
 #: app/views/configuration.discovery.edit.php:61
 msgid "Discovery by proxy"
@@ -5510,53 +5509,53 @@ msgstr "Objet de découverte"
 
 #: include/classes/data/CItemData.php:1244
 msgid "Discovery of VMware clusters, <url> - VMware service URL. Returns JSON"
-msgstr ""
+msgstr "Découverte de grappes de serveurs (clusters) VMware, <url> — URL de service VMware. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1252
 msgid "Discovery of VMware datastores, <url> - VMware service URL. Returns JSON"
-msgstr ""
+msgstr "Découverte de banques de données (datastores) VMware, <url> — URL de service VMware. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1304
 msgid "Discovery of VMware hypervisor datastores, <url> - VMware service URL, <uuid> - VMware hypervisor host name. Returns JSON"
-msgstr ""
+msgstr "Découverte des banques de données (datastores) de l’hyperviseur VMware, <url> — URL de service VMware. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1328
 msgid "Discovery of VMware hypervisors, <url> - VMware service URL. Returns JSON"
-msgstr ""
+msgstr "Découverte des hyperviseurs VMware, <url> — URL de service VMware. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1572
 msgid "Discovery of VMware virtual machine disk devices, <url> - VMware service URL, <uuid> - VMware virtual machine host name. Returns JSON"
-msgstr ""
+msgstr "Découverte des périphériques de stockage de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1584
 msgid "Discovery of VMware virtual machine file systems, <url> - VMware service URL, <uuid> - VMware virtual machine host name. Returns JSON"
-msgstr ""
+msgstr "Découverte des systèmes de fichiers de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1516
 msgid "Discovery of VMware virtual machine network interfaces, <url> - VMware service URL, <uuid> - VMware virtual machine host name. Returns JSON"
-msgstr ""
+msgstr "Découverte des interfaces réseau de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1460
 msgid "Discovery of VMware virtual machines, <url> - VMware service URL. Returns JSON"
-msgstr ""
+msgstr "Découverte des machines virtuelles VMware, <url> — URL de service VMware. Retourne un objet JSON"
 
 #: app/controllers/CControllerAuditLogList.php:215
 #: app/views/configuration.discovery.edit.php:136
 #: app/views/monitoring.discovery.view.php:49
-#: app/views/monitoring.widget.discovery.view.php:32
-#: include/actions.inc.php:52 include/forms.inc.php:889
+#: app/views/monitoring.widget.discovery.view.php:32 include/actions.inc.php:52
+#: include/forms.inc.php:889
 msgid "Discovery rule"
 msgstr "Règle de découverte"
 
 #: include/classes/api/services/CDiscoveryRule.php:60
 #, c-format
 msgid "Discovery rule \"%1$s\" already exists on \"%2$s\", inherited from another template."
-msgstr "La règle de découverte \"%1$s\" existe déjà sur \"%2$s\", héritée d'un autre modèle."
+msgstr "La règle de découverte « %1$s » existe déjà sur « %2$s », héritée d’un autre modèle."
 
 #: include/classes/api/services/CDiscoveryRule.php:61
 #, c-format
 msgid "Discovery rule \"%1$s\" already exists on \"%2$s\"."
-msgstr "La règle de découverte \"%1$s\" existe déjà sur \"%2$s\"."
+msgstr "La règle de découverte « %1$s » existe déjà sur « %2$s »."
 
 #: include/classes/api/services/CDRule.php:272
 #: include/classes/api/services/CDRule.php:285
@@ -5564,29 +5563,28 @@ msgstr "La règle de découverte \"%1$s\" existe déjà sur \"%2$s\"."
 #: include/classes/api/services/CDRule.php:437
 #, c-format
 msgid "Discovery rule \"%1$s\" already exists."
-msgstr "La règle de découverte \"%1$s\" existe déjà."
+msgstr "La règle de découverte « %1$s » existe déjà."
 
 #: include/classes/api/services/CDiscoveryRule.php:2161
 #, c-format
 msgid "Discovery rule \"%1$s\" cannot be copied without its master item."
-msgstr "La règle de découverte \"%1$s\" ne peut pas être copiée sans son élément principal."
+msgstr "La règle de découverte « %1$s » ne peut pas être copiée sans son élément principal."
 
 #: include/classes/api/services/CDRule.php:847
 #: include/classes/api/services/CDRule.php:864
 #, c-format
 msgid "Discovery rule \"%1$s\" is used in \"%2$s\" action."
-msgstr "La règle de découverte \"%1$s\" est utilisée dans l'action \"%2$s\"."
+msgstr "La règle de découverte « %1$s » est utilisée dans l’action « %2$s »."
 
 #: app/controllers/CControllerDiscoveryCreate.php:85 host_discovery.php:715
 msgid "Discovery rule created"
 msgstr "Règle de découverte créée"
 
 #: app/controllers/CControllerDiscoveryDelete.php:66 host_discovery.php:410
-#, fuzzy
 msgid "Discovery rule deleted"
 msgid_plural "Discovery rules deleted"
 msgstr[0] "Règle de découverte supprimée"
-msgstr[1] "Règle de découverte supprimée"
+msgstr[1] "Règles de découverte supprimées"
 
 #: app/controllers/CControllerDiscoveryDisable.php:71 host_discovery.php:745
 msgid "Discovery rule disabled"
@@ -5626,7 +5624,7 @@ msgstr "État de la découverte"
 
 #: include/classes/data/CItemData.php:1152
 msgid "Disk read statistics. Returns integer with type in sectors, operations, bytes; float with type in sps, ops, bps"
-msgstr "Statistiques de lecture du disque. Retourne un entier avec le type parmi sectors, operations, bytes ; un flottant avec le type parmi sps, ops, bps"
+msgstr "Statistiques de lecture du disque. Retourne un entier avec le type parmi secteurs, operations ou octets ; un flottant avec le type parmi sps, ops, bps"
 
 #: include/classes/data/CItemData.php:1228
 msgid "Disk space in bytes or in percentage from total. Returns integer for bytes; float for percentage"
@@ -5634,7 +5632,7 @@ msgstr "Espace disque en octets ou en pourcentage du total. Retourne un entier p
 
 #: include/classes/data/CItemData.php:1156
 msgid "Disk write statistics. Returns integer with type in sectors, operations, bytes; float with type in sps, ops, bps"
-msgstr "Statistiques d'écriture du disque. Retourne un entier avec le type parmi sectors, operations, bytes ; un flottant avec le type parmi sps, ops, bps"
+msgstr "Statistiques d’écriture du disque. Retourne un entier avec le type parmi secteurs, operations ou octets ; un flottant avec le type parmi sps, ops, bps"
 
 #: app/views/administration.trigdisplay.edit.php:89
 msgid "Display OK triggers for"
@@ -5669,29 +5667,27 @@ msgstr "Affichage de %1$s à %2$s parmi %3$s trouvés"
 
 #: include/classes/widgets/views/widget.svggraph.form.view.php:292
 msgid "Displaying options"
-msgstr "Options d'affichage"
+msgstr "Options d’affichage"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:780
 msgid "Division denominator"
-msgstr ""
+msgstr "Dénominateur"
 
-#: app/views/popup.lldoperation.php:190
-#: app/views/popup.massupdate.item.php:294
+#: app/views/popup.lldoperation.php:190 app/views/popup.massupdate.item.php:294
 #: include/views/configuration.item.edit.php:823
 #: include/views/configuration.item.prototype.edit.php:767
 msgid "Do not keep history"
-msgstr ""
+msgstr "Ne pas conserver l’historique"
 
-#: app/views/popup.lldoperation.php:211
-#: app/views/popup.massupdate.item.php:310
+#: app/views/popup.lldoperation.php:211 app/views/popup.massupdate.item.php:310
 #: include/views/configuration.item.edit.php:863
 #: include/views/configuration.item.prototype.edit.php:782
 msgid "Do not keep trends"
-msgstr ""
+msgstr "Ne pas conserver les tendances"
 
 #: jsLoader.php:224 jsLoader.php:360
 msgid "Do you wish to replace the conditional expression?"
-msgstr "Souhaitez-vous remplacer l'expression conditionnelle ?"
+msgstr "Souhaitez‐vous remplacer l’expression conditionnelle ?"
 
 #: app/partials/monitoring.host.filter.php:51
 #: app/partials/monitoring.host.filter.php:200
@@ -5702,7 +5698,7 @@ msgstr "Souhaitez-vous remplacer l'expression conditionnelle ?"
 #: include/classes/widgets/CWidgetHelper.php:509
 #: include/classes/widgets/CWidgetHelper.php:575
 msgid "Does not contain"
-msgstr ""
+msgstr "Ne contient pas"
 
 #: app/partials/monitoring.host.filter.php:50
 #: app/partials/monitoring.host.filter.php:199
@@ -5713,7 +5709,7 @@ msgstr ""
 #: include/classes/widgets/CWidgetHelper.php:508
 #: include/classes/widgets/CWidgetHelper.php:574
 msgid "Does not equal"
-msgstr ""
+msgstr "Est différent de"
 
 #: app/partials/monitoring.host.filter.php:49
 #: app/partials/monitoring.host.filter.php:198
@@ -5724,11 +5720,11 @@ msgstr ""
 #: include/classes/widgets/CWidgetHelper.php:507
 #: include/classes/widgets/CWidgetHelper.php:573
 msgid "Does not exist"
-msgstr ""
+msgstr "N’existe pas"
 
 #: include/items.inc.php:1875
 msgid "Does not match regular expression"
-msgstr "Ne correspond pas à l'expression régulière"
+msgstr "Ne correspond pas à l’expression rationnelle"
 
 #: include/graphs.inc.php:61 include/views/js/monitoring.sysmaps.js.php:782
 #: include/views/js/monitoring.sysmaps.js.php:872
@@ -5747,7 +5743,7 @@ msgstr "Arrêté"
 
 #: jsLoader.php:198 jsLoader.php:212
 msgid "Download image"
-msgstr ""
+msgstr "Télécharger l’image"
 
 #: include/classes/setup/CSetupWizard.php:856
 msgid "Download the configuration file"
@@ -5757,7 +5753,7 @@ msgstr "Télécharger le fichier de configuration"
 #: app/views/popup.service.time.edit.php:46
 #: include/classes/screens/CScreenDiscovery.php:120
 msgid "Downtime"
-msgstr "Temps d'arrêt"
+msgstr "Temps d’arrêt"
 
 #: include/classes/widgets/CWidgetHelper.php:769
 #: include/classes/widgets/CWidgetHelper.php:813
@@ -5776,41 +5772,41 @@ msgstr "Style de dessin"
 #: include/classes/api/services/CMap.php:1076
 #, c-format
 msgid "Duplicate \"name\" value \"%1$s\" for map."
-msgstr "Valeur \"name\" \"%1$s\" en doublon pour la carte."
+msgstr "Valeur « name » « %1$s » en doublon pour la carte."
 
 #: include/classes/api/services/CMap.php:818
 #: include/classes/api/services/CMap.php:1285
 #, c-format
 msgid "Duplicate \"usrgrpid\" \"%1$s\" in user groups for map \"%2$s\"."
-msgstr ""
+msgstr "Il existe un doublon de « usrgrpid » valant « %1$s » dans les groupes d’utilisateurs de la carte « %2$s »."
 
 #: include/classes/api/services/CTrigger.php:1142
 #, c-format
 msgid "Duplicate dependencies in trigger \"%1$s\"."
-msgstr "Dépendances en doublon dans le déclencheur \"%1$s\"."
+msgstr "Dépendances en doublon dans le déclencheur « %1$s »."
 
 #: include/classes/api/services/CTriggerPrototype.php:974
 #, c-format
 msgid "Duplicate dependencies in trigger prototype \"%1$s\"."
-msgstr "Dépendances en doublon dans le prototype de déclencheur \"%1$s\"."
+msgstr "Dépendances en doublon dans le prototype de déclencheur « %1$s »."
 
 #: include/classes/api/services/CHost.php:1932
 #: include/classes/api/services/CHost.php:2229
 #, c-format
 msgid "Duplicate host. Host with the same host name \"%1$s\" already exists in data."
-msgstr ""
+msgstr "Hôte en doublon. Un hôte existe déjà avec le même nom d’hôte « %1$s » dans les données."
 
 #: include/classes/api/services/CHost.php:1939
 #: include/classes/api/services/CHost.php:2249
 #, c-format
 msgid "Duplicate host. Host with the same visible name \"%1$s\" already exists in data."
-msgstr ""
+msgstr "Hôte en doublon. Un hôte existe déjà avec le même nom d’affichage « %1$s » dans les données."
 
 #: include/classes/api/services/CMap.php:743
 #: include/classes/api/services/CMap.php:1211
 #, c-format
 msgid "Duplicate userid \"%1$s\" in users for map \"%2$s\"."
-msgstr "Identifiant d'utilisateur \"%1$s\" en doublon dans les utilisateurs pour la carte \"%2$s\"."
+msgstr "Identifiant d’utilisateur « %1$s » en doublon dans les utilisateurs pour la carte « %2$s »."
 
 #: app/views/hintbox.eventlist.php:75
 #: app/views/monitoring.widget.problems.view.php:65 include/blocks.inc.php:580
@@ -5837,11 +5833,11 @@ msgstr "Éléments dynamiques"
 
 #: jsLoader.php:283
 msgid "Each URL should have a unique name. Please make sure there is only one URL named"
-msgstr "Chaque URL doit avoir un nom unique. Veuillez vous assurer qu'il n'existe qu'un URL du même nom"
+msgstr "Chaque URL doit avoir un nom unique. Veuillez vous assurer qu’il n’existe qu’un URL du même nom"
 
 #: include/classes/widgets/CWidgetHelper.php:1168
 msgid "Each item"
-msgstr ""
+msgstr "Chaque élément"
 
 #: app/partials/monitoring.service.list.edit.php:127
 #: app/views/administration.user.edit.php:355
@@ -5877,11 +5873,11 @@ msgstr "Éditer la carte"
 
 #: app/controllers/CControllerPopupLldOperation.php:351
 msgid "Edit operation"
-msgstr ""
+msgstr "Modifier l’opération"
 
 #: jsLoader.php:207
 msgid "Edit tree element"
-msgstr "Éditer un élément d'arborescence"
+msgstr "Éditer un élément d’arborescence"
 
 #: jsLoader.php:361
 msgid "Edit trigger"
@@ -5899,14 +5895,14 @@ msgstr "Valeur effective"
 #: include/classes/api/managers/CHistoryManager.php:1385
 #, c-format
 msgid "Elasticsearch URL is not set for type: %1$s."
-msgstr ""
+msgstr "L’URL Elasticsearch n’est pas définie pour le type : %1$s."
 
 #: include/classes/helpers/CElasticsearchHelper.php:86
 #: include/classes/helpers/CElasticsearchHelper.php:185
 #: include/classes/helpers/CElasticsearchHelper.php:195
 #, c-format
 msgid "Elasticsearch error: %1$s."
-msgstr "Erreur Elasticsearch : %1$s."
+msgstr "Erreur Elasticsearch : %1$s."
 
 #: include/views/monitoring.sysmap.edit.php:278
 msgid "Element"
@@ -5914,7 +5910,7 @@ msgstr "Élément"
 
 #: include/maps.inc.php:47 include/views/js/monitoring.sysmaps.js.php:737
 msgid "Element name"
-msgstr "Nom de l'élément"
+msgstr "Nom de l’élément"
 
 #: include/views/js/monitoring.sysmaps.js.php:361
 #: include/views/js/monitoring.sysmaps.js.php:515
@@ -5932,26 +5928,26 @@ msgstr "Vide"
 #: include/classes/api/services/CHttpTest.php:1029
 #, c-format
 msgid "Empty SSL certificate file for web scenario \"%1$s\"."
-msgstr "Certificat SSL vide pour le scénario web \"%1$s\"."
+msgstr "Certificat SSL vide pour le scénario Web « %1$s »."
 
 #: include/classes/api/services/CHttpTest.php:1023
 #, c-format
 msgid "Empty SSL key file for web scenario \"%1$s\"."
-msgstr "Clé SSL vide pour le scénario web \"%1$s\"."
+msgstr "Clef SSL vide pour le scénario Web « %1$s »."
 
 #: include/classes/validators/CColorValidator.php:33
 msgid "Empty color."
-msgstr ""
+msgstr "Couleur vide."
 
 #: include/classes/api/services/CDiscoveryRule.php:1836
 #, c-format
 msgid "Empty filter condition formula ID for discovery rule \"%1$s\"."
-msgstr "Identifiant de formule de condition vide pour la règle de découverte \"%1$s\"."
+msgstr "Identifiant de formule de condition vide pour la règle de découverte « %1$s »."
 
 #: include/classes/api/services/CDiscoveryRule.php:1828
 #, c-format
 msgid "Empty filter condition macro for discovery rule \"%1$s\"."
-msgstr "Macro de condition vide pour l'action \"%1$s\"."
+msgstr "Macro de condition vide pour l’action « %1$s »."
 
 #: include/classes/api/services/CDRule.php:194
 #: include/classes/api/services/CDRule.php:320
@@ -5969,7 +5965,7 @@ msgstr "Macro de condition vide pour l'action \"%1$s\"."
 #: include/classes/api/services/CTemplate.php:707
 #: include/classes/api/services/CTrigger.php:798
 msgid "Empty input parameter."
-msgstr "Paramètre d'entrée vide."
+msgstr "Paramètre d’entrée vide."
 
 #: include/classes/api/services/CMap.php:1042
 msgid "Empty map ID."
@@ -5994,23 +5990,23 @@ msgstr "Activer"
 
 #: app/views/administration.authentication.edit.php:110
 msgid "Enable HTTP authentication"
-msgstr "Activer l'authentification HTTP"
+msgstr "Activer l’authentification HTTP"
 
 #: app/views/administration.authentication.edit.php:156
 msgid "Enable LDAP authentication"
-msgstr "Activer l'authentification LDAP"
+msgstr "Activer l’authentification LDAP"
 
 #: app/views/administration.authentication.edit.php:215
 msgid "Enable SAML authentication"
-msgstr ""
+msgstr "Activer l’authentification SAML"
 
 #: app/views/administration.audit.settings.edit.php:43
 msgid "Enable audit logging"
-msgstr ""
+msgstr "Activer la journalisation pour l’audit"
 
 #: app/views/administration.housekeeping.edit.php:160
 msgid "Enable compression"
-msgstr ""
+msgstr "Activer la compression"
 
 #: app/views/administration.script.edit.php:249
 msgid "Enable confirmation"
@@ -6018,11 +6014,11 @@ msgstr "Activer confirmation"
 
 #: app/views/administration.usergroup.list.php:225
 msgid "Enable debug mode"
-msgstr "Activer le mode debug"
+msgstr "Activer le mode débogage"
 
 #: app/views/administration.usergroup.list.php:225
 msgid "Enable debug mode in selected groups?"
-msgstr "Activer le mode debug des groupes sélectionnés ?"
+msgstr "Activer le mode débogage des groupes sélectionnés ?"
 
 #: include/actions.inc.php:694 include/actions.inc.php:1031
 msgid "Enable host"
@@ -6030,7 +6026,7 @@ msgstr "Activer hôte"
 
 #: app/views/configuration.host.list.php:283
 msgid "Enable host?"
-msgstr "Activer l'hôte ?"
+msgstr "Activer l’hôte ?"
 
 #: app/views/administration.proxy.list.php:183
 #: include/views/configuration.hostgroups.list.php:200
@@ -6039,7 +6035,7 @@ msgstr "Activer les hôtes"
 
 #: app/views/administration.proxy.list.php:184
 msgid "Enable hosts monitored by selected proxies?"
-msgstr "Activer les hôtes surveillés par les proxys sélectionnés ?"
+msgstr "Activer les hôtes surveillés par les proxys sélectionnés ?"
 
 #: app/views/administration.audit.settings.edit.php:47
 #: app/views/administration.housekeeping.edit.php:43
@@ -6053,53 +6049,53 @@ msgstr "Activer le nettoyage interne"
 #: app/views/administration.token.list.php:199
 #: app/views/administration.user.token.list.php:151
 msgid "Enable selected API tokens?"
-msgstr ""
+msgstr "Activer les jetons d’API sélectionnés ?"
 
 #: include/views/configuration.action.list.php:163
 msgid "Enable selected actions?"
-msgstr "Activer les actions sélectionnées ?"
+msgstr "Activer les actions sélectionnées ?"
 
 #: app/views/configuration.correlation.list.php:147
 msgid "Enable selected correlations?"
-msgstr "Activer les corrélations sélectionnées ?"
+msgstr "Activer les corrélations sélectionnées ?"
 
 #: app/views/configuration.discovery.list.php:120
 #: include/views/configuration.host.discovery.list.php:324
 msgid "Enable selected discovery rules?"
-msgstr "Activer les règles de découverte sélectionnées ?"
+msgstr "Activer les règles de découverte sélectionnées ?"
 
 #: app/views/administration.usergroup.list.php:213
 msgid "Enable selected groups?"
-msgstr "Activer les groupes sélectionnés ?"
+msgstr "Activer les groupes sélectionnés ?"
 
 #: app/views/configuration.host.list.php:497
 #: include/views/configuration.hostgroups.list.php:200
 msgid "Enable selected hosts?"
-msgstr "Activer les hôtes sélectionnés ?"
+msgstr "Activer les hôtes sélectionnés ?"
 
 #: include/views/configuration.item.list.php:285
 msgid "Enable selected items?"
-msgstr "Activer les éléments sélectionnés ?"
+msgstr "Activer les éléments sélectionnés ?"
 
 #: app/views/administration.mediatype.list.php:167
 msgid "Enable selected media types?"
-msgstr "Activer les types de média sélectionnés ?"
+msgstr "Activer les types de média sélectionnés ?"
 
 #: app/views/administration.module.list.php:123
 msgid "Enable selected modules?"
-msgstr ""
+msgstr "Activer les modules sélectionnés ?"
 
 #: app/views/reports.scheduledreport.list.php:85
 msgid "Enable selected scheduled reports?"
-msgstr ""
+msgstr "Activer les rapports planifiés sélectionnés ?"
 
 #: include/views/configuration.triggers.list.php:341
 msgid "Enable selected triggers?"
-msgstr "Activer les déclencheurs sélectionnés ?"
+msgstr "Activer les déclencheurs sélectionnés ?"
 
 #: include/views/configuration.httpconf.list.php:210
 msgid "Enable selected web scenarios?"
-msgstr "Activer les scénarios web sélectionnés ?"
+msgstr "Activer les scénarios Web sélectionnés ?"
 
 #: app/views/popup.massupdate.item.php:376
 #: include/views/configuration.host.discovery.edit.php:689
@@ -6154,7 +6150,7 @@ msgstr "Activer les trap"
 #: include/html.inc.php:280 include/httptest.inc.php:47
 #: include/items.inc.php:138 include/items.inc.php:141
 #: include/items.inc.php:182 include/triggers.inc.php:999
-#: include/triggers.inc.php:1868
+#: include/triggers.inc.php:1870
 #: include/views/configuration.action.edit.php:147
 #: include/views/configuration.action.list.php:76
 #: include/views/configuration.action.list.php:137
@@ -6168,7 +6164,7 @@ msgstr "Activé"
 
 #: app/views/administration.authentication.edit.php:299
 msgid "Encrypt"
-msgstr ""
+msgstr "Chiffrer"
 
 #: app/partials/configuration.host.edit.html.php:527
 #: app/views/administration.proxy.edit.php:143
@@ -6180,15 +6176,15 @@ msgstr "Chiffrement"
 
 #: app/views/administration.autoreg.edit.php:43
 msgid "Encryption level"
-msgstr ""
+msgstr "Niveau de chiffrement"
 
 #: app/partials/scheduledreport.formgrid.html.php:160
 msgid "End date"
-msgstr ""
+msgstr "Date de fin"
 
 #: app/views/popup.itemtestedit.view.php:296
 msgid "End of line sequence"
-msgstr ""
+msgstr "Séquence de fin de ligne"
 
 #: include/locales.inc.php:46
 msgid "English (en_US)"
@@ -6205,7 +6201,7 @@ msgstr "Anglais (en_US)"
 #: include/classes/api/services/CValueMap.php:451
 #, c-format
 msgid "Entry with UUID \"%1$s\" already exists."
-msgstr ""
+msgstr "Une entrée avec l’UUID « %1$s » existe déjà."
 
 #: app/partials/monitoring.host.filter.php:47
 #: app/partials/monitoring.host.filter.php:196
@@ -6233,26 +6229,26 @@ msgstr "Erreur"
 #: include/db.inc.php:518
 #, c-format
 msgid "Error in search request for table \"%1$s\"."
-msgstr "Erreur dans la requête de recherche dans la table \"%1$s\"."
+msgstr "Erreur dans la requête de recherche dans la table « %1$s »."
 
 #: include/func.inc.php:1642 jsLoader.php:226
 msgid "Error message"
-msgstr "Message d'erreur"
+msgstr "Message d’erreur"
 
 #: app/partials/administration.system.info.php:161
 #, c-format
 msgid "Error! Unable to start Zabbix server due to unsupported %1$s database server version. Must be at least (%2$s)"
-msgstr ""
+msgstr "Erreur ! Impossible de démarrer le serveur Zabbix en raison d’une version du serveur de base de données %1$s non prise en charge. La version minimale est %2$s"
 
 #: include/classes/screens/CScreenHttpTestDetails.php:111
 #: include/classes/screens/CScreenHttpTestDetails.php:182
 #, c-format
 msgid "Error: %1$s"
-msgstr "Erreur : %1$s"
+msgstr "Erreur : %1$s"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1045
 msgid "Evaluation period"
-msgstr ""
+msgstr "Période d’évaluation"
 
 #: include/events.inc.php:180
 msgid "Event"
@@ -6271,56 +6267,56 @@ msgstr "Événement acquitté"
 #: include/classes/helpers/CMenuHelper.php:198
 #: include/classes/helpers/CRoleHelper.php:366
 msgid "Event correlation"
-msgstr "Corrélation d'événement"
+msgstr "Corrélation d’événement"
 
 #: app/controllers/CControllerCorrelationEdit.php:114
 #: app/controllers/CControllerCorrelationList.php:128
 #: app/views/configuration.correlation.edit.php:29
 msgid "Event correlation rules"
-msgstr "Règles de corrélation d'événement"
+msgstr "Règles de corrélation d’événement"
 
 #: tr_events.php:29 tr_events.php:177 tr_events.php:196
 msgid "Event details"
-msgstr "Détails de l'événement"
+msgstr "Détails de l’événement"
 
 #: include/triggers.inc.php:989
 msgid "Event generation"
-msgstr "Génération d'événement"
+msgstr "Génération d’événement"
 
 #: include/actions.inc.php:363
 msgid "Event is acknowledged"
-msgstr ""
+msgstr "L’événement a été acquitté"
 
 #: include/actions.inc.php:363
 msgid "Event is not acknowledged"
-msgstr ""
+msgstr "L’événement n’a pas été acquitté"
 
 #: tr_events.php:188
 msgid "Event list [previous 20]"
-msgstr "Liste d'événements [20 précédents]"
+msgstr "Liste d’événements [20 précédents]"
 
 #: include/classes/data/CItemData.php:864
 msgid "Event log monitoring. Returns log"
-msgstr "Supervision du journal d'événements. Retourne un journal"
+msgstr "Supervision du journal d’événements. Retourne un journal"
 
 #: app/views/popup.triggerwizard.php:87
 #: include/views/configuration.trigger.prototype.edit.php:77
 #: include/views/configuration.triggers.edit.php:99
 msgid "Event name"
-msgstr ""
+msgstr "Nom de l’événement"
 
 #: include/classes/helpers/CCorrelationHelper.php:55
 msgid "Event tag pair"
-msgstr "Paire de tags d'événement"
+msgstr "Paire d’étiquettes d’événement"
 
 #: app/views/popup.condition.common.php:614 include/actions.inc.php:63
 msgid "Event type"
-msgstr "Type d'événement"
+msgstr "Type d’événement"
 
 #: app/controllers/CControllerPopupAcknowledgeCreate.php:168
 msgid "Event updated"
 msgid_plural "Events updated"
-msgstr[0] "Mettre à jour l'événement"
+msgstr[0] "Mettre à jour l’événement"
 msgstr[1] "Mettre à jour les événements"
 
 #: app/views/administration.housekeeping.edit.php:41
@@ -6337,16 +6333,16 @@ msgstr "Chaque semaine(s)"
 
 #: app/views/administration.geomaps.edit.php:33
 msgid "Example"
-msgstr ""
+msgstr "Exemple"
 
 #: app/views/administration.miscconfig.edit.php:36
 msgid "Example: https://localhost/zabbix/ui/"
-msgstr ""
+msgstr "Exemple : https://localhost/zabbix/ui/"
 
 #: app/partials/massupdate.macros.tab.php:103
 #: app/partials/massupdate.valuemaps.tab.php:77
 msgid "Except selected"
-msgstr ""
+msgstr "Sauf la sélection"
 
 #: app/partials/js/scheduledreport.subscription.js.php:170
 #: app/partials/js/scheduledreport.subscription.js.php:185
@@ -6360,7 +6356,7 @@ msgstr "Exclure"
 #: include/classes/widgets/forms/CWidgetFormProblems.php:57
 #: include/classes/widgets/forms/CWidgetFormWeb.php:42
 msgid "Exclude host groups"
-msgstr "Exclure un groupe d'hôte"
+msgstr "Exclure un groupe d’hôte"
 
 #: app/controllers/CControllerAuditLogList.php:197 jsLoader.php:217
 msgid "Execute"
@@ -6368,7 +6364,7 @@ msgstr "Exécuter"
 
 #: include/classes/data/CItemData.php:1608
 msgid "Execute WMI query and return the JSON document with all selected objects"
-msgstr ""
+msgstr "Exécute la requête WMI et retourne les données JSON contenant tous les objets sélectionnés"
 
 #: include/classes/data/CItemData.php:1604
 msgid "Execute WMI query and return the first selected object. Returns integer, float, string or text (depending on the request)"
@@ -6379,7 +6375,7 @@ msgstr "Exécute une requête WMI et retourne le premier objet sélectionné. Re
 #: include/views/configuration.item.edit.php:1018
 #: include/views/configuration.item.list.php:301
 msgid "Execute now"
-msgstr ""
+msgstr "Exécuter maintenant"
 
 #: app/views/administration.script.edit.php:121
 #: app/views/administration.script.list.php:78
@@ -6388,7 +6384,7 @@ msgstr "Exécuter sur"
 
 #: include/classes/helpers/CRoleHelper.php:422
 msgid "Execute scripts"
-msgstr ""
+msgstr "Exécuter les scripts"
 
 #: include/actions.inc.php:2127
 #: include/views/administration.auditacts.list.php:78
@@ -6404,7 +6400,7 @@ msgstr "Script exécuté"
 
 #: jsLoader.php:218
 msgid "Execution confirmation"
-msgstr "Confirmation d'exécution"
+msgstr "Confirmation d’exécution"
 
 #: app/partials/monitoring.host.filter.php:46
 #: app/partials/monitoring.host.filter.php:195
@@ -6415,7 +6411,7 @@ msgstr "Confirmation d'exécution"
 #: include/classes/widgets/CWidgetHelper.php:504
 #: include/classes/widgets/CWidgetHelper.php:570
 msgid "Exists"
-msgstr ""
+msgstr "Existe"
 
 #: include/classes/html/CCollapsibleUiWidget.php:60
 #: include/classes/widgets/CWidgetHelper.php:997 jsLoader.php:307
@@ -6430,7 +6426,7 @@ msgstr "Substituer les macros"
 #: app/partials/layout.htmlpage.aside.php:42
 #: app/partials/layout.htmlpage.aside.php:44
 msgid "Expand sidebar"
-msgstr ""
+msgstr "Agrandir la barre latérale"
 
 #: include/views/monitoring.sysmap.edit.php:152
 msgid "Expand single problem"
@@ -6439,7 +6435,7 @@ msgstr "Détailler problème unique"
 #: app/partials/scheduledreport.table.html.php:92
 #: app/views/reports.scheduledreport.list.php:63
 msgid "Expired"
-msgstr ""
+msgstr "Expiré"
 
 #: include/views/configuration.maintenance.list.php:68
 #: include/views/configuration.maintenance.list.php:98
@@ -6450,7 +6446,7 @@ msgstr "Expiré"
 #: app/partials/scheduledreport.table.html.php:95
 #, c-format
 msgid "Expired on %1$s."
-msgstr ""
+msgstr "Expire le %1$s."
 
 #: app/views/administration.token.edit.php:81
 #: app/views/administration.token.list.php:132
@@ -6459,12 +6455,12 @@ msgstr ""
 #: app/views/administration.user.token.list.php:93
 #: app/views/administration.user.token.view.php:48
 msgid "Expires at"
-msgstr ""
+msgstr "Expire le"
 
 #: app/views/administration.token.list.php:61
 #: app/views/administration.user.token.list.php:44
 msgid "Expires in less than"
-msgstr ""
+msgstr "Expire dans moins de"
 
 #: app/views/popup.generic.php:503 include/graphs.inc.php:27
 msgid "Exploded"
@@ -6476,7 +6472,7 @@ msgstr "Exporter"
 
 #: app/controllers/CControllerExport.php:113
 msgid "Export failed"
-msgstr ""
+msgstr "L’exportation a échoué"
 
 #: app/views/monitoring.problem.view.php:99
 msgid "Export to CSV"
@@ -6507,28 +6503,28 @@ msgstr "Expression"
 #: app/controllers/CControllerRegExTest.php:86
 #: include/classes/triggers/CTextTriggerConstructor.php:64
 msgid "Expression cannot be empty"
-msgstr "L'expression ne peut pas être vide"
+msgstr "L’expression ne peut pas être vide"
 
 #: include/views/configuration.trigger.prototype.edit.php:176
 #: include/views/configuration.trigger.prototype.edit.php:369
 #: include/views/configuration.triggers.edit.php:198
 #: include/views/configuration.triggers.edit.php:393
 msgid "Expression constructor"
-msgstr "Constructeur d'expression"
+msgstr "Constructeur d’expression"
 
 #: include/forms.inc.php:1867 include/forms.inc.php:1874
 #: include/forms.inc.php:1884
 msgid "Expression syntax error."
-msgstr "Erreur de syntaxe dans l'expression."
+msgstr "Erreur de syntaxe dans l’expression."
 
 #: app/views/administration.regex.edit.php:47
 #: app/views/administration.regex.edit.php:128
 msgid "Expression type"
-msgstr "Type d'expression"
+msgstr "Type d’expression"
 
 #: app/views/popup.testtriggerexpr.php:29
 msgid "Expression variable elements"
-msgstr ""
+msgstr "Éléments variables d’expression"
 
 #: app/views/administration.regex.edit.php:112
 #: app/views/administration.regex.edit.php:139
@@ -6562,7 +6558,7 @@ msgstr "Échec"
 #: app/partials/administration.system.info.php:182
 #, c-format
 msgid "Fail-over delay: %1$s"
-msgstr ""
+msgstr "Délai avant basculement  : %1$s"
 
 #: app/views/monitoring.widget.web.view.php:30 include/actions.inc.php:2139
 #: include/views/administration.auditacts.list.php:88
@@ -6571,7 +6567,7 @@ msgstr "Échoué"
 
 #: app/controllers/CControllerAuditLogList.php:192
 msgid "Failed login"
-msgstr ""
+msgstr "Échec"
 
 #: app/controllers/CControllerDashboardUpdate.php:146
 #: app/controllers/CControllerTemplateDashboardUpdate.php:140
@@ -6583,15 +6579,15 @@ msgstr "Impossible de créer le tableau de bord"
 #: include/views/js/common.item.edit.js.php:200
 #: include/views/js/configuration.httpconf.edit.js.php:102
 msgid "Failed to parse URL."
-msgstr "Échec d'analyse de l'URL."
+msgstr "Échec d’analyse de l’URL."
 
 #: jsLoader.php:135
 msgid "Failed to paste dashboard page."
-msgstr ""
+msgstr "Impossible de coller la page de tableau de bord."
 
 #: jsLoader.php:136
 msgid "Failed to paste widget."
-msgstr ""
+msgstr "Impossible de coller le widget."
 
 #: app/controllers/CControllerDashboardUpdate.php:141
 #: app/controllers/CControllerTemplateDashboardUpdate.php:135
@@ -6602,11 +6598,11 @@ msgstr "Impossible de mettre à jour le tableau de bord"
 
 #: jsLoader.php:137
 msgid "Failed to update dashboard page properties."
-msgstr ""
+msgstr "Impossible de mettre à jour les propriétés de la page du tableau de bord."
 
 #: jsLoader.php:138
 msgid "Failed to update dashboard properties."
-msgstr ""
+msgstr "Impossible de mettre à jour les propriétés du tableau de bord."
 
 #: include/classes/api/services/CTemplate.php:625
 msgid "Failed to update template."
@@ -6614,31 +6610,31 @@ msgstr "Échec lors de la mise à jour du modèle."
 
 #: jsLoader.php:139
 msgid "Failed to update widget properties."
-msgstr ""
+msgstr "Impossible de mettre à jour les propriétés du widget."
 
 #: include/items.inc.php:37
 msgid "Failure Audit"
-msgstr "Audit d'échec"
+msgstr "Audit d’échec"
 
 #: app/views/system.warning.php:26 app/views/system.warning.php:38
 msgid "Fatal error, please report to the Zabbix team"
-msgstr "Erreur fatale, veuillez en informer l'équipe Zabbix"
+msgstr "Erreur fatale, veuillez en informer l’équipe Zabbix"
 
 #: include/classes/widgets/CWidgetConfig.php:49
 msgid "Favorite graphs"
-msgstr ""
+msgstr "Graphiques préférés"
 
 #: include/classes/widgets/CWidgetConfig.php:50
 msgid "Favorite maps"
-msgstr ""
+msgstr "Cartes préférées"
 
 #: include/func.inc.php:221
 msgid "Feb"
-msgstr "Fév"
+msgstr "févr."
 
 #: include/func.inc.php:101 include/func.inc.php:238 jsLoader.php:232
 msgid "February"
-msgstr "Février"
+msgstr "février"
 
 #: hostinventoriesoverview.php:85 include/views/inventory.host.list.php:63
 msgid "Field"
@@ -6647,7 +6643,7 @@ msgstr "Champ"
 #: include/classes/db/DB.php:379
 #, c-format
 msgid "Field \"%1$s\" cannot be set to NULL."
-msgstr "Le champ \"%1$s\" ne peut pas être configuré à NULL."
+msgstr "Le champ « %1$s » ne peut pas être configuré à NULL."
 
 #: app/controllers/CControllerActionOperationValidate.php:50
 #: app/controllers/CControllerDashboardPropertiesCheck.php:40
@@ -6660,16 +6656,15 @@ msgstr "Le champ \"%1$s\" ne peut pas être configuré à NULL."
 #: include/classes/api/services/CDRule.php:538
 #: include/classes/api/services/CHost.php:892
 #: include/classes/api/services/CTemplate.php:950
-#: include/classes/validators/CNewValidator.php:86
-#: include/validate.inc.php:286
+#: include/classes/validators/CNewValidator.php:86 include/validate.inc.php:286
 #, c-format
 msgid "Field \"%1$s\" is mandatory."
-msgstr "Le champ \"%1$s\" est obligatoire."
+msgstr "Le champ « %1$s » est obligatoire."
 
 #: include/classes/api/services/CMap.php:793
 #, c-format
 msgid "Field \"%1$s\" is missing a value for map \"%2$s\"."
-msgstr "La valeur pour le champ \"%1$s\" de la carte \"%2$s\" est manquante."
+msgstr "La valeur pour le champ « %1$s » de la carte « %2$s » est manquante."
 
 #: include/validate.inc.php:175 include/validate.inc.php:183
 #: include/validate.inc.php:189 include/validate.inc.php:193
@@ -6677,34 +6672,34 @@ msgstr "La valeur pour le champ \"%1$s\" de la carte \"%2$s\" est manquante."
 #: include/validate.inc.php:229
 #, c-format
 msgid "Field \"%1$s\" is not correct: %2$s"
-msgstr "Le champ \"%1$s\" n'est pas correct : %2$s"
+msgstr "Le champ « %1$s » n’est pas correct : %2$s"
 
 #: include/validate.inc.php:167
 #, c-format
 msgid "Field \"%1$s\" is not integer."
-msgstr "Le champ \"%1$s\" n'est pas un entier."
+msgstr "Le champ « %1$s » n’est pas un entier."
 
 #: include/validate.inc.php:202
 #, c-format
 msgid "Field \"%1$s\" is not string."
-msgstr "Le champ \"%1$s\" n'est pas une chaîne."
+msgstr "Le champ « %1$s » n’est pas une chaîne."
 
 #: include/validate.inc.php:298
 #, c-format
 msgid "Field \"%1$s\" must be missing."
-msgstr "Le champ \"%1$s\" doit être manquant."
+msgstr "Le champ « %1$s » doit être manquant."
 
 #: include/classes/api/services/CTemplate.php:492
 msgid "Field \"host\" is mandatory."
-msgstr "Le champ \"hôte\" est obligatoire."
+msgstr "Le champ « hôte » est obligatoire."
 
 #: include/classes/data/CItemData.php:1172
 msgid "File checksum, calculated by the UNIX cksum algorithm. Returns integer for crc32 (default) and string for md5, sha256"
-msgstr ""
+msgstr "Somme de contrôle du fichier, calculée avec la commande UNIX cksum. Retourne un entier avec l’algorithme par défaut CRC32, et une chaîne de caractères avec les algorithmes MD5 et SHA256"
 
 #: include/classes/import/readers/CYamlImportReader.php:52
 msgid "File is empty"
-msgstr ""
+msgstr "Le fichier est vide"
 
 #: include/classes/helpers/CUploadFile.php:156
 #, c-format
@@ -6713,11 +6708,11 @@ msgstr "Fichier trop volumineux, la taille maximale de téléchargement est de %
 
 #: include/classes/data/CItemData.php:1192
 msgid "File owner information. Returns string"
-msgstr ""
+msgstr "Informations sur le propriétaire du fichier. Renvoie une chaîne"
 
 #: include/classes/data/CItemData.php:1208
 msgid "File size in bytes (default) or in newlines. Returns integer"
-msgstr ""
+msgstr "Taille du fichier en octets (par défaut) ou en nombre de lignes. Renvoie un entier"
 
 #: include/classes/data/CItemData.php:1212
 msgid "File time information. Returns integer (Unix timestamp)"
@@ -6785,11 +6780,11 @@ msgstr "Filtre"
 
 #: app/controllers/CControllerPopupTabFilterEdit.php:117
 msgid "Filter properties"
-msgstr ""
+msgstr "Propriétés du filtre"
 
 #: app/controllers/CControllerServiceListGeneral.php:181
 msgid "Filter results"
-msgstr ""
+msgstr "Filtrer les résultats"
 
 #: app/views/popup.lldoverride.php:183
 #: include/views/configuration.host.discovery.edit.php:822
@@ -6799,7 +6794,7 @@ msgstr "Filtres"
 
 #: include/classes/data/CItemData.php:1204
 msgid "Find string in a file. Returns 0 - match not found; 1 - found"
-msgstr "Trouver une chaîne dans un fichier. Retourne 0 - correspondance non trouvée ; 1 - trouvée"
+msgstr "Trouver une chaîne dans un fichier. Retourne 0 — correspondance non trouvée ; 1 — trouvée"
 
 #: include/classes/data/CItemData.php:1200
 msgid "Find string in a file. Returns the line containing the matched string, or as specified by the optional output parameter"
@@ -6807,7 +6802,7 @@ msgstr "Trouver une chaîne dans un fichier. Retourne la ligne contenant la cha�
 
 #: include/classes/data/CItemData.php:1600
 msgid "Find string on a web page. Returns the matched string, or as specified by the optional output parameter"
-msgstr "Trouver une chaîne sur une page web. Retourne la chaîne correspondante, ou selon ce qui est spécifié dans le paramètre optionnel output"
+msgstr "Trouver une chaîne sur une page Web. Retourne la chaîne correspondante, ou selon ce qui est spécifié dans le paramètre optionnel output"
 
 #: include/classes/setup/CSetupWizard.php:334
 msgid "Finish"
@@ -6838,11 +6833,10 @@ msgstr "Fixe"
 
 #: include/classes/helpers/CServiceHelper.php:152
 msgid "Fixed status"
-msgstr ""
+msgstr "Statut fixe"
 
 #: app/views/js/popup.massupdate.tmpl.js.php:81
-#: app/views/popup.lldoperation.php:124
-#: app/views/popup.massupdate.item.php:234
+#: app/views/popup.lldoperation.php:124 app/views/popup.massupdate.item.php:234
 #: include/views/configuration.host.discovery.edit.php:637
 #: include/views/configuration.item.edit.php:742
 #: include/views/configuration.item.edit.php:749
@@ -6866,7 +6860,7 @@ msgstr "Police"
 
 #: include/views/js/monitoring.sysmaps.js.php:541
 msgid "Font color"
-msgstr ""
+msgstr "Couleur de la police"
 
 #: include/views/js/monitoring.sysmaps.js.php:377
 #: include/views/js/monitoring.sysmaps.js.php:535
@@ -6885,12 +6879,12 @@ msgstr "Formule"
 #: include/classes/api/services/CDiscoveryRule.php:1806
 #, c-format
 msgid "Formula missing for discovery rule \"%1$s\"."
-msgstr ""
+msgstr "Absence de formule pour la règle de découverte « %1$s »."
 
 #: include/classes/api/services/CDiscoveryRule.php:1597
 #, c-format
 msgid "Formula missing for override \"%1$s\"."
-msgstr ""
+msgstr "Absence de formule pour le remplacement « %1$s »."
 
 #: include/locales.inc.php:54
 msgid "French (fr_FR)"
@@ -6916,18 +6910,18 @@ msgstr "De"
 
 #: app/views/administration.miscconfig.edit.php:33
 msgid "Frontend URL"
-msgstr ""
+msgstr "URL frontale"
 
 #: app/views/administration.usergroup.edit.php:78
 #: app/views/administration.usergroup.edit.php:86
 #: app/views/administration.usergroup.list.php:76
 #: app/views/administration.user.list.php:113
 msgid "Frontend access"
-msgstr "Accès à l'interface"
+msgstr "Accès à l’interface"
 
 #: app/views/administration.user.edit.php:655
 msgid "Frontend messaging"
-msgstr "Messages dans l'interface"
+msgstr "Messages dans l’interface"
 
 #: app/partials/monitoring.problem.filter.php:221
 #: include/classes/widgets/forms/CWidgetFormProblems.php:138
@@ -6968,23 +6962,23 @@ msgstr "Général"
 #: app/partials/scheduledreport.subscription.php:34
 #: app/views/popup.scheduledreport.subscription.php:100
 msgid "Generate report by"
-msgstr ""
+msgstr "Générer un rapport par"
 
 #: chart4.php:172
 #, c-format
 msgid "Generated in %1$s sec"
-msgstr ""
+msgstr "Généré en %1$s s"
 
 #: app/controllers/CControllerGeomapsEdit.php:75
 #: app/views/administration.geomaps.edit.php:120
 #: app/views/administration.geomaps.edit.php:127
 #: include/classes/helpers/CMenuHelper.php:244 include/html.inc.php:895
 msgid "Geographical maps"
-msgstr ""
+msgstr "Cartes géographiques"
 
 #: include/classes/widgets/CWidgetConfig.php:51
 msgid "Geomap"
-msgstr ""
+msgstr "Carte géographique"
 
 #: include/locales.inc.php:55
 msgid "Georgian (ka_GE)"
@@ -6996,30 +6990,30 @@ msgstr "Allemand (de_DE)"
 
 #: include/classes/data/CItemData.php:1592
 msgid "Get content of web page. Returns web page source as text"
-msgstr "Obtenir le contenu d'une page web. Retourne la source de la page web sous forme de texte"
+msgstr "Obtenir le contenu d’une page Web. Retourne la source de la page Web sous forme de texte"
 
 #: app/views/popup.itemtestedit.view.php:251
 msgid "Get value"
-msgstr ""
+msgstr "Récupérer la valeur"
 
 #: app/views/js/popup.itemtestedit.view.js.php:503
 #: app/views/popup.itemtestedit.view.php:432
 msgid "Get value and test"
-msgstr ""
+msgstr "Récupérer et tester la valeur"
 
 #: app/views/popup.itemtestedit.view.php:94
 msgid "Get value from host"
-msgstr ""
+msgstr "Récupérer la valeur depuis l’hôte"
 
 #: app/controllers/CControllerPopupTestTriggerExpr.php:48
 #: include/triggers.inc.php:1147
 msgid "Given expression is not a macro"
-msgstr "L'expression fournie n'est pas une macro"
+msgstr "L’expression fournie n’est pas une macro"
 
 #: include/classes/api/services/CIconMap.php:366
 #, c-format
 msgid "Global regular expression \"%1$s\" does not exist."
-msgstr "L'expression régulière globale \"%1$s\" n'existe pas."
+msgstr "L’expression rationnelle globale « %1$s » n’existe pas."
 
 #: app/partials/hostmacros.inherited.list.html.php:56
 msgid "Global value"
@@ -7037,36 +7031,36 @@ msgstr "Aller à"
 #: app/views/system.warning.php:31 include/func.inc.php:1527
 #, c-format
 msgid "Go to \"%1$s\""
-msgstr ""
+msgstr "Aller à « %1$s »"
 
 #: include/classes/helpers/CPagerHelper.php:188
 msgid "Go to first page"
-msgstr ""
+msgstr "Aller à la première page"
 
 #: include/classes/helpers/CPagerHelper.php:233
 #, c-format
 msgid "Go to last page, %1$s"
-msgstr ""
+msgstr "Aller à la dernière page, %1$s"
 
 #: include/classes/helpers/CPagerHelper.php:227
 #, c-format
 msgid "Go to next page, %1$s"
-msgstr ""
+msgstr "Aller à la page suivante, %1$s"
 
 #: include/classes/helpers/CPagerHelper.php:218
 #, c-format
 msgid "Go to page %1$s"
-msgstr ""
+msgstr "Aller à la page %1$s"
 
 #: include/classes/helpers/CPagerHelper.php:214
 #, c-format
 msgid "Go to page %1$s, current page"
-msgstr ""
+msgstr "Aller à la page %1$s, page actuelle"
 
 #: include/classes/helpers/CPagerHelper.php:199
 #, c-format
 msgid "Go to previous page, %1$s"
-msgstr ""
+msgstr "Aller à la page précédente, %1$s"
 
 #: include/httptest.inc.php:414
 msgid "Google Chrome"
@@ -7093,30 +7087,30 @@ msgstr "Graphique"
 #: include/classes/api/services/CGraphGeneral.php:1129
 #, c-format
 msgid "Graph \"%1$s\" already exists on \"%2$s\" (inherited from another template)."
-msgstr "Le graphique \"%1$s\" existe déjà sur \"%2$s\" (hérité d'un autre modèle)."
+msgstr "Le graphique « %1$s » existe déjà sur « %2$s » (hérité d’un autre modèle)."
 
 #: include/classes/api/services/CGraphGeneral.php:1177
 #: include/classes/api/services/CGraphGeneral.php:1187
 #, c-format
 msgid "Graph \"%1$s\" already exists on \"%2$s\" (items are not identical)."
-msgstr "Le graphique \"%1$s\" existe déjà sur \"%2$s\" (les éléments ne sont pas identiques)."
+msgstr "Le graphique « %1$s » existe déjà sur « %2$s » (les éléments ne sont pas identiques)."
 
 #: include/classes/api/services/CGraphGeneral.php:1135
 #, c-format
 msgid "Graph \"%1$s\" already exists on \"%2$s\" as a graph created from graph prototype."
-msgstr ""
+msgstr "Le graphique « %1$s » existe déjà dans « %2$s » en tant que graphique créé à partir du prototype de graphique."
 
 #: include/classes/api/services/CGraphGeneral.php:1038
 #: include/classes/api/services/CGraphGeneral.php:1246
 #: include/graphs.inc.php:444
 #, c-format
 msgid "Graph \"%1$s\" already exists on \"%2$s\"."
-msgstr "Le graphique \"%1$s\" existe déjà sur \"%2$s\"."
+msgstr "Le graphique « %1$s » existe déjà sur « %2$s »."
 
 #: include/classes/api/services/CGraph.php:36
 #, c-format
 msgid "Graph \"%1$s\" with templated items cannot contain items from other hosts."
-msgstr "Le graphique \"%1$s\" avec des éléments de modèles ne peut pas contenir d'éléments d'autres hôtes."
+msgstr "Le graphique « %1$s » avec des éléments de modèles ne peut pas contenir d’éléments d’autres hôtes."
 
 #: include/classes/widgets/CWidgetConfig.php:52
 msgid "Graph (classic)"
@@ -7149,17 +7143,17 @@ msgstr "Prototype de graphique"
 #: include/classes/api/services/CGraphPrototype.php:568
 #, c-format
 msgid "Graph prototype \"%1$s\" contains item prototypes from multiple discovery rules."
-msgstr "Le prototype de graphique \"%1$s\" contient les prototypes d'éléments de plusieurs règles de découverte."
+msgstr "Le prototype de graphique « %1$s » contient les prototypes d’éléments de plusieurs règles de découverte."
 
 #: include/classes/api/services/CGraphPrototype.php:574
 #, c-format
 msgid "Graph prototype \"%1$s\" must have at least one item prototype."
-msgstr "Le prototype de graphique \"%1$s\" doit avoir au moins un prototype d'élément."
+msgstr "Le prototype de graphique « %1$s » doit avoir au moins un prototype d’élément."
 
 #: include/classes/api/services/CGraphPrototype.php:36
 #, c-format
 msgid "Graph prototype \"%1$s\" with templated items cannot contain items from other hosts."
-msgstr "Le prototype de graphique \"%1$s\" avec des éléments de modèles ne peut pas contenir des éléments d'autres hôtes."
+msgstr "Le prototype de graphique « %1$s » avec des éléments de modèles ne peut pas contenir des éléments d’autres hôtes."
 
 #: graphs.php:230
 msgid "Graph prototype added"
@@ -7177,7 +7171,7 @@ msgstr "Prototype de graphique mis à jour"
 #: include/classes/api/services/CDashboardGeneral.php:535
 #, c-format
 msgid "Graph prototype with ID \"%1$s\" is not available."
-msgstr "Le prototype de graphique avec l'ID \"%1$s\" n'est pas disponible."
+msgstr "Le prototype de graphique avec l’ID « %1$s » n’est pas disponible."
 
 #: app/controllers/CControllerPopupGeneric.php:261
 #: app/controllers/CControllerPopupImportCompare.php:175
@@ -7212,12 +7206,12 @@ msgstr "Graphique mis à jour"
 #: include/classes/api/services/CDashboardGeneral.php:504
 #, c-format
 msgid "Graph with ID \"%1$s\" is not available."
-msgstr "Le graphique avec l'ID \"%1$s\" n'est pas disponible."
+msgstr "Le graphique avec l’ID « %1$s » n’est pas disponible."
 
 #: include/classes/api/services/CGraphGeneral.php:859
 #, c-format
 msgid "Graph with name \"%1$s\" already exists in graphs or graph prototypes."
-msgstr "Un graphique nommé \"%1$s\" existe déjà parmi les graphiques ou prototypes de graphiques."
+msgstr "Un graphique nommé « %1$s » existe déjà parmi les graphiques ou prototypes de graphiques."
 
 #: app/controllers/CControllerPopupGeneric.php:248
 #: app/controllers/CControllerPopupImportCompare.php:167
@@ -7264,22 +7258,22 @@ msgstr "Groupe"
 #: include/classes/api/services/CHostGroup.php:650
 #, c-format
 msgid "Group \"%1$s\" cannot be deleted, because it is used by a host prototype."
-msgstr "Le groupe \"%1$s\" ne peut pas être effacé, car il est utilisé par un prototype d'hôte."
+msgstr "Le groupe « %1$s » ne peut pas être effacé, car il est utilisé par un prototype d’hôte."
 
 #: include/classes/api/services/CHostGroup.php:700
 #, c-format
 msgid "Group \"%1$s\" cannot be deleted, because it is used in a correlation condition."
-msgstr "Le groupe \"%1$s\" ne peut pas être effacé, car il est utilisé dans une condition de corrélation."
+msgstr "Le groupe « %1$s » ne peut pas être effacé, car il est utilisé dans une condition de corrélation."
 
 #: include/classes/import/importers/CTemplateImporter.php:394
 #, c-format
 msgid "Group \"%1$s\" does not exist."
-msgstr "Le groupe \"%1$s\" n'existe pas."
+msgstr "Le groupe « %1$s » n’existe pas."
 
 #: include/classes/import/importers/CHostImporter.php:299
 #, c-format
 msgid "Group \"%1$s\" for host \"%2$s\" does not exist."
-msgstr "Le groupe \"%1$s\" pour l'hôte \"%2$s\" n'existe pas."
+msgstr "Le groupe « %1$s » pour l’hôte « %2$s » n’existe pas."
 
 #: hostgroups.php:113
 msgid "Group added"
@@ -7303,7 +7297,7 @@ msgstr "Nom du groupe"
 #: include/classes/api/services/CHostPrototype.php:1271
 #, c-format
 msgid "Group prototype cannot be based on a discovered host group \"%1$s\"."
-msgstr "Le prototype de groupe ne peut pas être basé sur un groupe d'hôte \"%1$s\" découvert."
+msgstr "Le prototype de groupe ne peut pas être basé sur un groupe d’hôte « %1$s » découvert."
 
 #: include/views/configuration.host.prototype.edit.php:207
 msgid "Group prototypes"
@@ -7328,12 +7322,12 @@ msgstr "Groupes"
 
 #: include/classes/helpers/CMenuHelper.php:360
 msgid "Guest user"
-msgstr ""
+msgstr "Utilisateur invité"
 
 #: jsLoader.php:182
 msgctxt "abbreviation of severity level"
 msgid "H"
-msgstr ""
+msgstr "H"
 
 #: include/translateDefines.inc.php:35
 msgid "H:i"
@@ -7397,11 +7391,11 @@ msgstr "Matériel (détails complet)"
 
 #: include/classes/data/CItemData.php:1032
 msgid "Hardware sensor reading. Returns float"
-msgstr "Lecture d'un capteur matériel. Retourne un flottant"
+msgstr "Lecture d’un capteur matériel. Retourne un flottant"
 
 #: include/classes/setup/CSetupWizard.php:499
 msgid "HashiCorp Vault"
-msgstr ""
+msgstr "Coffres‐forts HashiCorp"
 
 #: app/views/popup.httpstep.php:133 app/views/popup.httpstep.php:161
 #: app/views/popup.massupdate.item.php:116
@@ -7413,12 +7407,12 @@ msgstr ""
 #: include/views/configuration.item.prototype.edit.php:359
 #: include/views/configuration.item.prototype.edit.php:417
 msgid "Headers"
-msgstr "En-têtes"
+msgstr "En‐têtes"
 
 #: include/classes/helpers/CCookieHelper.php:68
 #: include/classes/helpers/CCookieHelper.php:102
 msgid "Headers already sent."
-msgstr ""
+msgstr "En‑têtes déjà envoyés."
 
 #: include/locales.inc.php:58
 msgid "Hebrew (he_IL)"
@@ -7449,7 +7443,7 @@ msgstr "Caché"
 
 #: jsLoader.php:387
 msgid "Hide debug"
-msgstr "Cacher le debug"
+msgstr "Cacher le débogage"
 
 #: include/classes/widgets/forms/CWidgetFormProblemHosts.php:112
 #: include/classes/widgets/forms/CWidgetFormProblemsBySv.php:164
@@ -7463,7 +7457,7 @@ msgstr "Cacher sélections"
 #: app/partials/layout.htmlpage.aside.php:45
 #: app/partials/layout.htmlpage.aside.php:47
 msgid "Hide sidebar"
-msgstr ""
+msgstr "Masquer la barre latérale"
 
 #: include/classes/html/CBreadcrumbs.php:40
 msgctxt "screen reader"
@@ -7477,15 +7471,15 @@ msgstr "Haut"
 #: app/partials/administration.system.info.php:180
 #: app/partials/administration.system.info.php:187
 msgid "High availability cluster"
-msgstr ""
+msgstr "Grappe de serveurs haute disponibilité"
 
 #: app/controllers/CControllerAuditLogList.php:218
 msgid "High availability node"
-msgstr ""
+msgstr "Nœud de haute disponibilité"
 
 #: include/classes/widgets/forms/CWidgetFormSystemInfo.php:32
 msgid "High availability nodes"
-msgstr ""
+msgstr "Nœuds de haute disponibilité"
 
 #: include/classes/core/ZBase.php:361
 msgid "High-contrast dark"
@@ -7518,15 +7512,15 @@ msgstr "Historique"
 
 #: app/views/administration.housekeeping.edit.php:158
 msgid "History and trends compression"
-msgstr ""
+msgstr "Compression de l’historique et des tendances"
 
 #: include/classes/api/services/CHistory.php:353
 msgid "History cleanup is not supported if compression is enabled"
-msgstr ""
+msgstr "Le nettoyage de l’historique n’est pas pris en charge si la compression est activée"
 
 #: app/controllers/CControllerAuditLogList.php:198
 msgid "History clear"
-msgstr ""
+msgstr "Historique nettoyé"
 
 #: httpconf.php:189 httpconf.php:433 items.php:956 items.php:1036
 msgid "History cleared"
@@ -7535,31 +7529,30 @@ msgstr "Historique nettoyé"
 #: include/views/configuration.httpconf.edit.php:262
 #: include/views/configuration.item.edit.php:1033
 msgid "History clearing can take a long time. Continue?"
-msgstr "Le nettoyage de l'historique prend du temps. Continuer ?"
+msgstr "Le nettoyage de l’historique prend du temps. Continuer ?"
 
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:47
 msgid "History data selection"
-msgstr "Sélection des données d'historique"
+msgstr "Sélection des données d’historique"
 
 #: app/views/popup.triggerexpr.php:111
 msgid "History functions"
-msgstr ""
+msgstr "Fonctions d’historique"
 
 #: app/controllers/CControllerPopupLldOperation.php:219
-#: app/views/popup.lldoperation.php:185
-#: app/views/popup.massupdate.item.php:291 disc_prototypes.php:131
-#: include/views/configuration.item.edit.php:820
+#: app/views/popup.lldoperation.php:185 app/views/popup.massupdate.item.php:291
+#: disc_prototypes.php:131 include/views/configuration.item.edit.php:820
 #: include/views/configuration.item.prototype.edit.php:764 items.php:67
 msgid "History storage period"
-msgstr "Période de stockage de l'historique"
+msgstr "Période de stockage de l’historique"
 
 #: include/classes/html/CTabFilter.php:150
 msgid "Home"
-msgstr ""
+msgstr "Accueil"
 
 #: app/views/administration.module.edit.php:44
 msgid "Homepage"
-msgstr ""
+msgstr "Page d’accueil"
 
 #: include/classes/widgets/forms/CWidgetFormHostAvail.php:49
 #: include/classes/widgets/forms/CWidgetFormProblemsBySv.php:122
@@ -7613,7 +7606,7 @@ msgstr[1] "Hôtes"
 #: include/classes/import/importers/CHostImporter.php:71
 #, c-format
 msgid "Host \"%1$s\" already exists."
-msgstr "L'hôte \"%1$s\" existe déjà."
+msgstr "L’hôte « %1$s » existe déjà."
 
 #: include/classes/api/services/CHostGroup.php:1347
 #: include/classes/api/services/CHost.php:958
@@ -7621,12 +7614,12 @@ msgstr "L'hôte \"%1$s\" existe déjà."
 #: include/classes/api/services/CHost.php:2130
 #, c-format
 msgid "Host \"%1$s\" cannot be without host group."
-msgstr "L'hôte \"%1$s\" ne peut pas ne pas avoir de groupe d'hôte."
+msgstr "L’hôte « %1$s » ne peut pas ne pas avoir de groupe d’hôte."
 
 #: include/classes/api/services/CProxy.php:448
 #, c-format
 msgid "Host \"%1$s\" is monitored by proxy \"%2$s\"."
-msgstr ""
+msgstr "L’hôte « %1$s » est supervisé par le proxy « %2$s »."
 
 #: include/actions.inc.php:55
 msgid "Host IP"
@@ -7643,19 +7636,19 @@ msgstr "Hôte ajouté"
 #: app/controllers/CControllerPopupItemTest.php:1303
 #: app/views/popup.itemtestedit.view.php:99
 msgid "Host address"
-msgstr ""
+msgstr "Adresse de l’hôte"
 
 #: include/classes/widgets/CWidgetConfig.php:54
 msgid "Host availability"
-msgstr ""
+msgstr "Disponibilité de l’hôte"
 
 #: include/classes/api/services/CHostInterface.php:1027
 msgid "Host cannot have more than one default interface of the same type."
-msgstr "Un hôte ne peut pas avoir plus d'une interface par défaut du même type."
+msgstr "Un hôte ne peut pas avoir plus d’une interface par défaut du même type."
 
 #: app/views/administration.proxy.list.php:81 hostinventoriesoverview.php:89
 msgid "Host count"
-msgstr "Nombre d'hôtes"
+msgstr "Nombre d’hôtes"
 
 #: app/controllers/CControllerHostMassDelete.php:65
 msgid "Host deleted"
@@ -7692,30 +7685,30 @@ msgstr[1] "Hôtes désactivés"
 #: include/views/js/monitoring.sysmaps.js.php:152 jsLoader.php:266
 #: report2.php:398
 msgid "Host group"
-msgstr "Groupe d'hôtes"
+msgstr "Groupe d’hôtes"
 
 #: include/classes/api/services/CHostGroup.php:743
 #, c-format
 msgid "Host group \"%1$s\" already exists."
-msgstr "Le groupe d'hôtes \"%1$s\" existe déjà."
+msgstr "Le groupe d’hôtes « %1$s » existe déjà."
 
 #: include/classes/api/services/CHostGroup.php:686
 #, c-format
 msgid "Host group \"%1$s\" cannot be deleted, because it is used in a global script."
-msgstr "Le groupe d'hôtes \"%1$s\" ne peut pas être effacé, car il est utilisé dans un script global."
+msgstr "Le groupe d’hôtes « %1$s » ne peut pas être effacé, car il est utilisé dans un script global."
 
 #: include/classes/api/services/CHostGroup.php:636
 #, c-format
 msgid "Host group \"%1$s\" is internal and cannot be deleted."
-msgstr ""
+msgstr "Le groupe d’hôtes « %1$s » est interne et ne peut pas être supprimé."
 
 #: include/views/js/monitoring.sysmaps.js.php:103
 msgid "Host group elements"
-msgstr "Éléments du groupe d'hôtes"
+msgstr "Éléments du groupe d’hôtes"
 
 #: include/views/monitoring.sysmap.edit.php:164
 msgid "Host group label type"
-msgstr "Type d'étiquette du groupe d'hôtes"
+msgstr "Type d’étiquette du groupe d’hôtes"
 
 #: include/classes/api/services/CDashboardGeneral.php:555
 #: include/classes/api/services/CScript.php:812
@@ -7723,7 +7716,7 @@ msgstr "Type d'étiquette du groupe d'hôtes"
 #: include/classes/api/services/CUserGroup.php:444
 #, c-format
 msgid "Host group with ID \"%1$s\" is not available."
-msgstr "Le groupe d'hôtes avec l'ID \"%1$s\" n'est pas disponible."
+msgstr "Le groupe d’hôtes avec l’ID « %1$s » n’est pas disponible."
 
 #: app/controllers/CControllerPopupGeneric.php:145
 #: app/controllers/CControllerUsergroupGrouprightAdd.php:36
@@ -7733,8 +7726,7 @@ msgstr "Le groupe d'hôtes avec l'ID \"%1$s\" n'est pas disponible."
 #: app/partials/monitoring.problem.filter.php:35
 #: app/partials/popup.operations.php:199
 #: app/views/configuration.host.list.php:60
-#: app/views/monitoring.latest.view.php:50
-#: app/views/monitoring.web.view.php:50
+#: app/views/monitoring.latest.view.php:50 app/views/monitoring.web.view.php:50
 #: app/views/popup.condition.common.php:101
 #: app/views/popup.condition.common.php:282
 #: app/views/popup.massupdate.host.php:83
@@ -7763,7 +7755,7 @@ msgstr "Le groupe d'hôtes avec l'ID \"%1$s\" n'est pas disponible."
 #: include/views/inventory.host.list.php:46
 #: include/views/reports.toptriggers.php:40 report2.php:446
 msgid "Host groups"
-msgstr "Groupes d'hôtes"
+msgstr "Groupes d’hôtes"
 
 #: app/views/popup.massupdate.item.php:60
 #: include/views/configuration.host.discovery.edit.php:514
@@ -7778,23 +7770,23 @@ msgstr "Interface hôte"
 #: include/views/inventory.host.list.php:26
 #: include/views/inventory.host.view.php:265
 msgid "Host inventory"
-msgstr "Inventaire d'hôtes"
+msgstr "Inventaire d’hôtes"
 
 #: hostinventoriesoverview.php:26 hostinventoriesoverview.php:150
 msgid "Host inventory overview"
-msgstr "Aperçu d'inventaire d'hôtes"
+msgstr "Aperçu d’inventaire d’hôtes"
 
 #: include/views/monitoring.sysmap.edit.php:178
 msgid "Host label type"
-msgstr "Type d'étiquette d'hôte"
+msgstr "Type d’étiquette d’hôte"
 
 #: app/partials/configuration.host.edit.html.php:341
 msgid "Host macros"
-msgstr "Macros d'hôte"
+msgstr "Macros d’hôte"
 
 #: include/actions.inc.php:64
 msgid "Host metadata"
-msgstr "Métadonnées de l'hôte"
+msgstr "Métadonnées de l’hôte"
 
 #: app/partials/configuration.host.edit.html.php:89
 #: app/views/configuration.discovery.edit.php:106
@@ -7803,59 +7795,59 @@ msgstr "Métadonnées de l'hôte"
 #: include/views/configuration.host.prototype.edit.php:65
 #: include/views/inventory.host.view.php:50
 msgid "Host name"
-msgstr "Nom de l'hôte"
+msgstr "Nom de l’hôte"
 
 #: include/hosts.inc.php:284
 msgid "Host networks"
-msgstr "Réseaux de l'hôte"
+msgstr "Réseaux de l’hôte"
 
 #: app/controllers/CControllerAuditLogList.php:221
 #: app/views/popup.lldoperation.php:54
 #: include/views/js/configuration.host.discovery.edit.overr.js.php:168
 msgid "Host prototype"
-msgstr "Prototype d'hôte"
+msgstr "Prototype d’hôte"
 
 #: include/classes/api/services/CHostPrototype.php:978
 #, c-format
 msgid "Host prototype \"%1$s\" already exists on \"%2$s\", inherited from another template."
-msgstr "Le prototype d'hôte \"%1$s\" existe déjà sur \"%2$s\", hérité d'un autre modèle."
+msgstr "Le prototype d’hôte « %1$s » existe déjà sur « %2$s », hérité d’un autre modèle."
 
 #: include/classes/api/services/CHostPrototype.php:966
 #, c-format
 msgid "Host prototype \"%1$s\" already exists on \"%2$s\"."
-msgstr "Le prototype d'hôte \"%1$s\" existe déjà sur \"%2$s\"."
+msgstr "Le prototype d’hôte « %1$s » existe déjà sur « %2$s »."
 
 #: host_prototypes.php:288
 msgid "Host prototype added"
-msgstr "Prototype d'hôte ajouté"
+msgstr "Prototype d’hôte ajouté"
 
 #: include/classes/api/services/CHostPrototype.php:1759
 msgid "Host prototype cannot have more than one default interface of the same type."
-msgstr ""
+msgstr "Le prototype d’hôte ne peut avoir plus d’une interface par défaut du même type."
 
 #: host_prototypes.php:147
 msgid "Host prototype deleted"
-msgstr "Prototype d'hôte supprimé"
+msgstr "Prototype d’hôte supprimé"
 
 #: include/views/configuration.host.prototype.edit.php:334
 msgid "Host prototype macros"
-msgstr ""
+msgstr "Macros prototypes d’hôtes"
 
 #: host_prototypes.php:274 host_prototypes.php:304 host_prototypes.php:324
 msgid "Host prototype updated"
 msgid_plural "Host prototypes updated"
-msgstr[0] "Prototype d'hôte mis à jour"
-msgstr[1] "Prototypes d'hôtes mis à jour"
+msgstr[0] "Prototype d’hôte mis à jour"
+msgstr[1] "Prototypes d’hôtes mis à jour"
 
 #: include/classes/api/services/CHostPrototype.php:182
 #, c-format
 msgid "Host prototype with host name \"%1$s\" already exists in discovery rule \"%2$s\"."
-msgstr "Un prototype d'hôte avec le nom d'hôte \"%1$s\" existe déjà dans la règle de découverte \"%2$s\"."
+msgstr "Un prototype d’hôte avec le nom d’hôte « %1$s » existe déjà dans la règle de découverte « %2$s »."
 
 #: include/classes/api/services/CHostPrototype.php:183
 #, c-format
 msgid "Host prototype with visible name \"%1$s\" already exists in discovery rule \"%2$s\"."
-msgstr "Un prototype d'hôte avec le nom visible \"%1$s\" existe déjà dans la règle de découverte \"%2$s\"."
+msgstr "Un prototype d’hôte avec le nom visible « %1$s » existe déjà dans la règle de découverte « %2$s »."
 
 #: app/controllers/CControllerPopupImportCompare.php:176
 #: include/html.inc.php:483
@@ -7863,27 +7855,27 @@ msgstr "Un prototype d'hôte avec le nom visible \"%1$s\" existe déjà dans la 
 #: include/views/configuration.host.prototype.edit.php:33
 #: include/views/configuration.host.prototype.list.php:27
 msgid "Host prototypes"
-msgstr "Prototypes d'hôtes"
+msgstr "Prototypes d’hôtes"
 
 #: host_prototypes.php:340
 msgid "Host prototypes deleted"
-msgstr "Prototypes d'hôtes supprimés"
+msgstr "Prototypes d’hôtes supprimés"
 
 #: include/hosts.inc.php:294
 msgid "Host router"
-msgstr "Hôte - Routeur"
+msgstr "Hôte — routeur"
 
 #: include/hosts.inc.php:289
 msgid "Host subnet mask"
-msgstr "Masque de sous-réseau de l'hôte"
+msgstr "Masque de sous‐réseau de l’hôte"
 
 #: include/classes/widgets/forms/CWidgetFormClock.php:34
 msgid "Host time"
-msgstr "Temps de l'hôte"
+msgstr "Temps de l’hôte"
 
 #: include/classes/api/services/CHost.php:821
 msgid "Host update failed."
-msgstr "Échec de la mise à jour de l'hôte."
+msgstr "Échec de la mise à jour de l’hôte."
 
 #: app/controllers/CControllerHostUpdate.php:143
 msgid "Host updated"
@@ -7892,14 +7884,14 @@ msgstr "Hôte mis à jour"
 #: include/classes/api/services/CDashboardGeneral.php:572
 #, c-format
 msgid "Host with ID \"%1$s\" is not available."
-msgstr "L'hôte avec l'ID \"%1$s\" n'est pas disponible."
+msgstr "L’hôte avec l’ID « %1$s » n’est pas disponible."
 
 #: include/classes/api/services/CHost.php:2028
 #: include/classes/api/services/CHost.php:2310
 #: include/classes/api/services/CTemplate.php:1222
 #, c-format
 msgid "Host with the same name \"%1$s\" already exists."
-msgstr "Un hôte ayant le même nom \"%1$s\" existe déjà."
+msgstr "Un hôte ayant le même nom « %1$s » existe déjà."
 
 #: include/classes/api/services/CHost.php:2034
 #: include/classes/api/services/CHost.php:2317
@@ -7907,7 +7899,7 @@ msgstr "Un hôte ayant le même nom \"%1$s\" existe déjà."
 #: include/classes/api/services/CTemplate.php:1187
 #, c-format
 msgid "Host with the same visible name \"%1$s\" already exists."
-msgstr "Un hôte ayant le même nom visible \"%1$s\" existe déjà."
+msgstr "Un hôte ayant le même nom visible « %1$s » existe déjà."
 
 #: app/controllers/CControllerHostView.php:125
 #: app/controllers/CControllerPopupGeneric.php:109
@@ -7919,8 +7911,7 @@ msgstr "Un hôte ayant le même nom visible \"%1$s\" existe déjà."
 #: app/views/administration.proxy.list.php:84
 #: app/views/configuration.host.list.php:35
 #: app/views/monitoring.host.view.php:49
-#: app/views/monitoring.latest.view.php:67
-#: app/views/monitoring.web.view.php:69
+#: app/views/monitoring.latest.view.php:67 app/views/monitoring.web.view.php:69
 #: app/views/popup.condition.common.php:251 app/views/popup.import.php:30
 #: app/views/search.php:185 app/views/search.php:213 app/views/search.php:218
 #: include/classes/helpers/CMenuHelper.php:44
@@ -7980,15 +7971,15 @@ msgstr "Hongrois (hu_HU)"
 #: jsLoader.php:185
 msgctxt "abbreviation of severity level"
 msgid "I"
-msgstr ""
+msgstr "I"
 
 #: app/partials/massupdate.macros.tab.php:111
 msgid "I confirm to remove all macros"
-msgstr ""
+msgstr "Je confirme vouloir supprimer toutes les macros"
 
 #: app/partials/massupdate.valuemaps.tab.php:84
 msgid "I confirm to remove all value mappings"
-msgstr ""
+msgstr "Je confirme vouloir supprimer toutes les correspondances de valeurs"
 
 #: include/discovery.inc.php:60
 msgid "ICMP ping"
@@ -8014,22 +8005,22 @@ msgstr "IP"
 #: app/views/configuration.discovery.edit.php:124 include/hosts.inc.php:1213
 #: include/maps.inc.php:46 include/views/inventory.host.view.php:81
 msgid "IP address"
-msgstr "adresse IP"
+msgstr "Adresse IP"
 
 #: include/classes/api/services/CHostInterface.php:333
 msgid "IP and DNS cannot be empty for host interface."
-msgstr "L'IP et le DNS ne peuvent être vide dans l'interface de l'hôte."
+msgstr "L’IP et le DNS ne peuvent être vide dans l’interface de l’hôte."
 
 #: app/views/configuration.discovery.edit.php:62
 #: app/views/configuration.discovery.list.php:77
 msgid "IP range"
-msgstr "Plage d'adresses IP"
+msgstr "Plage d’adresses IP"
 
 #: include/classes/api/services/CDRule.php:227
 #: include/classes/api/services/CDRule.php:375
 #, c-format
 msgid "IP range \"%1$s\" exceeds \"%2$s\" address limit"
-msgstr "La plage d'IP \"%1$s\" dépasse la limite d'adresses \"%2$s\""
+msgstr "La plage d’IP « %1$s » dépasse la limite d’adresses « %2$s »"
 
 #: app/partials/configuration.host.edit.html.php:523
 #: app/views/administration.script.edit.php:118
@@ -8045,7 +8036,7 @@ msgstr "IPMI"
 
 #: include/items.inc.php:96
 msgid "IPMI agent"
-msgstr "agent IPMI"
+msgstr "Agent IPMI"
 
 #: include/views/inventory.host.view.php:67
 msgid "IPMI interfaces"
@@ -8060,7 +8051,7 @@ msgstr "Capteur IPMI"
 
 #: include/classes/data/CItemData.php:880
 msgid "IPMI sensor IDs and other sensor-related parameters. Returns JSON."
-msgstr ""
+msgstr "Identifiants des capteurs IPMI et autres paramètres relatifs aux capteurs. Retournes un objet JSON."
 
 #: app/views/administration.iconmap.edit.php:58
 #: app/views/administration.image.edit.php:73
@@ -8091,41 +8082,41 @@ msgstr "Icône surlignée"
 #: app/views/administration.iconmap.edit.php:132
 #: app/views/administration.iconmap.list.php:39
 msgid "Icon map"
-msgstr "Correspondance d'icône"
+msgstr "Correspondance d’icône"
 
 #: include/classes/api/services/CIconMap.php:323
 #, c-format
 msgid "Icon map \"%1$s\" already exists."
-msgstr ""
+msgstr "Une carte d’icônes nommée « %1$s » existe déjà."
 
 #: include/classes/api/services/CIconMap.php:563
 #, c-format
 msgid "Icon map \"%1$s\" cannot be deleted. Used in map \"%2$s\"."
-msgstr "La correspondance d'icône \"%1$s\" ne peut pas être supprimée. Utilisée dans la carte \"%2$s\"."
+msgstr "La correspondance d’icône « %1$s » ne peut pas être supprimée. Utilisée dans la carte « %2$s »."
 
 #: app/controllers/CControllerIconMapCreate.php:49
 msgid "Icon map created"
-msgstr "Correspondance d'icône créée"
+msgstr "Correspondance d’icône créée"
 
 #: app/controllers/CControllerIconMapDelete.php:57
 msgid "Icon map deleted"
-msgstr "Correspondance d'icône supprimée"
+msgstr "Correspondance d’icône supprimée"
 
 #: app/controllers/CControllerIconMapUpdate.php:60
 msgid "Icon map updated"
-msgstr "Correspondance d'icône mise à jour"
+msgstr "Correspondance d’icône mise à jour"
 
 #: app/controllers/CControllerAuditLogList.php:223
 #: app/views/administration.iconmap.edit.php:29
 #: app/views/administration.iconmap.list.php:27
 #: include/classes/helpers/CMenuHelper.php:234 include/html.inc.php:891
 msgid "Icon mapping"
-msgstr "Correspondance d'icônes"
+msgstr "Correspondance d’icônes"
 
 #: include/classes/api/services/CIconMap.php:409
 #, c-format
 msgid "Icon with ID \"%1$s\" is not available."
-msgstr "L'icône avec l'IS \"%1$s\" n'est pas disponible."
+msgstr "L’icône avec l’IS « %1$s » n’est pas disponible."
 
 #: include/views/js/monitoring.sysmaps.js.php:259
 msgid "Icons"
@@ -8133,22 +8124,22 @@ msgstr "Icônes"
 
 #: app/views/administration.authentication.edit.php:222
 msgid "IdP entity ID"
-msgstr ""
+msgstr "Identifiant d’entité du fournisseur d’identité"
 
 #: include/classes/core/CModuleManager.php:155
 #, c-format
 msgid "Identical ID (%1$s) is used by modules located at %2$s."
-msgstr ""
+msgstr "Un identifiant identique « %1$s » est utilisé par les modules situés à %2$s."
 
 #: include/classes/core/CModuleManager.php:173
 #, c-format
 msgid "Identical actions are used by modules located at %1$s."
-msgstr ""
+msgstr "Des actions identiques sont utilisées par les modules situés à %1$s."
 
 #: include/classes/core/CModuleManager.php:162
 #, c-format
 msgid "Identical namespace (%1$s) is used by modules located at %2$s."
-msgstr ""
+msgstr "Un espace de noms identique « %1$s » est utilisé par les modules situés à %2$s."
 
 #: include/classes/data/CItemData.php:1136
 msgid "Identification of the system. Returns string"
@@ -8158,45 +8149,45 @@ msgstr "Identification du système. Retourne une chaîne"
 #, c-format
 msgid "If at least %2$s child service has %1$s status or above"
 msgid_plural "If at least %2$s child services have %1$s status or above"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Si au moins %2$s service fils a un statut %1$s ou supérieur"
+msgstr[1] "Si au moins %2$s services fils ont un statut %1$s ou supérieur"
 
 #: include/classes/helpers/CServiceHelper.php:35
 #, c-format
 msgid "If at least %2$s child services have %1$s status or above"
-msgstr ""
+msgstr "Si au moins %2$s services fils ont un statut %1$s ou supérieur"
 
 #: include/classes/helpers/CServiceHelper.php:40
 #: include/classes/helpers/CServiceHelper.php:89
 #, c-format
 msgid "If at least %2$s of child services have %1$s status or above"
-msgstr ""
+msgstr "Si au moins %2$s des services fils ont un statut %1$s ou supérieur"
 
 #: app/views/popup.lldoverride.php:54
 msgid "If filter matches"
-msgstr ""
+msgstr "Si le filtre correspond à"
 
 #: include/classes/helpers/CServiceHelper.php:95
 #, c-format
 msgid "If less than %2$s child service has %1$s status or below"
 msgid_plural "If less than %2$s child services have %1$s status or below"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Si au moins %2$s service fils a un statut %1$s ou inférieur"
+msgstr[1] "Si au moins %2$s services fils ont un statut %1$s ou inférieur"
 
 #: include/classes/helpers/CServiceHelper.php:45
 #, c-format
 msgid "If less than %2$s child services have %1$s status or below"
-msgstr ""
+msgstr "Si au moins %2$s services fils ont un statut %1$s ou inférieur"
 
 #: include/classes/helpers/CServiceHelper.php:50
 #: include/classes/helpers/CServiceHelper.php:101
 #, c-format
 msgid "If less than %2$s of child services have %1$s status or below"
-msgstr ""
+msgstr "Si au moins %2$s des services fils ont un statut %1$s ou inférieur"
 
 #: include/classes/api/services/CReport.php:348
 msgid "If no user groups are specified, at least one user must be included in the mailing list."
-msgstr ""
+msgstr "Si aucun groupe d’utilisateurs n’est spécifié, au moins un utilisateur doit être membre de la liste de diffusion."
 
 #: include/classes/helpers/CServiceHelper.php:55
 #: include/classes/helpers/CServiceHelper.php:60
@@ -8204,7 +8195,7 @@ msgstr ""
 #: include/classes/helpers/CServiceHelper.php:110
 #, c-format
 msgid "If weight of child services with %1$s status or above is at least %2$s"
-msgstr ""
+msgstr "Si le poids des services fils de statut %1$s ou supérieur est d’au moins %2$s"
 
 #: include/classes/helpers/CServiceHelper.php:65
 #: include/classes/helpers/CServiceHelper.php:70
@@ -8212,19 +8203,19 @@ msgstr ""
 #: include/classes/helpers/CServiceHelper.php:118
 #, c-format
 msgid "If weight of child services with %1$s status or below is less than %2$s"
-msgstr ""
+msgstr "Si le poids des services fils de statut %1$s ou inférieur est d’au maximum %2$s"
 
 #: include/func.inc.php:1516 include/func.inc.php:1536
 msgid "If you think this message is wrong, please consult your administrators about getting the necessary permissions."
-msgstr "Si vous pensez que ce message n'est pas correct, veuillez consulter votre administrateur pour obtenir les permissions nécessaires."
+msgstr "Si vous pensez que ce message n’est pas correct, veuillez consulter votre administrateur pour obtenir les permissions nécessaires."
 
 #: app/views/administration.miscconfig.edit.php:124
 msgid "Iframe sandboxing exceptions"
-msgstr ""
+msgstr "Exception du bac à sable de l’« iframe »"
 
 #: include/classes/helpers/CServiceHelper.php:151
 msgid "Ignore this service"
-msgstr ""
+msgstr "Ignorer ce service"
 
 #: app/controllers/CControllerAuditLogList.php:224
 #: app/views/administration.image.edit.php:60
@@ -8238,7 +8229,7 @@ msgstr "Image"
 #: include/classes/api/services/CImage.php:501
 #, c-format
 msgid "Image \"%1$s\" already exists."
-msgstr "L'image \"%1$s\" existe déjà."
+msgstr "L’image « %1$s » existe déjà."
 
 #: app/controllers/CControllerImageCreate.php:123
 msgid "Image added"
@@ -8250,12 +8241,12 @@ msgstr "Image supprimée"
 
 #: include/views/monitoring.sysmap.edit.php:220
 msgid "Image label type"
-msgstr "Type d'étiquette d'image"
+msgstr "Type d’étiquette d’image"
 
 #: include/classes/helpers/CUploadFile.php:129
 #, c-format
 msgid "Image size must be less than %1$s."
-msgstr ""
+msgstr "La taille de l’image doit être inférieure à %1$s."
 
 #: app/controllers/CControllerImageUpdate.php:147
 msgid "Image updated"
@@ -8269,7 +8260,7 @@ msgstr "Images"
 
 #: app/views/popup.import.php:74
 msgid "Images for all maps will be updated!"
-msgstr "Les images de toutes les cartes seront mises à jour !"
+msgstr "Les images de toutes les cartes seront mises à jour !"
 
 #: include/views/configuration.action.edit.php:236
 msgid "Immediately"
@@ -8287,7 +8278,7 @@ msgstr "Importer"
 #: app/controllers/CControllerPopupImportCompare.php:141
 #: app/controllers/CControllerPopupImport.php:154
 msgid "Import failed"
-msgstr ""
+msgstr "L’importation a échoué"
 
 #: app/views/popup.import.php:135
 msgid "Import file"
@@ -8300,7 +8291,7 @@ msgstr "Importé avec succès"
 #: hostinventories.php:192
 #, c-format
 msgid "Impossible to filter by inventory field \"%1$s\", which does not exist."
-msgstr ""
+msgstr "Impossible de filtrer par le champ d’inventaire « %1$s » qui n’existe pas."
 
 #: include/html.inc.php:277 include/maps.inc.php:409
 msgid "In maintenance"
@@ -8318,12 +8309,12 @@ msgstr "Dans la plage"
 #: app/controllers/CControllerPopupScheduledReportEdit.php:121
 #: app/controllers/CControllerScheduledReportEdit.php:303
 msgid "Inaccessible dashboard"
-msgstr ""
+msgstr "Tableau de bord inaccessible"
 
 #: app/partials/configuration.host.edit.html.php:60
 #: app/views/configuration.host.list.php:234
 msgid "Inaccessible discovery rule"
-msgstr ""
+msgstr "Règle de découverte inaccessible"
 
 #: app/controllers/CControllerDashboardWidgetEdit.php:320
 msgid "Inaccessible graph"
@@ -8331,7 +8322,7 @@ msgstr "Graphique inaccessible"
 
 #: app/controllers/CControllerDashboardWidgetEdit.php:322
 msgid "Inaccessible graph prototype"
-msgstr ""
+msgstr "Prototype de graphique inaccessible"
 
 #: app/controllers/CControllerDashboardWidgetEdit.php:317
 #: host_prototypes.php:459
@@ -8348,12 +8339,12 @@ msgstr "Élément inaccessible"
 
 #: app/controllers/CControllerDashboardWidgetEdit.php:321
 msgid "Inaccessible item prototype"
-msgstr ""
+msgstr "Prototype d’élément inaccessible"
 
 #: app/partials/monitoring.host.view.html.php:89
 #: app/views/configuration.host.list.php:267
 #: include/classes/screens/CScreenProblem.php:386
-#: include/hostgroups.inc.php:293 include/triggers.inc.php:2023
+#: include/hostgroups.inc.php:293 include/triggers.inc.php:2025
 #: include/views/inventory.host.view.php:42
 msgid "Inaccessible maintenance"
 msgstr "Maintenance inaccessible"
@@ -8365,11 +8356,11 @@ msgstr "Carte inaccessible"
 
 #: httpconf.php:663 include/graphs.inc.php:274 include/hosts.inc.php:649
 #: include/httptest.inc.php:222 include/items.inc.php:916
-#: include/triggers.inc.php:2162
+#: include/triggers.inc.php:2164
 msgid "Inaccessible template"
 msgstr "Modèle inaccessible"
 
-#: include/triggers.inc.php:2368 include/triggers.inc.php:2376
+#: include/triggers.inc.php:2370 include/triggers.inc.php:2378
 msgid "Inaccessible trigger"
 msgstr "Déclencheur inaccessible"
 
@@ -8382,15 +8373,14 @@ msgstr "Déclencheur inaccessible"
 #: app/controllers/CControllerScheduledReportEdit.php:281
 #: app/controllers/CControllerScheduledReportList.php:136
 #: include/actions.inc.php:2009 include/actions.inc.php:2032
-#: include/actions.inc.php:2037
-#: include/classes/helpers/CDashboardHelper.php:39 include/events.inc.php:251
-#: include/views/monitoring.sysmap.edit.php:81
+#: include/actions.inc.php:2037 include/classes/helpers/CDashboardHelper.php:39
+#: include/events.inc.php:251 include/views/monitoring.sysmap.edit.php:81
 msgid "Inaccessible user"
 msgstr "Utilisateur inaccessible"
 
 #: app/controllers/CControllerScheduledReportEdit.php:231
 msgid "Inaccessible user group"
-msgstr ""
+msgstr "Groupe d’utilisateurs inaccessible"
 
 #: app/partials/js/scheduledreport.subscription.js.php:165
 #: app/partials/js/scheduledreport.subscription.js.php:181
@@ -8401,12 +8391,12 @@ msgstr "Inclure"
 
 #: app/views/administration.mediatype.edit.php:240
 msgid "Include event menu entry"
-msgstr ""
+msgstr "Inclure l’entrée de menu d’événement"
 
 #: app/views/administration.usergroup.edit.php:140
 #: app/views/administration.usergroup.edit.php:191
 msgid "Include subgroups"
-msgstr "Inclure les sous-groupes"
+msgstr "Inclure les sous‐groupes"
 
 #: include/classes/data/CItemData.php:948
 msgid "Incoming traffic statistics on network interface. Returns integer"
@@ -8415,37 +8405,37 @@ msgstr "Statistiques de trafic entrant sur une interface réseau. Retourne un en
 #: include/classes/api/services/CService.php:1450
 #, c-format
 msgid "Incompatible \"propagation_rule\" and \"propagation_value\" parameters for service \"%1$s\"."
-msgstr ""
+msgstr "Les paramètres « propagation_rule » et « propagation_value » du service « %1$s » sont incompatibles."
 
 #: include/classes/api/services/CMap.php:655
 #: include/classes/api/services/CMap.php:1138
 #, c-format
 msgid "Incorrect \"height\" value for map \"%1$s\"."
-msgstr "Valeur \"height\" incorrecte pour la carte \"%1$s\"."
+msgstr "Valeur « height » incorrecte pour la carte « %1$s »."
 
 #: include/classes/api/services/CMap.php:803
 #: include/classes/api/services/CMap.php:1271
 #, c-format
 msgid "Incorrect \"permission\" value \"%1$s\" in user groups for map \"%2$s\"."
-msgstr "Valeur \"permission\" \"%1$s\" incorrecte dans les groupes d'utilisateurs pour la carte \"%2$s\"."
+msgstr "Valeur « permission » « %1$s » incorrecte dans les groupes d’utilisateurs pour la carte « %2$s »."
 
 #: include/classes/api/services/CMap.php:728
 #: include/classes/api/services/CMap.php:1197
 #, c-format
 msgid "Incorrect \"permission\" value \"%1$s\" in users for map \"%2$s\"."
-msgstr "Valeur \"permission\" \"%1$s\" incorrecte dans les utilisateurs pour la carte \"%2$s\"."
+msgstr "Valeur « permission » « %1$s » incorrecte dans les utilisateurs pour la carte « %2$s »."
 
 #: include/classes/api/services/CMap.php:674
 #: include/classes/api/services/CMap.php:1144
 #, c-format
 msgid "Incorrect \"private\" value \"%1$s\" for map \"%2$s\"."
-msgstr "Valeur \"private\" \"%1$s\" incorrecte pour la carte \"%2$s\"."
+msgstr "Valeur « private » « %1$s » incorrecte pour la carte « %2$s »."
 
 #: include/classes/api/services/CMap.php:649
 #: include/classes/api/services/CMap.php:1132
 #, c-format
 msgid "Incorrect \"width\" value for map \"%1$s\"."
-msgstr "Valeur \"width\" incorrecte pour la carte \"%1$s\"."
+msgstr "Valeur « width » incorrecte pour la carte « %1$s »."
 
 #: include/classes/api/services/CMap.php:876
 #: include/classes/api/services/CMap.php:883
@@ -8457,12 +8447,12 @@ msgstr "Valeur \"width\" incorrecte pour la carte \"%1$s\"."
 #: include/classes/api/services/CMap.php:1382
 #, c-format
 msgid "Incorrect %1$s label type value for map \"%2$s\"."
-msgstr "Valeur de type d'étiquette %1$s incorrecte pour la carte \"%2$s\"."
+msgstr "Valeur de type d’étiquette %1$s incorrecte pour la carte « %2$s »."
 
 #: include/classes/api/clients/CLocalApiClient.php:71
 #, c-format
 msgid "Incorrect API \"%1$s\"."
-msgstr "API \"%1$s\" incorrecte."
+msgstr "API « %1$s » incorrecte."
 
 #: include/classes/api/services/CDRule.php:579
 msgid "Incorrect SNMP OID."
@@ -8474,95 +8464,95 @@ msgstr "Communauté SNMP incorrecte."
 
 #: include/classes/helpers/CVaultHelper.php:137
 msgid "Incorrect Vault API endpoint."
-msgstr ""
+msgstr "Point de terminaison de l’API du coffre‑fort incorrect."
 
 #: include/classes/helpers/CVaultHelper.php:61
 msgid "Incorrect Vault token."
-msgstr ""
+msgstr "Jeton de coffre‑fort incorrect."
 
 #: include/classes/validators/CActionCondValidator.php:122
 msgid "Incorrect action condition discovery check."
-msgstr "Test de découverte associé à la condition d'action incorrect."
+msgstr "Test de découverte associé à la condition d’action incorrect."
 
 #: include/classes/api/services/CAction.php:3310
 msgid "Incorrect action condition discovery check. Discovery check does not exist or you have no access to it."
-msgstr "Test de découverte associé à la condition d'action incorrect. Le test de découverte n'existe pas ou vous n'y avez pas accès."
+msgstr "Test de découverte associé à la condition d’action incorrect. Le test de découverte n’existe pas ou vous n’y avez pas accès."
 
 #: include/classes/validators/CActionCondValidator.php:95
 msgid "Incorrect action condition discovery object."
-msgstr "Test de découverte associé à la condition d'action incorrect."
+msgstr "Test de découverte associé à la condition d’action incorrect."
 
 #: include/classes/api/services/CAction.php:3269
 msgid "Incorrect action condition discovery rule. Discovery rule does not exist or you have no access to it."
-msgstr "Règle de découverte associée à la condition d'action incorrecte. La règle de découverte n'existe pas ou vous n'y avez pas accès."
+msgstr "Règle de découverte associée à la condition d’action incorrecte. La règle de découverte n’existe pas ou vous n’y avez pas accès."
 
 #: include/classes/validators/CActionCondValidator.php:140
 msgid "Incorrect action condition discovery status."
-msgstr "État de découverte associé à la condition d'action incorrect."
+msgstr "État de découverte associé à la condition d’action incorrect."
 
 #: include/classes/validators/CActionCondValidator.php:164
 msgid "Incorrect action condition event type."
-msgstr "Type d'événement associé à la condition d'action incorrect."
+msgstr "Type d’événement associé à la condition d’action incorrect."
 
 #: include/classes/api/services/CAction.php:2989
 msgid "Incorrect action condition or operation host group. Host group does not exist or you have no access to it."
-msgstr ""
+msgstr "Condition d’action ou groupe d’hôtes d’opération incorrect. Le groupe d’hôtes n’existe pas ou vous n’y avez pas accès."
 
 #: include/classes/api/services/CAction.php:3049
 msgid "Incorrect action condition or operation host. Host does not exist or you have no access to it."
-msgstr ""
+msgstr "Condition d’action ou hôte d’opération incorrect. L’hôte n’existe pas ou vous n’y avez pas accès."
 
 #: include/classes/api/services/CAction.php:3187
 msgid "Incorrect action condition or operation template. Template does not exist or you have no access to it."
-msgstr ""
+msgstr "Condition d’action ou modèle d’opération incorrect. Le modèle n’existe pas ou vous n’y avez pas accès."
 
 #: include/classes/validators/CActionCondValidator.php:131
 #, c-format
 msgid "Incorrect action condition port \"%1$s\"."
-msgstr "Port de condition d'action \"%1$s\" incorrect."
+msgstr "Port de condition d’action « %1$s » incorrect."
 
 #: include/classes/api/services/CAction.php:3351
 msgid "Incorrect action condition proxy. Proxy does not exist or you have no access to it."
-msgstr "Proxy associé à la condition d'action incorrect. Le proxy n'existe pas ou vous n'y avez pas accès."
+msgstr "Proxy associé à la condition d’action incorrect. Le proxy n’existe pas ou vous n’y avez pas accès."
 
 #: include/classes/api/services/CAction.php:3391
 msgid "Incorrect action condition service. Service does not exist or you have no access to it."
-msgstr ""
+msgstr "Service de condition d’action incorrect. Le service n’existe pas ou vous n’y avez pas accès."
 
 #: include/classes/validators/CActionCondValidator.php:155
 msgid "Incorrect action condition trigger severity."
-msgstr "Sévérité de déclencheur de condition d'action incorrecte."
+msgstr "Sévérité de déclencheur de condition d’action incorrecte."
 
 #: include/classes/api/services/CAction.php:3228
 msgid "Incorrect action condition trigger. Trigger does not exist or you have no access to it."
-msgstr "Déclencheur associé à la condition d'action incorrect. Le déclencheur n'existe pas ou vous n'y avez pas accès."
+msgstr "Déclencheur associé à la condition d’action incorrect. Le déclencheur n’existe pas ou vous n’y avez pas accès."
 
 #: include/classes/validators/CActionCondValidator.php:211
 msgid "Incorrect action condition type."
-msgstr "Type associé à la condition d'action incorrect."
+msgstr "Type associé à la condition d’action incorrect."
 
 #: app/controllers/CControllerActionOperationValidate.php:83
 #: app/controllers/CControllerActionOperationValidate.php:89
 #: include/classes/api/services/CAction.php:2814
 msgid "Incorrect action operation escalation step values."
-msgstr "Valeurs de pas d'escalade associées à la condition d'action incorrectes."
+msgstr "Valeurs de pas d’escalade associées à la condition d’action incorrectes."
 
 #: include/classes/api/services/CAction.php:2889
 msgid "Incorrect action operation media type. Media type does not exist or you have no access to it."
-msgstr ""
+msgstr "Type de média d’opération d’action incorrect. Le type de média n’existe pas ou vous n’y avez pas accès."
 
 #: app/controllers/CControllerActionOperationValidate.php:63
 #, c-format
 msgid "Incorrect action operation type \"%1$s\" for event source \"%2$s\"."
-msgstr "Type d'opération d'action \"%1$s\" incorrect pour la source d'événement \"%2$s\"."
+msgstr "Type d’opération d’action « %1$s » incorrect pour la source d’événement « %2$s »."
 
 #: include/classes/api/services/CAction.php:3135
 msgid "Incorrect action operation user group. User group does not exist or you have no access to it."
-msgstr ""
+msgstr "Groupe d’utilisateurs d’opération d’action incorrect. Le groupe d’utilisateurs n’existe pas ou vous n’y avez pas accès."
 
 #: include/classes/api/services/CAction.php:3092
 msgid "Incorrect action operation user. User does not exist or you have no access to it."
-msgstr ""
+msgstr "Utilisateur d’opération d’action incorrect. L’utilisateur n’existe pas ou vous n’y avez pas accès."
 
 #: include/classes/api/services/CDRule.php:206
 #: include/classes/api/services/CDRule.php:348
@@ -8623,41 +8613,41 @@ msgstr "Arguments incorrects passés à la fonction."
 
 #: include/classes/api/services/CHostInterface.php:1094
 msgid "Incorrect bulk value for interface."
-msgstr "Valeur de masse incorrecte pour l'interface."
+msgstr "Valeur de masse incorrecte pour l’interface."
 
 #: include/classes/api/services/CHost.php:981
 #: include/classes/api/services/CHost.php:1885
 #: include/classes/api/services/CHost.php:2223
 #, c-format
 msgid "Incorrect characters used for host name \"%1$s\"."
-msgstr ""
+msgstr "Présence de caractères incorrects dans le nom d’hôte « %1$s »."
 
 #: include/classes/api/services/CTemplate.php:502
 #: include/classes/api/services/CTemplate.php:1232
 #, c-format
 msgid "Incorrect characters used for template name \"%1$s\"."
-msgstr "Caractères incorrects utilisés pour le nom de modèle \"%1$s\"."
+msgstr "Caractères incorrects utilisés pour le nom de modèle « %1$s »."
 
 #: include/classes/api/services/CDiscoveryRule.php:1801
 #, c-format
 msgid "Incorrect conditions for discovery rule \"%1$s\"."
-msgstr "Conditions incorrectes pour la règle de découverte \"%1$s\"."
+msgstr "Conditions incorrectes pour la règle de découverte « %1$s »."
 
 #: include/classes/api/services/CDiscoveryRule.php:1807
 #, c-format
 msgid "Incorrect custom expression \"%2$s\" for discovery rule \"%1$s\": %3$s."
-msgstr "Expression personnalisée \"%2$s\" incorrecte pour la règle de découverte \"%1$s\" : %3$s."
+msgstr "Expression personnalisée « %2$s » incorrecte pour la règle de découverte « %1$s » : %3$s."
 
 #: include/classes/api/services/CDiscoveryRule.php:1598
 #, c-format
 msgid "Incorrect custom expression \"%2$s\" for override \"%1$s\": %3$s."
-msgstr ""
+msgstr "Expression personnalisée « %2$s » incorrecte dans le remplacement « %1$s » : %3$s."
 
 #: include/classes/db/MysqlDbBackend.php:69
 #: include/classes/db/PostgresqlDbBackend.php:95
 #, c-format
 msgid "Incorrect default charset for Zabbix database: %1$s."
-msgstr ""
+msgstr "Jeu de caractères par défaut de la base de données Zabbix incorrect : %1$s."
 
 #: include/classes/api/services/CEvent.php:510
 #: include/classes/api/services/CProblem.php:375
@@ -8667,7 +8657,7 @@ msgstr "Valeur evaltype incorrecte."
 #: include/classes/validators/event/CEventSourceObjectValidator.php:69
 #, c-format
 msgid "Incorrect event object \"%1$s\" (%2$s) for event source \"%3$s\" (%4$s), only the following objects are supported: %5$s."
-msgstr "Objet d'événement \"%1$s\" (%2$s) incorrect pour la source d'événement \"%3$s\" (%4$s), seuls les objets suivants sont supportés : %5$s."
+msgstr "Objet d’événement « %1$s » (%2$s) incorrect pour la source d’événement « %3$s » (%4$s), seuls les objets suivants sont pris en charge : %5$s."
 
 #: include/classes/api/services/CAlert.php:386
 msgid "Incorrect eventobject value."
@@ -8680,7 +8670,7 @@ msgstr "Valeur eventsource incorrecte."
 #: include/classes/db/DB.php:691 include/classes/db/DB.php:965
 #, c-format
 msgid "Incorrect field \"%1$s\" name or value in where statement for table \"%2$s\"."
-msgstr "Nom ou valeur incorrecte du champ \"%1$s\" dans l'instruction \"where\" pour la table \"%2$s\"."
+msgstr "Nom ou valeur incorrecte du champ « %1$s » dans l’instruction « where » pour la table « %2$s »."
 
 #: include/classes/api/services/CMap.php:606
 msgid "Incorrect fields for sysmap."
@@ -8691,7 +8681,7 @@ msgstr "Champs incorrects pour sysmap."
 #: include/classes/setup/CSetupWizard.php:948
 #, c-format
 msgid "Incorrect file path for \"%1$s\": %2$s."
-msgstr ""
+msgstr "Chemin d’accès à «%1$s » incorrect : %2$s."
 
 #: include/classes/helpers/CUploadFile.php:162
 msgid "Incorrect file upload."
@@ -8700,22 +8690,22 @@ msgstr "Téléversement de fichier incorrect."
 #: include/classes/api/services/CDiscoveryRule.php:1837
 #, c-format
 msgid "Incorrect filter condition formula ID for discovery rule \"%1$s\"."
-msgstr "Identifiant de formule de condition de filtre incorrect pour la règle de découverte \"%1$s\"."
+msgstr "Identifiant de formule de condition de filtre incorrect pour la règle de découverte « %1$s »."
 
 #: include/classes/api/services/CDiscoveryRule.php:1829
 #, c-format
 msgid "Incorrect filter condition macro for discovery rule \"%1$s\"."
-msgstr "Macro de condition de filtre incorrect pour la règle de découverte \"%1$s\"."
+msgstr "Macro de condition de filtre incorrect pour la règle de découverte « %1$s »."
 
 #: include/classes/api/services/CDiscoveryRule.php:1633
 #, c-format
 msgid "Incorrect filter condition macro for override \"%1$s\"."
-msgstr ""
+msgstr "La macro de condition de filtrage est incorrecte pour le remplacement « %1$s »."
 
 #: include/classes/api/services/CDiscoveryRule.php:1843
 #, c-format
 msgid "Incorrect filter condition operator for discovery rule \"%1$s\"."
-msgstr "Opérateur de condition de filtre incorrect pour la règle de découverte \"%1$s\"."
+msgstr "Opérateur de condition de filtre incorrect pour la règle de découverte « %1$s »."
 
 #: app/controllers/CControllerPopupTestTriggerExpr.php:49
 #: include/classes/triggers/CTextTriggerConstructor.php:115
@@ -8725,7 +8715,7 @@ msgstr "Fonction incorrecte utilisée"
 
 #: image.php:46
 msgid "Incorrect image index."
-msgstr "Index d'image incorrect."
+msgstr "Index d’image incorrect."
 
 #: include/classes/api/services/CHostInterface.php:675
 #: include/classes/api/services/CHost.php:964
@@ -8735,54 +8725,54 @@ msgstr "Index d'image incorrect."
 #: include/classes/api/services/CTemplate.php:674
 #: include/classes/api/services/CTrigger.php:803
 msgid "Incorrect input parameters."
-msgstr "Paramètres d'entrée incorrects."
+msgstr "Paramètres d’entrée incorrects."
 
 #: include/classes/api/services/CHostInterface.php:801
 #, c-format
 msgid "Incorrect interface DNS parameter \"%1$s\" provided."
-msgstr ""
+msgstr "Paramètre DNS d’interface « %1$s » fourni incorrect."
 
 #: include/classes/api/services/CHostInterface.php:846
 #, c-format
 msgid "Incorrect interface port \"%1$s\" provided."
-msgstr ""
+msgstr "Port d’interface « %1$s » fourni incorrect."
 
 #: include/classes/api/services/CHost.php:2003
 #: include/classes/api/services/CHost.php:2206
 #, c-format
 msgid "Incorrect inventory field \"%1$s\"."
-msgstr ""
+msgstr "Champ d’inventaire « %1$s » fourni incorrect."
 
 #: app/controllers/CControllerActionOperationValidate.php:176
 msgid "Incorrect inventory mode in action operation."
-msgstr "Mode d'inventaire incorrection dans une opération d'action."
+msgstr "Mode d’inventaire incorrection dans une opération d’action."
 
 #: include/classes/api/services/CGraphGeneral.php:325
 msgid "Incorrect item for axis value."
-msgstr "Élément incorrect pour la valeur de l'axe."
+msgstr "Élément incorrect pour la valeur de l’axe."
 
 #: include/classes/api/services/CTriggerGeneral.php:1632
 #, c-format
 msgid "Incorrect item key \"%1$s\" provided for trigger expression on \"%2$s\"."
-msgstr "Clé d'élément \"%1$s\" incorrecte pour l'expression du déclencheur sur \"%2$s\"."
+msgstr "Clef d’élément « %1$s » incorrecte pour l’expression du déclencheur sur « %2$s »."
 
 #: app/controllers/CControllerPopupTestTriggerExpr.php:50
 #: include/triggers.inc.php:1149
 msgid "Incorrect item value type"
-msgstr "Type de valeur d'élément incorrect"
+msgstr "Type de valeur d’élément incorrect"
 
 #: include/classes/api/services/CTriggerGeneral.php:1639
 #, c-format
 msgid "Incorrect item value type \"%1$s\" provided for trigger function \"%2$s\"."
-msgstr "Type de valeur d'élément \"%1$s\" incorrect fourni pour la fonction de déclencheur \"%2$s\"."
+msgstr "Type de valeur d’élément « %1$s » incorrect fourni pour la fonction de déclencheur « %2$s »."
 
 #: include/forms.inc.php:1516
 msgid "Incorrect list of items."
-msgstr "Liste d'éléments incorrecte."
+msgstr "Liste d’éléments incorrecte."
 
 #: app/controllers/CControllerPopupMaintenancePeriod.php:89
 msgid "Incorrect maintenance - date must be between 1970.01.01 and 2038.01.18"
-msgstr "Maintenance incorrecte - la date doit être entre 1970.01.01 et 2038.01.18"
+msgstr "Maintenance incorrecte — la date doit être entre le 1/01/1970 et le 18/01/2038"
 
 #: app/controllers/CControllerPopupMaintenancePeriod.php:125
 msgid "Incorrect maintenance period (minimum 5 minutes)"
@@ -8797,17 +8787,17 @@ msgstr "Identifiant de carte incorrect."
 #: include/classes/api/services/CUser.php:1637
 #, c-format
 msgid "Incorrect method \"%1$s.%2$s\"."
-msgstr "Méthode \"%1$s.%2$s\" incorrecte."
+msgstr "Méthode « %1$s.%2$s » incorrecte."
 
 #: include/classes/api/services/CEvent.php:498
 #: include/classes/api/services/CProblem.php:363
 msgid "Incorrect object value."
-msgstr "Valeur d'objet incorrecte."
+msgstr "Valeur d’objet incorrecte."
 
 #: include/classes/db/OracleDbBackend.php:141
 #, c-format
 msgid "Incorrect parameter \"%1$s\" value: %2$s."
-msgstr ""
+msgstr "Valeur du paramètre « %1$s » incorrecte : %2$s."
 
 #: include/classes/api/services/CMaintenance.php:332
 #: include/classes/api/services/CMaintenance.php:552
@@ -8822,14 +8812,14 @@ msgstr "Intervalle de ports incorrect."
 #: app/controllers/CControllerRegExTest.php:73
 #, c-format
 msgid "Incorrect regular expression \"%1$s\": \"%2$s\""
-msgstr "Expression régulière \"%1$s\" incorrecte : \"%2$s\""
+msgstr "Expression rationnelle « %1$s » incorrecte : « %2$s »"
 
 #: include/classes/server/CZabbixServer.php:509
 #: include/classes/server/CZabbixServer.php:551
 #: include/classes/server/CZabbixServer.php:558
 #, c-format
 msgid "Incorrect response received from Zabbix server \"%1$s\"."
-msgstr "Réponse incorrecte reçue du serveur Zabbix \"%1$s\"."
+msgstr "Réponse incorrecte reçue du serveur Zabbix « %1$s »."
 
 #: app/controllers/CControllerServiceTimeValidate.php:66
 #: app/controllers/CControllerServiceTimeValidate.php:87
@@ -8850,11 +8840,11 @@ msgstr "Valeur source incorrecte."
 #: include/classes/api/services/CHost.php:2172
 #, c-format
 msgid "Incorrect status for host \"%1$s\"."
-msgstr "État incorrect pour l'hôte \"%1$s\"."
+msgstr "État incorrect pour l’hôte « %1$s »."
 
 #: include/classes/api/services/CHttpTest.php:737
 msgid "Incorrect templated web scenario step count."
-msgstr "Compte d'étapes de scénario web de template incorrect."
+msgstr "Compte d’étapes de scénario Web de template incorrect."
 
 #: include/classes/triggers/CTextTriggerConstructor.php:130
 msgid "Incorrect trigger expression"
@@ -8869,38 +8859,38 @@ msgstr "Expression du déclencheur incorrecte."
 #: include/classes/api/services/CTriggerGeneral.php:1405
 #, c-format
 msgid "Incorrect trigger expression. Host \"%1$s\" does not exist or you have no access to this host."
-msgstr "Expression du déclencheur incorrecte. L'hôte \"%1$s\" n'existe pas ou vous n'y avez pas accès."
+msgstr "Expression du déclencheur incorrecte. L’hôte « %1$s » n’existe pas ou vous n’y avez pas accès."
 
 #: include/classes/api/services/CTriggerGeneral.php:1406
 msgid "Incorrect trigger expression. Trigger expression elements should not belong to a template and a host simultaneously."
-msgstr "Expression du déclencheur incorrecte. Les éléments de l'expression du déclencheur ne peuvent pas appartenir à un modèle et un hôte simultanément."
+msgstr "Expression du déclencheur incorrecte. Les éléments de l’expression du déclencheur ne peuvent pas appartenir à un modèle et un hôte simultanément."
 
 #: include/classes/api/services/CTriggerGeneral.php:588
 #: include/classes/api/services/CTriggerGeneral.php:1411
 #, c-format
 msgid "Incorrect trigger prototype expression. Host \"%1$s\" does not exist or you have no access to this host."
-msgstr "Expression du prototype de déclencheur incorrecte. L'hôte \"%1$s\" n'existe pas ou vous n'y avez pas accès."
+msgstr "Expression du prototype de déclencheur incorrecte. L’hôte « %1$s » n’existe pas ou vous n’y avez pas accès."
 
 #: include/classes/api/services/CTriggerGeneral.php:1412
 msgid "Incorrect trigger prototype expression. Trigger prototype expression elements should not belong to a template and a host simultaneously."
-msgstr "Expression du prototype de déclencheur incorrecte. Les éléments de l'expression du déclencheur ne peuvent pas appartenir à un modèle et un hôte simultanément."
+msgstr "Expression du prototype de déclencheur incorrecte. Les éléments de l’expression du déclencheur ne peuvent pas appartenir à un modèle et un hôte simultanément."
 
 #: include/classes/api/services/CDiscoveryRule.php:1794
 #, c-format
 msgid "Incorrect type of calculation for discovery rule \"%1$s\"."
-msgstr "Type de calcul incorrect pour la règle de découverte \"%1$s\"."
+msgstr "Type de calcul incorrect pour la règle de découverte « %1$s »."
 
 #: include/classes/api/services/CMap.php:764
 #: include/classes/api/services/CMap.php:1232
 #, c-format
 msgid "Incorrect user ID specified for map \"%1$s\"."
-msgstr "Identifiant d'utilisateur incorrect pour la carte \"%1$s\"."
+msgstr "Identifiant d’utilisateur incorrect pour la carte « %1$s »."
 
 #: include/classes/api/services/CMap.php:835
 #: include/classes/api/services/CMap.php:1302
 #, c-format
 msgid "Incorrect user group ID specified for map \"%1$s\"."
-msgstr "Identifiant de groupe d'utilisateurs incorrect pour la carte \"%1$s\"."
+msgstr "Identifiant de groupe d’utilisateurs incorrect pour la carte « %1$s »."
 
 #: include/classes/api/services/CUser.php:1530
 #: include/classes/api/services/CUser.php:1544
@@ -8908,7 +8898,7 @@ msgstr "Identifiant de groupe d'utilisateurs incorrect pour la carte \"%1$s\"."
 #: include/classes/api/services/CUser.php:2043
 #: include/classes/validators/CLdapAuthValidator.php:88 index_http.php:83
 msgid "Incorrect user name or password or account is temporarily blocked."
-msgstr ""
+msgstr "Nom d’utilisateur ou mot de passe incorrect, ou bien le compte est temporairement bloqué."
 
 #: app/controllers/CControllerActionOperationValidate.php:121
 #: app/controllers/CControllerPopupGeneric.php:466
@@ -8933,35 +8923,35 @@ msgstr ""
 #: include/validate.inc.php:347
 #, c-format
 msgid "Incorrect value \"%1$s\" for \"%2$s\" field."
-msgstr "Valeur \"%1$s\" incorrecte pour le champ \"%2$s\"."
+msgstr "Valeur « %1$s » incorrecte pour le champ « %2$s »."
 
 #: include/validate.inc.php:336
 #, c-format
 msgid "Incorrect value \"%1$s\" for \"%2$s\" field: must be between %3$s and %4$s, and have no more than %5$s digits after the decimal point."
-msgstr ""
+msgstr "La valeur « %1$s » du champ « %2$s » est incorrecte : elle doit être comprise entre %3$s et %4$s, et posséder au maximum %5$s décimales."
 
 #: app/controllers/CControllerAuthenticationUpdate.php:153
 #: include/validate.inc.php:341
 #, c-format
 msgid "Incorrect value \"%1$s\" for \"%2$s\" field: must be between %3$s and %4$s."
-msgstr "Valeur \"%1$s\" incorrecte pour le champ \"%2$s\" : doit être entre %3$s et %4$s."
+msgstr "Valeur « %1$s » incorrecte pour le champ « %2$s » : doit être entre %3$s et %4$s."
 
 #: include/classes/db/DB.php:413
 #, c-format
 msgid "Incorrect value \"%1$s\" for float field \"%2$s\"."
-msgstr "Valeur incorrecte \"%1$s\" pour le champ de nombre flottant \"%2$s\"."
+msgstr "Valeur incorrecte « %1$s » pour le champ de nombre flottant « %2$s »."
 
 #: include/classes/db/DB.php:406
 #, c-format
 msgid "Incorrect value \"%1$s\" for int field \"%2$s\"."
-msgstr "Valeur incorrecte \"%1$s\" pour le champ d'entier \"%2$s\"."
+msgstr "Valeur incorrecte « %1$s » pour le champ d’entier « %2$s »."
 
 #: include/classes/api/services/CMaintenance.php:400
 #: include/classes/api/services/CMaintenance.php:668
 #: include/classes/db/DB.php:399
 #, c-format
 msgid "Incorrect value \"%1$s\" for unsigned int field \"%2$s\"."
-msgstr "Valeur incorrecte \"%1$s\" pour le champ d'entier non signé \"%2$s\"."
+msgstr "Valeur incorrecte « %1$s » pour le champ d’entier non signé « %2$s »."
 
 #: include/classes/validators/CNewValidator.php:125
 #: include/classes/validators/CNewValidator.php:137
@@ -8973,7 +8963,7 @@ msgstr "Valeur incorrecte \"%1$s\" pour le champ d'entier non signé \"%2$s\"."
 #: include/validate.inc.php:350
 #, c-format
 msgid "Incorrect value for \"%1$s\" field."
-msgstr "Valeur incorrecte pour le champ \"%1$s\"."
+msgstr "Valeur incorrecte pour le champ « %1$s »."
 
 #: app/controllers/CControllerActionOperationValidate.php:98
 #: app/controllers/CControllerAuthenticationUpdate.php:103
@@ -9207,11 +9197,11 @@ msgstr "Valeur incorrecte pour le champ \"%1$s\"."
 #: include/validate.inc.php:330
 #, c-format
 msgid "Incorrect value for field \"%1$s\": %2$s."
-msgstr "Valeur incorrecte pour le champ \"%1$s\" : %2$s."
+msgstr "Valeur incorrecte pour le champ « %1$s » : %2$s."
 
 #: include/classes/helpers/CServiceHelper.php:149
 msgid "Increase by"
-msgstr ""
+msgstr "Augmenter de"
 
 #: include/locales.inc.php:60
 msgid "Indonesian (id_ID)"
@@ -9219,7 +9209,7 @@ msgstr "Indonésien (id_ID)"
 
 #: include/func.inc.php:1337 include/func.inc.php:1341
 msgid "Infinity"
-msgstr ""
+msgstr "Infini"
 
 #: app/controllers/CControllerPopupMediatypeTestSend.php:172
 #: app/partials/monitoring.latest.view.html.php:60
@@ -9253,15 +9243,15 @@ msgstr "Information"
 
 #: include/classes/data/CItemData.php:1184
 msgid "Information about a file. Returns JSON"
-msgstr ""
+msgstr "Informations d’un fichier. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1036
 msgid "Information about a service. Returns integer with param as state, startup; string - with param as displayname, path, user; text - with param as description; Specifically for state: 0 - running, 1 - paused, 2 - start pending, 3 - pause pending, 4 - continue pending, 5 - stop pending, 6 - stopped, 7 - unknown, 255 - no such service; Specifically for startup: 0 - automatic, 1 - automatic delayed, 2 - manual, 3 - disabled, 4 - unknown"
-msgstr "Informations à propos d'un service. Retourne un entier avec param state, startup ; une chaîne avec param displayname, path, user ; du texte avec param description ; Pour state : 0 - en fonctionnement, 1 - en pause, 2 - démarrage en attente, 3 - pause en attente, 4 - continue en attente, 5 - arrêt en attente, 6 - arrêté, 7 - inconnu, 255 - service introuvable ; Pour startup : 0 - automatique, 1 - automatique avec délai, 2 - manuel, 3 - désactivé, 4 - inconnu"
+msgstr "Informations à propos d’un service. Retourne un entier avec state et startup comme paramètres ; une chaîne avec displayname, path et user comme paramètres ; du texte avec le paramètre description ; les valeurs d’état (state) possibles sont : 0 — en fonctionnement, 1 — en pause, 2 — démarrage en attente, 3 — pause en attente, 4 — continue en attente, 5 — arrêt en attente, 6 — arrêté, 7 — inconnu, 255 — service introuvable ; les valeurs de démarrage (startup) sont : 0 — automatique, 1 — automatique avec délai, 2 — manuel, 3 — désactivé, 4 — inconnu"
 
 #: include/views/configuration.host.prototype.edit.php:249
 msgid "Inherit"
-msgstr ""
+msgstr "Hériter"
 
 #: app/partials/configuration.filter.items.php:198
 #: include/views/configuration.triggers.list.php:112
@@ -9270,19 +9260,19 @@ msgstr "Hérité"
 
 #: app/partials/configuration.host.edit.html.php:342
 msgid "Inherited and host macros"
-msgstr "Macros héritées et d'hôtes"
+msgstr "Macros héritées et d’hôtes"
 
 #: include/views/configuration.host.prototype.edit.php:335
 msgid "Inherited and host prototype macros"
-msgstr ""
+msgstr "Macros héritées et de prototype d’hôte"
 
 #: app/partials/configuration.tags.tab.php:140
 msgid "Inherited and item tags"
-msgstr ""
+msgstr "Étiquettes héritées et d’éléments"
 
 #: app/partials/configuration.tags.tab.php:135
 msgid "Inherited and scenario tags"
-msgstr ""
+msgstr "Étiquettes héritées et de scénarios"
 
 #: include/views/configuration.template.edit.php:193
 msgid "Inherited and template macros"
@@ -9290,19 +9280,19 @@ msgstr "Macros héritées et de modèle"
 
 #: app/partials/configuration.tags.tab.php:130
 msgid "Inherited and trigger tags"
-msgstr "Tags hérités et déclencheurs"
+msgstr "Étiquettes hérités et déclencheurs"
 
 #: include/forms.inc.php:306
 msgid "Inherited items"
-msgstr "Éléments hérités "
+msgstr "Éléments hérités"
 
 #: include/classes/widgets/forms/CWidgetFormGeoMap.php:75
 msgid "Initial view"
-msgstr ""
+msgstr "Affichage initial"
 
 #: include/classes/widgets/forms/CWidgetFormGeoMap.php:79
 msgid "Initial view is ignored if the default view is set."
-msgstr ""
+msgstr "L’affichage initial est ignoré si une vue par défaut est définie."
 
 #: app/views/popup.triggerexpr.php:239
 msgid "Insert"
@@ -9324,11 +9314,11 @@ msgstr "Installation"
 
 #: include/hosts.inc.php:259
 msgid "Installer name"
-msgstr "Nom de l'installeur"
+msgstr "Nom de l’installeur"
 
 #: include/classes/helpers/CMenuHelper.php:337
 msgid "Integrations"
-msgstr ""
+msgstr "Intégrations"
 
 #: app/partials/monitoring.host.view.html.php:30
 #: app/views/administration.proxy.edit.php:76
@@ -9341,32 +9331,32 @@ msgstr "Interface"
 #: include/classes/api/services/CHostInterface.php:1047
 #, c-format
 msgid "Interface is linked to item \"%1$s\" on \"%2$s\"."
-msgstr "L'interface est liée à l'élément \"%1$s\" sur \"%2$s\"."
+msgstr "L’interface est liée à l’élément « %1$s » sur « %2$s »."
 
 #: include/classes/widgets/forms/CWidgetFormHostAvail.php:39
 msgid "Interface type"
-msgstr ""
+msgstr "Type d’interface"
 
 #: include/classes/api/services/CHostInterface.php:337
 #, c-format
 msgid "Interface with DNS \"%1$s\" cannot have empty IP address."
-msgstr "L'interface avec le DNS \"%1$s\" cannotne peut pas avoir d'adresse IP vide."
+msgstr "L’interface avec le DNS « %1$s » cannotne peut pas avoir d’adresse IP vide."
 
 #: include/classes/api/services/CHostInterface.php:343
 #: include/classes/api/services/CHostInterface.php:350
 #, c-format
 msgid "Interface with IP \"%1$s\" cannot have empty DNS name while having \"Use DNS\" property on \"%2$s\"."
-msgstr "L'interface avec l'IP \"%1$s\" ne peut pas avoir de nom DNS vide avec la proprioété \"Utiliser le DNS\" à \"%2$s\"."
+msgstr "L’interface avec l’IP « %1$s » ne peut pas avoir de nom DNS vide avec la proprioété « Utiliser le DNS » à « %2$s »."
 
 #: include/classes/api/services/CHostInterface.php:356
 #, c-format
 msgid "Interface with IP \"%1$s\" cannot have empty DNS name."
-msgstr "L'interface avec l'IP \"%1$s\" ne peut pas avoir de nom DNS vide."
+msgstr "L’interface avec l’IP « %1$s » ne peut pas avoir de nom DNS vide."
 
 #: app/partials/configuration.host.edit.html.php:242
 #: include/views/configuration.host.prototype.edit.php:246
 msgid "Interfaces"
-msgstr ""
+msgstr "Interfaces"
 
 #: app/views/administration.authentication.edit.php:33
 msgctxt "authentication"
@@ -9385,7 +9375,7 @@ msgstr "Erreur JSON-RPC interne."
 #: include/classes/helpers/CMenuHelper.php:190
 #: include/views/configuration.action.list.php:31
 msgid "Internal actions"
-msgstr ""
+msgstr "Actions internes"
 
 #: app/views/administration.housekeeping.edit.php:67
 msgid "Internal data storage period"
@@ -9407,12 +9397,12 @@ msgstr "Erreur interne."
 #: app/views/popup.mediatype.message.php:73
 #: include/classes/helpers/CMediatypeHelper.php:194
 msgid "Internal problem"
-msgstr ""
+msgstr "Problème interne"
 
 #: app/views/popup.mediatype.message.php:76
 #: include/classes/helpers/CMediatypeHelper.php:205
 msgid "Internal problem recovery"
-msgstr ""
+msgstr "Résolution de problème interne"
 
 #: include/httptest.inc.php:403
 msgid "Internet Explorer"
@@ -9420,8 +9410,7 @@ msgstr "Internet Explorer"
 
 #: app/partials/monitoring.latest.view.html.php:51
 #: app/views/configuration.discovery.list.php:79
-#: app/views/popup.lldoperation.php:115
-#: app/views/popup.massupdate.item.php:226
+#: app/views/popup.lldoperation.php:115 app/views/popup.massupdate.item.php:226
 #: app/views/popup.service.edit.php:226 include/forms.inc.php:565
 #: include/views/configuration.host.discovery.edit.php:632
 #: include/views/configuration.host.discovery.list.php:199
@@ -9436,30 +9425,30 @@ msgstr "Intervalle"
 #: include/classes/api/services/CRole.php:738
 #, c-format
 msgid "Invalid API method \"%2$s\" for user role \"%1$s\"."
-msgstr ""
+msgstr "Méthode « %2$s » de l’API incorrecte pour le rôle d’utilisateur « %1$s »."
 
 #: include/classes/api/services/CHostInterface.php:829
 #, c-format
 msgid "Invalid IP address \"%1$s\"."
-msgstr "Adresse IP \"%1$s\" invalide."
+msgstr "Adresse IP « %1$s » invalide."
 
 #: include/classes/core/CJsonRpc.php:172
 msgid "Invalid JSON. An error occurred on the server while parsing the JSON text."
-msgstr "JSON invalide. Une erreur s'est produite sur le serveur pendant l'analyse du texte JSON."
+msgstr "JSON invalide. Une erreur s’est produite sur le serveur pendant l’analyse du texte JSON."
 
 #: include/classes/import/readers/CYamlImportReader.php:55
 msgid "Invalid YAML file contents"
-msgstr ""
+msgstr "Contenu du fichier YAML incorrect"
 
 #: include/classes/validators/CActionCondValidator.php:113
 #, c-format
 msgid "Invalid action condition: %1$s."
-msgstr "Condition d'action invalide: %1$s."
+msgstr "Condition d’action invalide : %1$s."
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1517
 #, c-format
 msgid "Invalid condition: %1$s."
-msgstr ""
+msgstr "Condition incorrecte : %1$s."
 
 #: app/controllers/CControllerTimeSelectorUpdate.php:219
 msgid "Invalid date."
@@ -9468,12 +9457,12 @@ msgstr "Data invalide."
 #: include/classes/validators/CEmailValidator.php:39
 #, c-format
 msgid "Invalid email address \"%1$s\"."
-msgstr "Adresse de courrier électronique non valide \"%1$s\"."
+msgstr "Adresse de courrier électronique non valide « %1$s »."
 
 #: include/classes/api/services/CUser.php:934
 #, c-format
 msgid "Invalid email address for media type with ID \"%1$s\"."
-msgstr "Adresse e-mail incorrecte pour le type de media avec l'ID \"%1$s\"."
+msgstr "Adresse de courriel incorrecte pour le type de media avec l’identifiant « %1$s »."
 
 #: app/controllers/CControllerPopupLldOperation.php:177
 #: app/controllers/CControllerPopupLldOperation.php:182
@@ -9486,28 +9475,28 @@ msgstr "Adresse e-mail incorrecte pour le type de media avec l'ID \"%1$s\"."
 #: items.php:558 items.php:563 items.php:576
 #, c-format
 msgid "Invalid interval \"%1$s\"."
-msgstr "Intervalle \"%1$s\" invalide."
+msgstr "Intervalle « %1$s » invalide."
 
 #: include/classes/api/services/CDiscoveryRule.php:62
 #, c-format
 msgid "Invalid key \"%1$s\" for discovery rule \"%2$s\" on \"%3$s\": %4$s."
-msgstr "Clé \"%1$s\" invalide pour la règle de découverte \"%2$s\" sur \"%3$s\" : %4$s."
+msgstr "Clef « %1$s » invalide pour la règle de découverte « %2$s » sur « %3$s » : %4$s."
 
 #: include/classes/api/services/CItem.php:63
 #, c-format
 msgid "Invalid key \"%1$s\" for item \"%2$s\" on \"%3$s\": %4$s."
-msgstr "Clé \"%1$s\" invalide pour l'élément \"%2$s\" sur \"%3$s\" : %4$s."
+msgstr "Clef « %1$s » invalide pour l’élément « %2$s » sur « %3$s » : %4$s."
 
 #: include/classes/api/services/CItemPrototype.php:52
 #, c-format
 msgid "Invalid key \"%1$s\" for item prototype \"%2$s\" on \"%3$s\": %4$s."
-msgstr "Clé \"%1$s\" invalide pour le prototype d'élément \"%2$s\" sur \"%3$s\" : %4$s."
+msgstr "Clef « %1$s » invalide pour le prototype d’élément « %2$s » sur « %3$s » : %4$s."
 
 #: app/controllers/CControllerPopupDiscoveryCheck.php:65
 #: include/classes/api/services/CDRule.php:563
 #, c-format
 msgid "Invalid key \"%1$s\": %2$s."
-msgstr "Clé \"%1$s\" invalide : %2$s."
+msgstr "Clef « %1$s » invalide : %2$s."
 
 #: include/classes/core/CJsonRpc.php:187
 msgid "Invalid method parameters."
@@ -9717,7 +9706,7 @@ msgstr "Paramètres de la méthode invalides."
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:499
 #, c-format
 msgid "Invalid parameter \"%1$s\": %2$s."
-msgstr "Paramètre \"%1$s\" invalide: %2$s."
+msgstr "Paramètre « %1$s » invalide : %2$s."
 
 #: include/classes/core/CJsonRpc.php:186
 msgid "Invalid params."
@@ -9725,12 +9714,12 @@ msgstr "Paramètres invalides."
 
 #: include/classes/core/CJsonRpc.php:176
 msgid "Invalid request."
-msgstr ""
+msgstr "Requête incorrecte."
 
 #: include/classes/api/services/CHttpTest.php:786
 #, c-format
 msgid "Invalid response code \"%1$s\"."
-msgstr "Code de réponse \"%1$s\" invalide."
+msgstr "Code de réponse « %1$s » invalide."
 
 #: include/classes/export/CConfigurationExportBuilder.php:86
 #: include/classes/export/CConfigurationExportBuilder.php:118
@@ -9795,7 +9784,7 @@ msgstr "Code de réponse \"%1$s\" invalide."
 #: include/classes/import/validators/CXmlValidator.php:64
 #, c-format
 msgid "Invalid tag \"%1$s\": %2$s."
-msgstr "Tag \"%1$s\" invalide : %2$s."
+msgstr "Étiquette « %1$s » invalide : %2$s."
 
 #: include/classes/validators/CActionCondValidator.php:103
 msgid "Invalid time period."
@@ -9804,7 +9793,7 @@ msgstr "Période de temps invalide."
 #: include/classes/validators/CApiInputValidator.php:2814
 #, c-format
 msgid "Invalid zoomparameter \"%1$s\": %2$s."
-msgstr ""
+msgstr "Paramètre d’agrandissement « %1$s » incorrect : %2$s."
 
 #: app/partials/configuration.host.edit.html.php:526
 #: app/views/popup.massupdate.host.php:295
@@ -9817,20 +9806,20 @@ msgstr "Inventaire"
 #: include/classes/api/services/CHost.php:1161
 #, c-format
 msgid "Inventory disabled for host \"%1$s\"."
-msgstr "Inventaire désactivé pour l'hôte \"%1$s\"."
+msgstr "Inventaire désactivé pour l’hôte « %1$s »."
 
 #: app/views/administration.iconmap.edit.php:58
 msgid "Inventory field"
-msgstr "Champ d'inventaire"
+msgstr "Champ d’inventaire"
 
 #: app/partials/popup.operations.php:225
 #: app/views/popup.massupdate.host.php:180
 msgid "Inventory mode"
-msgstr "Mode d'inventaire"
+msgstr "Mode d’inventaire"
 
 #: app/views/administration.user.list.php:111
 msgid "Is online?"
-msgstr "Est connecté ?"
+msgstr "Est connecté ?"
 
 #: app/partials/configuration.host.edit.html.php:492
 #: app/views/administration.proxy.edit.php:135
@@ -9866,28 +9855,28 @@ msgstr "Élément"
 #: include/classes/api/services/CItem.php:61
 #, c-format
 msgid "Item \"%1$s\" already exists on \"%2$s\", inherited from another template."
-msgstr "L'élément \"%1$s\" existe déjà sur \"%2$s\", hérité depuis un autre modèle."
+msgstr "L’élément « %1$s » existe déjà sur « %2$s », hérité depuis un autre modèle."
 
 #: include/classes/api/services/CItem.php:62
 #, c-format
 msgid "Item \"%1$s\" already exists on \"%2$s\"."
-msgstr "L'élément \"%1$s\" existe déjà sur \"%2$s\"."
+msgstr "L’élément « %1$s » existe déjà sur « %2$s »."
 
 #: include/items.inc.php:569
 #, c-format
 msgid "Item \"%1$s\" cannot be copied without its master item."
-msgstr "L'élément \"%1$s\" ne peut pas être copié sans son élément principal."
+msgstr "L’élément « %1$s » ne peut pas être copié sans son élément principal."
 
 #: include/classes/api/services/CItem.php:951
 #, c-format
 msgid "Item \"%1$s\" cannot populate a missing host inventory field number \"%2$d\". Choices are: from 0 (do not populate) to %3$d."
-msgstr "L'élément \"%1$s\" ne peut pas remplir le champ d'inventair numéro \"%2$d\" manquant. Les choix sont : de 0 (ne pas remplir) à %3$d."
+msgstr "L’élément « %1$s » ne peut pas remplir le champ d’inventair numéro « %2$d » manquant. Les choix sont : de 0 (ne pas remplir) à %3$d."
 
 #: include/classes/api/services/CDiscoveryRule.php:2280
 #: include/classes/api/services/CItemGeneral.php:2233
 #, c-format
 msgid "Item \"%1$s\" does not exist or you have no access to this item"
-msgstr "L’élément \"%1$s\" n'existe pas ou vous n'avez pas accès à cet élément"
+msgstr "L’élément « %1$s » n’existe pas ou vous n’avez pas accès à cet élément"
 
 #: items.php:931
 msgid "Item added"
@@ -9895,7 +9884,7 @@ msgstr "Élément ajouté"
 
 #: app/views/popup.itemtestedit.view.php:421
 msgid "Item contains user-defined macros with secret values. Values of these macros should be entered manually."
-msgstr ""
+msgstr "L’élément contient des macros d’utilisateur avec des valeurs secrètes. Les valeurs de ces macros devraient être saisies manuellement."
 
 #: items.php:1019
 msgid "Item copied"
@@ -9905,7 +9894,7 @@ msgstr[1] "Éléments copiés"
 
 #: app/views/administration.proxy.list.php:82
 msgid "Item count"
-msgstr "Nombre d'éléments"
+msgstr "Nombre d’éléments"
 
 #: items.php:516
 msgid "Item deleted"
@@ -9925,7 +9914,7 @@ msgstr[1] "Éléments activés"
 
 #: include/actions.inc.php:1265
 msgid "Item in \"not supported\" state"
-msgstr "Élément dans l'état \"non supporté\""
+msgstr "Élément dans l’état « non géré »"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1510
 msgid "Item not selected"
@@ -9934,7 +9923,7 @@ msgstr "Élément non sélectionné"
 #: include/classes/api/services/CItemGeneral.php:1254
 #, c-format
 msgid "Item pre-processing is missing parameters: %1$s"
-msgstr "Des paramètres manquent au prétraitement de l'élément: %1$s"
+msgstr "Des paramètres manquent au prétraitement de l’élément : %1$s"
 
 #: app/controllers/CControllerAuditLogList.php:227
 #: app/views/popup.lldoperation.php:51 app/views/popup.massupdate.item.php:492
@@ -9942,42 +9931,42 @@ msgstr "Des paramètres manquent au prétraitement de l'élément: %1$s"
 #: include/forms.inc.php:892
 #: include/views/js/configuration.host.discovery.edit.overr.js.php:165
 msgid "Item prototype"
-msgstr "Prototype de l'élément"
+msgstr "Prototype de l’élément"
 
 #: include/classes/api/services/CItemPrototype.php:50
 #, c-format
 msgid "Item prototype \"%1$s\" already exists on \"%2$s\", inherited from another template."
-msgstr "Le prototype d'élément \"%1$s\" existe déjà sur \"%2$s\", hérité d'un autre modèle."
+msgstr "Le prototype d’élément « %1$s » existe déjà sur « %2$s », hérité d’un autre modèle."
 
 #: include/classes/api/services/CItemGeneral.php:1041
 #, c-format
 msgid "Item prototype \"%1$s\" already exists on \"%2$s\", linked to another rule."
-msgstr "Le prototype d’élément \"%1$s\" existe déjà sur \"%2$s\", lié à une autre règle."
+msgstr "Le prototype d’élément « %1$s » existe déjà sur « %2$s », lié à une autre règle."
 
 #: include/classes/api/services/CItemPrototype.php:51
 #, c-format
 msgid "Item prototype \"%1$s\" already exists on \"%2$s\"."
-msgstr "Le prototype d'élément \"%1$s\" existe déjà sur \"%2$s\"."
+msgstr "Le prototype d’élément « %1$s » existe déjà sur « %2$s »."
 
 #: disc_prototypes.php:608
 msgid "Item prototype added"
-msgstr "Prototype d'élément ajouté"
+msgstr "Prototype d’élément ajouté"
 
 #: disc_prototypes.php:310
 msgid "Item prototype deleted"
-msgstr "Prototype d'élément supprimé"
+msgstr "Prototype d’élément supprimé"
 
 #: disc_prototypes.php:611 disc_prototypes.php:637 disc_prototypes.php:671
 msgid "Item prototype updated"
 msgid_plural "Item prototypes updated"
-msgstr[0] "Prototype d'élément mis à jour"
-msgstr[1] "Prototypes d'éléments mis à jour"
+msgstr[0] "Prototype d’élément mis à jour"
+msgstr[1] "Prototypes d’éléments mis à jour"
 
 #: include/classes/api/services/CDashboardGeneral.php:469
 #: include/classes/api/services/CDashboardGeneral.php:477
 #, c-format
 msgid "Item prototype with ID \"%1$s\" is not available."
-msgstr "Le prototype d'élément avec l'ID \"%1$s\" n'est pas disponible."
+msgstr "Le prototype d’élément avec l’ID « %1$s » n’est pas disponible."
 
 #: app/controllers/CControllerPopupGeneric.php:274
 #: app/controllers/CControllerPopupImportCompare.php:173
@@ -9986,23 +9975,23 @@ msgstr "Le prototype d'élément avec l'ID \"%1$s\" n'est pas disponible."
 #: include/views/configuration.item.prototype.edit.php:27
 #: include/views/configuration.item.prototype.list.php:27
 msgid "Item prototypes"
-msgstr "Prototypes d'éléments"
+msgstr "Prototypes d’éléments"
 
 #: disc_prototypes.php:651
 msgid "Item prototypes deleted"
-msgstr "Prototypes d'éléments supprimés"
+msgstr "Prototypes d’éléments supprimés"
 
 #: app/controllers/CControllerPopupMassupdateItem.php:375
 msgid "Item prototypes updated"
-msgstr "Prototypes d'élément mis à jour"
+msgstr "Prototypes d’élément mis à jour"
 
 #: app/partials/configuration.tags.tab.php:140
 msgid "Item tags"
-msgstr ""
+msgstr "Étiquettes d’élément"
 
 #: jsLoader.php:392
 msgid "Item type does not use interface"
-msgstr ""
+msgstr "Le type d’élément n’utilise pas l’interface"
 
 #: items.php:934
 msgid "Item updated"
@@ -10010,63 +9999,63 @@ msgstr "Élément mis à jour"
 
 #: include/classes/api/services/CItemGeneral.php:423
 msgid "Item uses host interface from non-parent host."
-msgstr "L'élément utilise une interface d'un hôte non-parent."
+msgstr "L’élément utilise une interface d’un hôte non‐parent."
 
 #: include/classes/api/services/CItemGeneral.php:426
 msgid "Item uses incorrect interface type."
-msgstr "L'élément utilise un type d'interface incorrect."
+msgstr "L’élément utilise un type d’interface incorrect."
 
 #: chart.php:101 chart.php:104
 msgid "Item values"
-msgstr "Valeurs de l'élément"
+msgstr "Valeurs de l’élément"
 
 #: include/items.inc.php:2114
 msgid "Item will not be refreshed. Please enter a correct update interval."
-msgstr "L'élément ne sera pas rafraichi. Veuillez saisir une période de mise à jour valide."
+msgstr "L’élément ne sera pas rafraichi. Veuillez saisir une période de mise à jour valide."
 
 #: include/items.inc.php:2101
 msgid "Item will not be refreshed. Specified update interval requires having at least one either flexible or scheduling interval."
-msgstr "L'élément ne sera pas rafraîchi. L'intervalle de mise à jour spécifié nécessite au moins un intervalle flexible ou planifié."
+msgstr "L’élément ne sera pas rafraîchi. L’intervalle de mise à jour spécifié nécessite au moins un intervalle flexible ou planifié."
 
 #: include/items.inc.php:2106
 msgid "Item will not be refreshed. Update interval should be between 1s and 1d. Also Scheduled/Flexible intervals can be used."
-msgstr "L'élément ne sera pas rafraîchi. L'intervalle de mise à jour devrait être entre 1s et 1d. Des intervalles planifiés/flexibles peuvent également être utilisés."
+msgstr "L’élément ne sera pas rafraîchi. L’intervalle de mise à jour devrait être entre 1s et 1d. Des intervalles planifiés/flexibles peuvent également être utilisés."
 
 #: include/classes/api/services/CDashboardGeneral.php:442
 #: include/classes/api/services/CDashboardGeneral.php:449
 #, c-format
 msgid "Item with ID \"%1$s\" is not available."
-msgstr "L’élément avec l'ID \"%1$s\" n'est pas disponible."
+msgstr "L’élément avec l’ID « %1$s » n’est pas disponible."
 
 #: include/classes/api/services/CItemGeneral.php:702
 #, c-format
 msgid "Item with key \"%1$s\" already exists on \"%2$s\" as a discovery rule."
-msgstr "Un élément avec la clé \"%1$s\" existe déjà sur \"%2$s\" comme règle de découverte."
+msgstr "Un élément avec la clef « %1$s » existe déjà sur « %2$s » comme règle de découverte."
 
 #: include/classes/api/services/CItemGeneral.php:708
 #, c-format
 msgid "Item with key \"%1$s\" already exists on \"%2$s\" as an item created from item prototype."
-msgstr "Un élément avec la clé \"%1$s\" existe déjà sur \"%2$s\" comme élément créé d'un prototype d'élément."
+msgstr "Un élément avec la clef « %1$s » existe déjà sur « %2$s » comme élément créé d’un prototype d’élément."
 
 #: include/classes/api/services/CItemGeneral.php:705
 #, c-format
 msgid "Item with key \"%1$s\" already exists on \"%2$s\" as an item prototype."
-msgstr "Un élément avec la clé \"%1$s\" existe déjà sur \"%2$s\" comme prototype d'élément."
+msgstr "Un élément avec la clef « %1$s » existe déjà sur « %2$s » comme prototype d’élément."
 
 #: include/classes/api/services/CItemGeneral.php:699
 #, c-format
 msgid "Item with key \"%1$s\" already exists on \"%2$s\" as an item."
-msgstr "Un élément avec la clé \"%1$s\" existe déjà sur \"%2$s\" comme élément."
+msgstr "Un élément avec la clef « %1$s » existe déjà sur « %2$s » comme élément."
 
 #: include/classes/api/services/CItemGeneral.php:711
 #, c-format
 msgid "Item with key \"%1$s\" already exists on \"%2$s\" as unknown item element."
-msgstr "Un élément avec la clé \"%1$s\" existe déjà sur \"%2$s\" comme élément inconnu."
+msgstr "Un élément avec la clef « %1$s » existe déjà sur « %2$s » comme élément inconnu."
 
 #: include/classes/api/services/CItemGeneral.php:2024
 #, c-format
 msgid "Item with key \"%1$s\" already exists on \"%2$s\"."
-msgstr "Un élément avec la clé \"%1$s\" existe déjà sur \"%2$s\"."
+msgstr "Un élément avec la clef « %1$s » existe déjà sur « %2$s »."
 
 #: app/controllers/CControllerPopupGeneric.php:223
 #: app/controllers/CControllerPopupImportCompare.php:168
@@ -10094,7 +10083,7 @@ msgstr "Éléments supprimés"
 
 #: include/views/monitoring.history.php:145
 msgid "Items list"
-msgstr "Liste d'éléments"
+msgstr "Liste d’éléments"
 
 #: include/classes/widgets/forms/CWidgetFormPlainText.php:41
 msgid "Items location"
@@ -10113,7 +10102,7 @@ msgstr "JMX"
 
 #: include/items.inc.php:99
 msgid "JMX agent"
-msgstr "agent JMX"
+msgstr "Agent JMX"
 
 #: app/views/popup.massupdate.item.php:79
 #: include/views/configuration.host.discovery.edit.php:559
@@ -10128,11 +10117,11 @@ msgstr "Interfaces JMX"
 
 #: include/classes/html/CButtonExport.php:75
 msgid "JSON"
-msgstr ""
+msgstr "JSON"
 
 #: include/classes/mvc/CController.php:231
 msgid "JSON array input is expected."
-msgstr ""
+msgstr "Une entrée de tableau JSON est attendue."
 
 #: app/views/popup.massupdate.item.php:95
 #: include/views/configuration.host.discovery.edit.php:285
@@ -10144,7 +10133,7 @@ msgstr "Données JSON"
 #: include/classes/api/services/CItemGeneral.php:2617
 #: include/classes/api/services/CItemGeneral.php:2646
 msgid "JSON is expected"
-msgstr ""
+msgstr "Un objet JSON est attendu"
 
 #: include/classes/validators/CNewValidator.php:113
 msgid "JSON string is expected"
@@ -10153,7 +10142,7 @@ msgstr "Une chaîne JSON est attendue"
 #: include/classes/core/CJsonRpc.php:146
 #, c-format
 msgid "JSON-RPC error generation failed. No such error \"%1$s\"."
-msgstr ""
+msgstr "Échec de la génération d’erreur JSON-RPC. Aucune erreur de ce type « %1$s »."
 
 #: include/items.inc.php:1827
 #: include/views/configuration.host.discovery.edit.php:838
@@ -10162,11 +10151,11 @@ msgstr "JSONPath"
 
 #: include/func.inc.php:220
 msgid "Jan"
-msgstr "Jan"
+msgstr "janv."
 
 #: include/func.inc.php:100 include/func.inc.php:237 jsLoader.php:231
 msgid "January"
-msgstr "Janvier"
+msgstr "janvier"
 
 #: include/locales.inc.php:63
 msgid "Japanese (ja_JP)"
@@ -10184,19 +10173,19 @@ msgstr "JavaScript"
 
 #: include/func.inc.php:226
 msgid "Jul"
-msgstr "Juil"
+msgstr "juill."
 
 #: include/func.inc.php:106 include/func.inc.php:243 jsLoader.php:237
 msgid "July"
-msgstr "Juillet"
+msgstr "juillet"
 
 #: include/func.inc.php:225
 msgid "Jun"
-msgstr "Juin"
+msgstr "juin"
 
 #: include/func.inc.php:105 include/func.inc.php:242 jsLoader.php:236
 msgid "June"
-msgstr "Juin"
+msgstr "juin"
 
 #: include/views/configuration.host.discovery.edit.php:682
 #: include/views/configuration.host.discovery.list.php:143
@@ -10205,15 +10194,14 @@ msgstr "Période de conservation des ressources perdues"
 
 #: include/httptest.inc.php:30
 msgid "Kerberos"
-msgstr ""
+msgstr "Kerberos"
 
 #: app/controllers/CControllerPopupGeneric.php:232
 #: app/controllers/CControllerPopupGeneric.php:243
 #: app/controllers/CControllerPopupGeneric.php:283
 #: app/partials/configuration.filter.items.php:94
 #: app/views/popup.discovery.check.php:62 disc_prototypes.php:46
-#: host_discovery.php:50
-#: include/views/configuration.host.discovery.edit.php:80
+#: host_discovery.php:50 include/views/configuration.host.discovery.edit.php:80
 #: include/views/configuration.host.discovery.list.php:103
 #: include/views/configuration.host.discovery.list.php:198
 #: include/views/configuration.item.edit.php:132
@@ -10221,16 +10209,16 @@ msgstr ""
 #: include/views/configuration.item.prototype.edit.php:117
 #: include/views/configuration.item.prototype.list.php:60 items.php:49
 msgid "Key"
-msgstr "Clé"
+msgstr "Clef"
 
 #: app/views/administration.script.edit.php:158
 #: include/views/js/common.item.edit.js.php:56
 msgid "Key passphrase"
-msgstr "Phrase de passe de la clé"
+msgstr "Phrase de passe de la clef"
 
 #: app/views/popup.triggerwizard.php:120
 msgid "Keyword"
-msgstr "Mot-clé"
+msgstr "Mot‐clef"
 
 #: include/html.inc.php:171
 msgid "Kiosk mode"
@@ -10255,7 +10243,7 @@ msgstr "Hôte LDAP"
 
 #: app/controllers/CControllerAuthenticationUpdate.php:104
 msgid "LDAP is not configured"
-msgstr "LDAP n'est pas configuré"
+msgstr "LDAP n’est pas configuré"
 
 #: app/controllers/CControllerAuthenticationUpdate.php:271
 msgid "LDAP login successful"
@@ -10267,16 +10255,16 @@ msgstr "Paramètres LDAP"
 
 #: app/views/popup.itemtestedit.view.php:299
 msgid "LF"
-msgstr ""
+msgstr "LF"
 
 #: include/views/configuration.host.discovery.edit.php:838
 msgid "LLD macro"
-msgstr "marco LLD"
+msgstr "Macro LLD"
 
 #: include/views/configuration.host.discovery.edit.php:897
 #: include/views/configuration.host.discovery.edit.php:950
 msgid "LLD macros"
-msgstr "macros LLD"
+msgstr "Macros LLD"
 
 #: app/partials/popup.operations.php:257
 #: app/views/configuration.correlation.edit.php:57
@@ -10292,7 +10280,7 @@ msgstr "Étiquette"
 #: include/views/js/monitoring.sysmaps.js.php:141
 #: include/views/js/monitoring.sysmaps.js.php:656
 msgid "Label location"
-msgstr "Positionnement de l'étiquette"
+msgstr "Positionnement de l’étiquette"
 
 #: app/views/administration.user.edit.php:247
 msgid "Language"
@@ -10301,7 +10289,7 @@ msgstr "Langue"
 #: include/classes/api/services/CUser.php:775
 #, c-format
 msgid "Language \"%1$s\" is not supported."
-msgstr ""
+msgstr "La langue « %1$s » n’est pas prise en charge."
 
 #: include/classes/helpers/CPagerHelper.php:232
 msgctxt "page navigation"
@@ -10352,12 +10340,12 @@ msgstr[1] "%1$d dernières années"
 
 #: app/partials/administration.ha.nodes.php:28
 msgid "Last access"
-msgstr ""
+msgstr "Dernier accès"
 
 #: app/views/administration.token.list.php:143
 #: app/views/administration.user.token.list.php:99
 msgid "Last accessed at"
-msgstr ""
+msgstr "Dernier accès à"
 
 #: app/partials/monitoring.latest.view.html.php:55
 #: app/partials/monitoring.latest.view.html.php:68
@@ -10378,7 +10366,7 @@ msgstr "Graphique du dernier mois"
 #: app/views/administration.user.list.php:70
 #: app/views/administration.user.list.php:108
 msgid "Last name"
-msgstr ""
+msgstr "Nom"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:62
 #: app/controllers/CControllerPopupTriggerExpr.php:76
@@ -10400,7 +10388,7 @@ msgstr "Dernière observation (âge)"
 
 #: app/partials/scheduledreport.table.html.php:43
 msgid "Last sent"
-msgstr ""
+msgstr "Dernier envoi"
 
 #: app/partials/monitoring.latest.view.html.php:56
 #: app/partials/monitoring.latest.view.html.php:69
@@ -10435,7 +10423,7 @@ msgstr "Letton (lv_LV)"
 #: include/classes/widgets/forms/CWidgetFormHostAvail.php:48
 #: include/classes/widgets/forms/CWidgetFormProblemsBySv.php:121
 msgid "Layout"
-msgstr ""
+msgstr "Disposition"
 
 #: include/classes/widgets/CWidgetHelper.php:782
 #: include/classes/widgets/CWidgetHelper.php:857
@@ -10470,15 +10458,15 @@ msgstr "Légende"
 #: app/controllers/CControllerPopupTriggerExpr.php:642
 #: app/controllers/CControllerPopupTriggerExpr.php:760
 msgid "Length"
-msgstr ""
+msgstr "Longueur"
 
 #: setup.php:195
 msgid "Licensed under"
-msgstr ""
+msgstr "Sous licence"
 
 #: app/views/administration.gui.edit.php:90
 msgid "Limit for search and filter results"
-msgstr "Limite d'éléments recherchés/filtrés"
+msgstr "Limite d’éléments recherchés/filtrés"
 
 #: include/classes/widgets/CWidgetHelper.php:770
 #: include/classes/widgets/CWidgetHelper.php:813
@@ -10492,7 +10480,7 @@ msgstr "Ligne"
 
 #: include/views/js/monitoring.sysmaps.js.php:597
 msgid "Line color"
-msgstr ""
+msgstr "Couleur de la ligne"
 
 #: include/views/js/monitoring.sysmaps.js.php:575
 msgid "Line type"
@@ -10512,13 +10500,13 @@ msgstr "Lien"
 #: include/classes/api/services/CMap.php:1476
 #, c-format
 msgid "Link \"selementid1\" field is pointing to a nonexistent map selement ID \"%1$s\" for map \"%2$s\"."
-msgstr ""
+msgstr "Le champ du lien « selementid1 » pointe vers un identifiant de carte selement « %1$s »  inexistant sur la carte « %2$s »."
 
 #: include/classes/api/services/CMap.php:1014
 #: include/classes/api/services/CMap.php:1484
 #, c-format
 msgid "Link \"selementid2\" field is pointing to a nonexistent map selement ID \"%1$s\" for map \"%2$s\"."
-msgstr ""
+msgstr "Le champ du lien « selementid2 » pointe vers un identifiant de carte selement « %1$s »  inexistant sur la carte « %2$s »."
 
 #: include/views/js/monitoring.sysmaps.js.php:737
 #: include/views/js/monitoring.sysmaps.js.php:748
@@ -10551,7 +10539,7 @@ msgstr "Modèles liés"
 
 #: include/views/configuration.template.list.php:125
 msgid "Linked to templates"
-msgstr ""
+msgstr "Lié aux nouveaux modèles"
 
 #: include/views/js/monitoring.sysmaps.js.php:734
 #: include/views/js/monitoring.sysmaps.js.php:745
@@ -10564,40 +10552,40 @@ msgstr "La liste est vide"
 
 #: include/classes/data/CItemData.php:1148
 msgid "List of block devices and their type. Returns JSON"
-msgstr ""
+msgstr "Liste des périphériques de type bloc et de leurs types. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1056
 msgid "List of detected CPUs/CPU cores. Returns JSON"
-msgstr ""
+msgstr "Liste des processeurs et des cœurs de processeurs. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1164
 msgid "List of directory entries, recursively. Returns JSON"
-msgstr ""
+msgstr "Liste récursive des entrées du répertoire. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1216
 msgid "List of mounted filesystems and their types. Returns JSON"
-msgstr ""
+msgstr "Liste des systèmes de fichiers montés et de leurs types. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1220
 msgid "List of mounted filesystems, their types, disk space and inode statistics. Returns JSON"
-msgstr ""
+msgstr "Liste des systèmes de fichiers montés, de leurs types, de leurs occupations et statistiques d’i‑nœuds. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:944
 msgid "List of network interfaces. Returns JSON"
-msgstr ""
+msgstr "Liste des interfaces réseau. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1012
 msgid "List of object instances of Windows performance counters, discovered using object names in English. Returns JSON"
-msgstr ""
+msgstr "Liste des instances d’objet des compteurs de performance Windows, découverts via les noms d’objets en anglais. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1008
 msgid "List of object instances of Windows performance counters. Returns JSON"
-msgstr ""
+msgstr "Liste des instances d’objet des compteurs de performance Windows. Retourne un objet JSON"
 
 #: app/views/popup.dashboard.share.edit.php:129
 #: include/views/monitoring.sysmap.edit.php:402
 msgid "List of user group shares"
-msgstr "Liste de partages pour les groupes d'utilisateurs"
+msgstr "Liste de partages pour les groupes d’utilisateurs"
 
 #: app/views/popup.dashboard.share.edit.php:134
 #: include/views/monitoring.sysmap.edit.php:407
@@ -10618,7 +10606,7 @@ msgstr "Liste des paquets installés. Retourne du texte"
 
 #: include/classes/data/CItemData.php:1040
 msgid "Listing of services. Returns 0 - if empty; text - list of services separated by a newline"
-msgstr "Liste des services. Retourne 0 - si vide ; texte - liste des services séparés par un changement de ligne"
+msgstr "Liste des services. Retourne 0 — si vide ; texte — liste des services séparés par un changement de ligne"
 
 #: include/locales.inc.php:65
 msgid "Lithuanian (lt_LT)"
@@ -10626,11 +10614,11 @@ msgstr "Lituanien (lt_LT)"
 
 #: include/classes/data/CItemData.php:1596
 msgid "Loading time of full web page (in seconds). Returns float"
-msgstr "Temps de chargement de la page web complète (en secondes). Retourne un flottant"
+msgstr "Temps de chargement de la page Web complète (en secondes). Retourne un flottant"
 
 #: include/classes/mvc/CControllerResponse.php:42
 msgid "Loading..."
-msgstr ""
+msgstr "Chargement en cours…"
 
 #: app/controllers/CControllerWidgetClockView.php:123
 msgid "Local"
@@ -10648,11 +10636,11 @@ msgstr "Emplacement"
 
 #: include/hosts.inc.php:219
 msgid "Location latitude"
-msgstr "Latitude de l'emplacement"
+msgstr "Latitude de l’emplacement"
 
 #: include/hosts.inc.php:224
 msgid "Location longitude"
-msgstr "Longitude de l'emplacement"
+msgstr "Longitude de l’emplacement"
 
 #: app/partials/configuration.filter.items.php:140
 #: app/views/popup.massupdate.item.php:159 include/items.inc.php:129
@@ -10663,17 +10651,17 @@ msgstr "Journal"
 
 #: include/classes/data/CItemData.php:920
 msgid "Log file monitoring with log rotation support. Returns log"
-msgstr "Supervision d'un fichier de log avec support de la rotation. Retourne un log"
+msgstr "Supervision d’un fichier de log avec gestion de la rotation. Retourne un journal"
 
 #: include/classes/data/CItemData.php:912
 msgid "Log file monitoring. Returns log"
-msgstr "Supervision d'un fichier de log. Retourne un log"
+msgstr "Supervision d’un fichier de log. Retourne un log"
 
 #: app/views/popup.massupdate.item.php:344
 #: include/views/configuration.item.edit.php:875
 #: include/views/configuration.item.prototype.edit.php:792
 msgid "Log time format"
-msgstr "Format de l'horodatage du journal"
+msgstr "Format de l’horodatage du journal"
 
 #: app/views/administration.miscconfig.edit.php:81
 msgid "Log unmatched SNMP traps"
@@ -10688,11 +10676,11 @@ msgstr "Connexion"
 
 #: app/views/administration.miscconfig.edit.php:87
 msgid "Login attempts"
-msgstr ""
+msgstr "Tentatives de connexion"
 
 #: app/views/administration.miscconfig.edit.php:93
 msgid "Login blocking interval"
-msgstr ""
+msgstr "Durée du blocage de l’authentification"
 
 #: include/classes/validators/CLdapAuthValidator.php:87
 msgid "Login name or password is incorrect."
@@ -10704,11 +10692,11 @@ msgstr "Déconnexion"
 
 #: app/views/administration.authentication.edit.php:287
 msgid "Logout requests"
-msgstr ""
+msgstr "Requêtes de déconnexion"
 
 #: app/views/administration.authentication.edit.php:293
 msgid "Logout responses"
-msgstr ""
+msgstr "Réponses de déconnexion"
 
 #: include/discovery.inc.php:139
 msgid "Lost"
@@ -10716,7 +10704,7 @@ msgstr "Perdu"
 
 #: include/actions.inc.php:1266
 msgid "Low-level discovery rule in \"not supported\" state"
-msgstr "Règle de découverte bas niveau dans l'état \"non supportée\""
+msgstr "Règle de découverte bas niveau dans l’état « non gérée »"
 
 #: include/classes/graphdraw/CLineGraphDraw.php:966
 msgid "M"
@@ -10741,7 +10729,7 @@ msgstr "MD2"
 
 #: include/classes/data/CItemData.php:1188
 msgid "MD5 checksum of file. Returns character string (MD5 hash of the file)"
-msgstr "Checksum MD5 d'un fichier. Retourne une chaîne de caractères (le hash MD5 du fichier)"
+msgstr "Checksum MD5 d’un fichier. Retourne une chaîne de caractères (le hash MD5 du fichier)"
 
 #: app/controllers/CControllerAuditLogList.php:228
 #: app/partials/hostmacros.inherited.list.html.php:48
@@ -10757,12 +10745,12 @@ msgstr "Macro"
 #: include/classes/api/services/CUserMacro.php:655
 #, c-format
 msgid "Macro \"%1$s\" already exists on \"%2$s\"."
-msgstr "La macro \"%1$s\" existe déjà sur \"%2$s\"."
+msgstr "La macro « %1$s » existe déjà sur « %2$s »."
 
 #: include/classes/api/services/CUserMacro.php:411
 #, c-format
 msgid "Macro \"%1$s\" already exists."
-msgstr "La macro \"%1$s\" existe déjà."
+msgstr "La macro « %1$s » existe déjà."
 
 #: app/partials/configuration.host.edit.html.php:525
 #: app/partials/massupdate.macros.tab.php:120
@@ -10806,16 +10794,16 @@ msgstr "Maintenance"
 #: include/classes/api/services/CMaintenance.php:742
 #, c-format
 msgid "Maintenance \"%1$s\" already exists."
-msgstr "La maintenance \"%1$s\" existe déjà."
+msgstr "La maintenance « %1$s » existe déjà."
 
 #: include/classes/api/services/CMaintenance.php:373
 #, c-format
 msgid "Maintenance \"%1$s\" value cannot be bigger than \"%2$s\"."
-msgstr ""
+msgstr "La valeur de maintenance « %1$s » ne peut être supérieure à « %2$s »."
 
 #: include/classes/api/services/CMaintenance.php:628
 msgid "Maintenance \"Active since\" value cannot be bigger than \"Active till\"."
-msgstr "La valeur \"Active depuis\" de la maintenance ne peut pas être ultérieure à la valeur \"Active jusqu'à\"."
+msgstr "La valeur « Active depuis » de la maintenance ne peut pas être ultérieure à la valeur « Active jusqu’à »."
 
 #: maintenance.php:122
 msgid "Maintenance added"
@@ -10857,26 +10845,26 @@ msgstr "Maintenance sans collecte de données"
 #: include/html.inc.php:977
 #, c-format
 msgid "Maintenance: %1$s"
-msgstr "Maintenance: %1$s"
+msgstr "Maintenance : %1$s"
 
 #: app/views/administration.token.view.php:42
 #: app/views/administration.user.token.view.php:41
 msgid "Make sure to copy the auth token as you won't be able to view it after the page is closed."
-msgstr ""
+msgstr "Assurez‐vous de copier le jeton d’authentification car vous ne pourrez plus le visualiser après la fermeture de la page."
 
 #: include/classes/helpers/CRoleHelper.php:423
 msgid "Manage API tokens"
-msgstr ""
+msgstr "Gérer les jetons de connexion"
 
 #: include/classes/helpers/CRoleHelper.php:427
 msgid "Manage scheduled reports"
-msgstr ""
+msgstr "Gérer de rapports planifiés"
 
 #: app/partials/configuration.host.edit.html.php:359
 #: app/partials/popup.operations.php:227
 #: app/views/administration.miscconfig.edit.php:60
-#: app/views/popup.lldoperation.php:281
-#: app/views/popup.massupdate.host.php:184 include/hosts.inc.php:1127
+#: app/views/popup.lldoperation.php:281 app/views/popup.massupdate.host.php:184
+#: include/hosts.inc.php:1127
 #: include/views/configuration.host.prototype.edit.php:361
 msgid "Manual"
 msgstr "Manuel"
@@ -10885,13 +10873,13 @@ msgstr "Manuel"
 #: app/views/administration.script.list.php:53
 #: app/views/administration.script.list.php:130
 msgid "Manual event action"
-msgstr ""
+msgstr "Action d’événement manuelle"
 
 #: app/views/administration.script.edit.php:101
 #: app/views/administration.script.list.php:52
 #: app/views/administration.script.list.php:126
 msgid "Manual host action"
-msgstr ""
+msgstr "Action manuelle de l’hôte"
 
 #: include/actions.inc.php:2070
 msgid "Manually closed"
@@ -10911,7 +10899,7 @@ msgstr "Carte"
 #: include/classes/api/services/CMap.php:1092
 #, c-format
 msgid "Map \"%1$s\" already exists."
-msgstr "La carte \"%1$s existe déjà\"."
+msgstr "La carte « %1$s existe déjà »."
 
 #: include/classes/api/services/CMap.php:737
 #: include/classes/api/services/CMap.php:812
@@ -10919,7 +10907,7 @@ msgstr "La carte \"%1$s existe déjà\"."
 #: include/classes/api/services/CMap.php:1279
 #, c-format
 msgid "Map \"%1$s\" is public and read-only sharing is disallowed."
-msgstr "La carte \"%1$s\" est publique et le partage en lecture seule est interdit."
+msgstr "La carte « %1$s » est publique et le partage en lecture seule est interdit."
 
 #: include/views/js/monitoring.sysmaps.js.php:77
 #: include/views/monitoring.sysmap.constructor.php:31
@@ -10932,23 +10920,23 @@ msgstr "Élément de carte"
 #: include/classes/api/services/CMapElement.php:154
 #, c-format
 msgid "Map element is missing parameters: %1$s"
-msgstr "Un paramètre manque à l'élément de carte: %1$s"
+msgstr "Un paramètre manque à l’élément de carte : %1$s"
 
 #: include/views/monitoring.sysmap.edit.php:243
 msgid "Map element label location"
-msgstr "Emplacement de l'étiquette de l'élément de carte"
+msgstr "Emplacement de l’étiquette de l’élément de carte"
 
 #: include/views/monitoring.sysmap.edit.php:234
 msgid "Map element label type"
-msgstr "Type d'étiquette de l'élément de carte"
+msgstr "Type d’étiquette de l’élément de carte"
 
 #: sysmap.php:131
 msgid "Map is updated! Return to map list?"
-msgstr ""
+msgstr "La carte a été mise à jour ! Voulez‐vous retourner à la liste des cartes ?"
 
 #: include/views/monitoring.sysmap.edit.php:206
 msgid "Map label type"
-msgstr "Type d'étiquette de carte"
+msgstr "Type d’étiquette de carte"
 
 #: include/classes/api/services/CMap.php:1062
 msgid "Map name cannot be empty."
@@ -10975,7 +10963,7 @@ msgstr "La mise à jour de la carte a échoué."
 #: include/classes/api/services/CDashboardGeneral.php:589
 #, c-format
 msgid "Map with ID \"%1$s\" is not available."
-msgstr "La carte avec l'ID \"%1$s\" n'est pas disponible."
+msgstr "La carte avec l’ID « %1$s » n’est pas disponible."
 
 #: app/controllers/CControllerPopupValueMapUpdate.php:94
 #: app/views/popup.valuemap.edit.php:51
@@ -10984,7 +10972,7 @@ msgstr "Correspond à"
 
 #: app/controllers/CControllerPopupGeneric.php:366
 msgid "Mapping"
-msgstr ""
+msgstr "Correspondance"
 
 #: app/controllers/CControllerPopupValueMapUpdate.php:148
 #: app/views/administration.iconmap.edit.php:124
@@ -11002,15 +10990,15 @@ msgstr "Cartes"
 
 #: include/func.inc.php:222
 msgid "Mar"
-msgstr "Mar"
+msgstr "mars"
 
 #: include/func.inc.php:102 include/func.inc.php:239 jsLoader.php:233
 msgid "March"
-msgstr "Mars"
+msgstr "mars"
 
 #: include/views/monitoring.sysmap.edit.php:146
 msgid "Mark elements on trigger status change"
-msgstr "Marquer les éléments lors de changement de l'état du déclencheur"
+msgstr "Marquer les éléments lors de changement de l’état du déclencheur"
 
 #: include/views/monitoring.history.php:176
 msgid "Mark others"
@@ -11060,11 +11048,11 @@ msgstr "Élément maître"
 
 #: include/items.inc.php:1871
 msgid "Matches regular expression"
-msgstr "Correspond à l'expression régulière"
+msgstr "Correspond à l’expression rationnelle"
 
 #: app/views/popup.triggerexpr.php:112
 msgid "Mathematical functions"
-msgstr ""
+msgstr "Fonctions mathématiques"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:364
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:134
@@ -11078,36 +11066,36 @@ msgstr "Max"
 
 #: app/views/administration.gui.edit.php:102
 msgid "Max count of elements to show inside table cell"
-msgstr "Nombre maximal d'éléments affichés dans une cellule"
+msgstr "Nombre maximal d’éléments affichés dans une cellule"
 
 #: app/views/administration.gui.edit.php:123
 msgid "Max history display period"
-msgstr ""
+msgstr "Durée d’affichage maximale de l’historique"
 
 #: app/views/administration.gui.edit.php:96
 msgid "Max number of columns and rows in overview tables"
-msgstr ""
+msgstr "Nombre maximum de colonnes et de lignes dans les tableaux des aperçus"
 
 #: app/views/administration.gui.edit.php:135
 msgid "Max period for time selector"
-msgstr ""
+msgstr "Durée maximale du sélecteur de temps"
 
 #: app/views/administration.geomaps.edit.php:98
 msgid "Max zoom level"
-msgstr ""
+msgstr "Agrandissement max"
 
 #: include/classes/data/CItemData.php:896
 msgid "Maximum number of opened files supported by OS. Returns integer"
-msgstr "Nombre maximal de fichiers ouverts supporté par le SE. Retourne un entier"
+msgstr "Nombre maximal de fichiers ouverts pris en charge par le SE. Retourne un entier"
 
 #: include/classes/data/CItemData.php:900
 msgid "Maximum number of processes supported by OS. Returns integer"
-msgstr "Nombre maximal de processus supporté par le SE. Retourne un entier"
+msgstr "Nombre maximal de processus pris en charge par le SE. Retourne un entier"
 
 #: app/partials/administration.system.info.php:150
 #, c-format
 msgid "Maximum required %1$s database version is %2$s."
-msgstr ""
+msgstr "La version maximum prise en charge pour la base de données %1$s est la %2$s."
 
 #: app/controllers/CControllerTimeSelectorUpdate.php:249
 #: include/classes/mvc/CController.php:312
@@ -11122,20 +11110,20 @@ msgstr[1] "La période maximale à afficher est %1$s jours."
 #: include/classes/api/services/CUser.php:941
 #, c-format
 msgid "Maximum total length of email address exceeded for media type with ID \"%1$s\"."
-msgstr "Longueur totale maximale de l'adresse e-mail dépassée pour le type de media avec l'ID \"%1$s\"."
+msgstr "Longueur totale maximale de l’adresse de courreil dépassée pour le type de media avec l’identifiant « %1$s »."
 
 #: app/views/administration.geomaps.edit.php:61
 msgid "Maximum zoom level of the map."
-msgstr ""
+msgstr "Agrandissement maximum de la carte."
 
 #: include/func.inc.php:104 include/func.inc.php:241 jsLoader.php:235
 msgid "May"
-msgstr "Mai"
+msgstr "mai"
 
 #: include/func.inc.php:224
 msgctxt "May short"
 msgid "May"
-msgstr "Mai"
+msgstr "mai"
 
 #: app/controllers/CControllerPopupMedia.php:167
 #: app/views/administration.user.edit.php:367
@@ -11151,7 +11139,7 @@ msgstr "Type de média"
 #: include/classes/api/services/CMediatype.php:408
 #, c-format
 msgid "Media type \"%1$s\" already exists."
-msgstr "Le type de média \"%1$s\" existe déjà."
+msgstr "Le type de média « %1$s » existe déjà."
 
 #: app/controllers/CControllerMediatypeCreate.php:158
 msgid "Media type added"
@@ -11182,7 +11170,7 @@ msgstr "Le test du type de média a échoué."
 
 #: app/views/js/popup.mediatypetest.edit.js.php:108
 msgid "Media type test log"
-msgstr ""
+msgstr "Journal du test du type de média"
 
 #: app/controllers/CControllerPopupMediatypeTestSend.php:142
 msgid "Media type test successful."
@@ -11195,11 +11183,11 @@ msgstr "Type de média mis à jour"
 #: include/classes/api/services/CUser.php:865
 #, c-format
 msgid "Media type with ID \"%1$s\" is not available."
-msgstr "Le type de média avec l'IS \"%1$s\" n'est pas disponible."
+msgstr "Le type de média avec l’IS « %1$s » n’est pas disponible."
 
 #: app/views/administration.mediatype.edit.php:30
-#: app/views/administration.mediatype.list.php:31
-#: app/views/popup.import.php:45 include/classes/helpers/CMenuHelper.php:283
+#: app/views/administration.mediatype.list.php:31 app/views/popup.import.php:45
+#: include/classes/helpers/CMenuHelper.php:283
 #: include/classes/helpers/CRoleHelper.php:385
 msgid "Media types"
 msgstr "Types de média"
@@ -11207,7 +11195,7 @@ msgstr "Types de média"
 #: include/classes/api/services/CMediatype.php:827
 #, c-format
 msgid "Media types used by action \"%1$s\"."
-msgstr ""
+msgstr "Types de média utilisés par l’action « %1$s »."
 
 #: app/views/administration.usergroup.list.php:75
 #: include/views/configuration.hostgroups.list.php:69
@@ -11217,11 +11205,11 @@ msgstr "Membres"
 #: include/classes/debug/CProfiler.php:165
 #, c-format
 msgid "Memory limit: %1$s"
-msgstr "Limite mémoire: %1$s"
+msgstr "Limite mémoire : %1$s"
 
 #: include/classes/data/CItemData.php:1232
 msgid "Memory size in bytes or in percentage from total. Returns integer for bytes; float for percentage"
-msgstr "Taille de la mémoire en octets ou en pourcentage du total. Retourne un entier pour les octets ; un flottant pour le pourcentage"
+msgstr "Taille de la mémoire en octets ou en pourcentage du total. Retourne un entier pour les octets ; un flottant pour le pourcentage"
 
 #: include/classes/data/CItemData.php:1020
 msgid "Memory used by process in bytes. Returns integer"
@@ -11229,15 +11217,15 @@ msgstr "Mémoire utilisée par un processeur en octets. Retourne un entier"
 
 #: app/views/administration.mediatype.edit.php:255
 msgid "Menu entry URL"
-msgstr ""
+msgstr "URL de l’élément de menu"
 
 #: app/views/administration.mediatype.edit.php:246
 msgid "Menu entry name"
-msgstr ""
+msgstr "Nom de l’élément de menu"
 
 #: app/views/administration.script.edit.php:106
 msgid "Menu path"
-msgstr ""
+msgstr "Chemin de menu"
 
 #: app/partials/popup.operations.php:160
 #: app/partials/scheduledreport.formgrid.html.php:178
@@ -11257,11 +11245,11 @@ msgstr "Format du message"
 
 #: app/controllers/CControllerPopupMediatypeMessage.php:98
 msgid "Message template"
-msgstr ""
+msgstr "Modèle de message"
 
 #: app/views/administration.mediatype.edit.php:297
 msgid "Message templates"
-msgstr ""
+msgstr "Modèles de message"
 
 #: app/views/administration.user.edit.php:660
 #: app/views/administration.user.edit.php:672
@@ -11271,7 +11259,7 @@ msgstr "Expiration du message"
 #: app/views/administration.mediatype.edit.php:279
 #: app/views/popup.mediatype.message.php:44
 msgid "Message type"
-msgstr ""
+msgstr "Type de message"
 
 #: include/actions.inc.php:1827 include/actions.inc.php:1921
 msgid "Message/Command"
@@ -11292,7 +11280,7 @@ msgstr "Méthode pas trouvée."
 
 #: include/httptest.inc.php:399
 msgid "Microsoft Edge"
-msgstr ""
+msgstr "Microsoft Edge"
 
 #: include/views/js/monitoring.sysmaps.js.php:41
 msgid "Middle"
@@ -11308,42 +11296,42 @@ msgstr "Min"
 
 #: app/views/administration.authentication.edit.php:39
 msgid "Minimum password length"
-msgstr ""
+msgstr "Longueur minimum"
 
 #: app/partials/administration.system.info.php:144
 #, c-format
 msgid "Minimum required %1$s database version is %2$s."
-msgstr ""
+msgstr "La version minimum requise pour la base de données %1$s est %2$s."
 
 #: include/classes/setup/CFrontendSetup.php:124
 #, c-format
 msgid "Minimum required PHP memory limit is %1$s (configuration option \"memory_limit\")."
-msgstr ""
+msgstr "La limite de consommation mémoire fixée par PHP doit être de %1$s minimum (directive de configuration « memory_limit »)."
 
 #: include/classes/setup/CFrontendSetup.php:162
 #, c-format
 msgid "Minimum required PHP upload filesize is %1$s (configuration option \"upload_max_filesize\")."
-msgstr ""
+msgstr "La taille maximale des fichiers fixée par PHP doit être de %1$s minimum (directive de configuration « upload_max_filesize »)."
 
 #: include/classes/setup/CFrontendSetup.php:106
 #, c-format
 msgid "Minimum required PHP version is %1$s."
-msgstr ""
+msgstr "La version minimum requise de PHP est %1$s."
 
 #: include/classes/setup/CFrontendSetup.php:193
 #, c-format
 msgid "Minimum required limit on execution time of PHP scripts is %1$s (configuration option \"max_execution_time\")."
-msgstr ""
+msgstr "La limite de durée d’exécution d’un script PHP doit être de %1$s minimum (directive de configuration « max_execution_time »)."
 
 #: include/classes/setup/CFrontendSetup.php:216
 #, c-format
 msgid "Minimum required limit on input parse time for PHP scripts is %1$s (configuration option \"max_input_time\")."
-msgstr ""
+msgstr "La limite de la durée d’analyse d’un script PHP doit être de %1$s minimum (directive de configuration « max_input_time »)."
 
 #: include/classes/setup/CFrontendSetup.php:143
 #, c-format
 msgid "Minimum required size of PHP post is %1$s (configuration option \"post_max_size\")."
-msgstr ""
+msgstr "La taille maximale des données postées par PHP doit être de %1$s minimum (directive de configuration « post_max_size »)."
 
 #: app/views/monitoring.map.view.php:48
 #: include/views/monitoring.sysmap.edit.php:267
@@ -11367,15 +11355,15 @@ msgstr "Minutes"
 #: include/classes/api/services/CGraphGeneral.php:490
 #: include/classes/api/services/CGraphGeneral.php:676
 msgid "Missing \"itemid\" field for item."
-msgstr "Champ \"itemid\" manquant pour l'élément."
+msgstr "Champ « itemid » manquant pour l’élément."
 
 #: include/classes/api/services/CGraphPrototype.php:37
 msgid "Missing \"name\" field for graph prototype."
-msgstr "Champ \"name\" manquant pour le prototype de graphique."
+msgstr "Champ « name » manquant pour le prototype de graphique."
 
 #: include/classes/api/services/CGraph.php:37
 msgid "Missing \"name\" field for graph."
-msgstr "Champ \"nom\" manquant pour le graphique."
+msgstr "Champ « nom » manquant pour le graphique."
 
 #: include/classes/widgets/CWidgetHelper.php:777
 #: include/classes/widgets/CWidgetHelper.php:853
@@ -11388,17 +11376,17 @@ msgstr "Données manquantes"
 #: include/classes/api/services/CGraph.php:38
 #, c-format
 msgid "Missing items for graph \"%1$s\"."
-msgstr "Éléments manquants pour le graphique \"%1$s\"."
+msgstr "Éléments manquants pour le graphique « %1$s »."
 
 #: include/classes/api/services/CGraphPrototype.php:38
 #, c-format
 msgid "Missing items for graph prototype \"%1$s\"."
-msgstr "Éléments manquants pour le prototype de graphique \"%1$s\"."
+msgstr "Éléments manquants pour le prototype de graphique « %1$s »."
 
 #: include/graphs.inc.php:408
 #, c-format
 msgid "Missing key \"%1$s\" for host \"%2$s\"."
-msgstr "Clé \"%1$s\" manquante pour l'hôte \"%2$s\"."
+msgstr "Clef « %1$s » manquante pour l’hôte « %2$s »."
 
 #: app/controllers/CControllerPopupTriggerExpr.php:242
 #: app/views/administration.proxy.list.php:51
@@ -11413,50 +11401,50 @@ msgstr "Modèle"
 #: app/controllers/CControllerAuditLogList.php:232
 #: app/views/administration.module.edit.php:52
 msgid "Module"
-msgstr ""
+msgstr "Module"
 
 #: app/controllers/CControllerModuleScan.php:98
 #, c-format
 msgid "Module added: %1$s."
 msgid_plural "Modules added: %1$s."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Module ajouté : %1$s."
+msgstr[1] "Modules ajoutés : %1$s."
 
 #: app/controllers/CControllerModuleScan.php:113
 #, c-format
 msgid "Module deleted: %1$s."
 msgid_plural "Modules deleted: %1$s."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Module effacé : %1$s."
+msgstr[1] "Modules effacés : %1$s."
 
 #: app/controllers/CControllerModuleUpdate.php:150
 #, c-format
 msgid "Module disabled: %1$s."
 msgid_plural "Modules disabled: %1$s."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Module désactivé : %1$s."
+msgstr[1] "Modules désactivés : %1$s."
 
 #: app/controllers/CControllerModuleUpdate.php:145
 #, c-format
 msgid "Module enabled: %1$s."
 msgid_plural "Modules enabled: %1$s."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Module activé : %1$s."
+msgstr[1] "Modules activés : %1$s."
 
 #: app/controllers/CControllerModuleUpdate.php:142
 #, c-format
 msgid "Module updated: %1$s."
-msgstr ""
+msgstr "Module mis à jour : %1$s."
 
 #: include/classes/api/services/CRole.php:714
 #, c-format
 msgid "Module with ID \"%2$s\" is not available for user role \"%1$s\"."
-msgstr ""
+msgstr "Le module dont l’identifiant est « %2$s » n‘est pas disponible pour le rôle d’utilisateur « %1$s »."
 
 #: include/classes/core/CModuleManager.php:222
 #, c-format
 msgid "Module.php class must extend %1$s for module located at %2$s."
-msgstr ""
+msgstr "La classe Module.php doit étendre %1$s pour le module dont la localisation est %2$s."
 
 #: app/controllers/CControllerModuleEdit.php:98
 #: app/controllers/CControllerModuleList.php:122
@@ -11464,11 +11452,11 @@ msgstr ""
 #: app/views/administration.module.list.php:27
 #: include/classes/helpers/CMenuHelper.php:246 include/html.inc.php:896
 msgid "Modules"
-msgstr ""
+msgstr "Modules"
 
 #: app/controllers/CControllerModuleScan.php:127
 msgid "Modules updated"
-msgstr ""
+msgstr "Modules mis à jour"
 
 #: include/func.inc.php:197
 msgid "Mon"
@@ -11516,7 +11504,7 @@ msgstr "Mensuel"
 
 #: include/classes/html/CMultiSelect.php:83 jsLoader.php:334
 msgid "More matches found..."
-msgstr "Plus de correspondances trouvées..."
+msgstr "Plus de correspondances trouvées…"
 
 #: jsLoader.php:344
 #, c-format
@@ -11527,20 +11515,20 @@ msgstr "Plus de %1$d correspondances trouvées pour %2$s"
 #: app/views/administration.queue.overview.php:51
 #: app/views/administration.queue.overview.proxy.php:51
 msgid "More than 10 minutes"
-msgstr "Plus de 10 minutes"
+msgstr "Plus de 10 minutes"
 
 #: include/classes/api/services/CGraphGeneral.php:872
 #, c-format
 msgid "More than one graph with name \"%1$s\" within host."
-msgstr "Plus d'un graphique nommé \"%1$s\" dans l'hôte."
+msgstr "Plus d’un graphique nommé « %1$s » dans l’hôte."
 
 #: include/classes/helpers/CServiceHelper.php:27
 msgid "Most critical if all children have problems"
-msgstr ""
+msgstr "Le plus critique si tous les fils ont des problèmes"
 
 #: include/classes/helpers/CServiceHelper.php:26
 msgid "Most critical of child services"
-msgstr ""
+msgstr "Le plus critique des services fils"
 
 #: include/httptest.inc.php:409
 msgid "Mozilla Firefox"
@@ -11561,24 +11549,24 @@ msgstr "Sourdine"
 
 #: app/views/monitoring.dashboard.list.php:94
 msgid "My"
-msgstr ""
+msgstr "Mon"
 
 #: include/classes/helpers/CServiceHelper.php:37
 #: include/classes/helpers/CServiceHelper.php:47
 msgid "N"
-msgstr ""
+msgstr "N"
 
 #: jsLoader.php:186
 msgctxt "abbreviation of severity level"
 msgid "N"
-msgstr ""
+msgstr "N"
 
 #: include/classes/helpers/CServiceHelper.php:42
 #: include/classes/helpers/CServiceHelper.php:52
 #: include/classes/helpers/CServiceHelper.php:62
 #: include/classes/helpers/CServiceHelper.php:72
 msgid "N%"
-msgstr ""
+msgstr "N%"
 
 #: include/discovery.inc.php:53
 msgid "NNTP"
@@ -11771,7 +11759,7 @@ msgstr "Prénom"
 
 #: app/views/administration.authentication.edit.php:303
 msgid "Name ID"
-msgstr ""
+msgstr "Identifiant du nom"
 
 #: include/views/js/configuration.httpconf.edit.js.php:100
 msgid "Name of the form field should not exceed 255 characters."
@@ -11779,15 +11767,15 @@ msgstr "Le champ de nom du formulaire ne doit pas dépasser 255 caractères."
 
 #: app/views/administration.module.edit.php:43
 msgid "Namespace"
-msgstr ""
+msgstr "Espace de noms"
 
 #: jsLoader.php:187
 msgid "Navigate to default view"
-msgstr ""
+msgstr "Naviguer vers la vue par défaut"
 
 #: jsLoader.php:188
 msgid "Navigate to initial view"
-msgstr ""
+msgstr "Naviguer vers la vue initiale"
 
 #: app/views/administration.housekeeping.edit.php:76
 msgid "Network discovery data storage period"
@@ -11795,7 +11783,7 @@ msgstr "Période de stockage des données de découverte réseau"
 
 #: include/classes/data/CItemData.php:952
 msgid "Network interface list (includes interface type, status, IPv4 address, description). Returns text"
-msgstr "Liste des interfaces réseau (inclut le type d'interface, l'état, l'adresse IPv4, la description). Retourne du texte"
+msgstr "Liste des interfaces réseau (inclut le type d’interface, l’état, l’adresse IPv4, la description). Retourne du texte"
 
 #: sysmaps.php:213
 msgid "Network map added"
@@ -11817,27 +11805,27 @@ msgstr "Cartes réseau"
 
 #: app/views/administration.miscconfig.edit.php:134
 msgid "Network timeout"
-msgstr ""
+msgstr "Délai de grâce du réseau"
 
 #: app/views/administration.miscconfig.edit.php:162
 msgid "Network timeout for item test"
-msgstr ""
+msgstr "Délai de grâce du réseau pour le test d’un élément"
 
 #: app/views/administration.miscconfig.edit.php:148
 msgid "Network timeout for media type test"
-msgstr ""
+msgstr "Délai de grâce du réseau pour le test du type de média"
 
 #: app/views/administration.miscconfig.edit.php:170
 msgid "Network timeout for scheduled report test"
-msgstr ""
+msgstr "Délai de grâce du réseau pour le test d’un rapport planifié"
 
 #: app/views/administration.miscconfig.edit.php:156
 msgid "Network timeout for script execution"
-msgstr ""
+msgstr "Délai de grâce du réseau pour l’exécution d’un script"
 
 #: include/classes/data/CItemData.php:1528
 msgid "Network utilization (combined transmit-rates and receive-rates) during the interval, <url> - VMware service URL, <uuid> - VMware virtual machine host name, <instance> - network interface instance"
-msgstr ""
+msgstr "Utilisation du réseau (débits en réception et transmission combinés) durant l’intervalle, <url> — URL de service VMware, <uuid> — nom de l’hôte virtuel VMware, <instance> — instance de l’interface réseau"
 
 #: app/views/administration.proxy.list.php:169 include/func.inc.php:191
 msgid "Never"
@@ -11845,7 +11833,7 @@ msgstr "Jamais"
 
 #: app/views/popup.service.statusrule.edit.php:93
 msgid "New additional rule"
-msgstr ""
+msgstr "Nouvelle règle additionnelle"
 
 #: app/controllers/CControllerPopupConditionActions.php:94
 #: app/controllers/CControllerPopupConditionEventCorr.php:87
@@ -11865,32 +11853,32 @@ msgstr "Nouvel élément"
 #: include/classes/helpers/CCorrelationHelper.php:54
 #: include/classes/helpers/CCorrelationHelper.php:129
 msgid "New event host group"
-msgstr "Nouveau groupe d'hôte d'événement"
+msgstr "Nouveau groupe d’hôte d’événement"
 
 #: include/classes/helpers/CCorrelationHelper.php:53
 #: include/classes/helpers/CCorrelationHelper.php:123
 msgid "New event tag name"
-msgstr ""
+msgstr "Nouveau nom d’étiquette d’événement"
 
 #: include/classes/helpers/CCorrelationHelper.php:57
 msgid "New event tag value"
-msgstr "Nouvelle valeur de tag d'événement"
+msgstr "Nouvelle valeur d’étiquette d’événement"
 
 #: app/views/configuration.host.edit.php:65 app/views/popup.host.edit.php:97
 msgid "New host"
-msgstr ""
+msgstr "Nouvel hôte"
 
 #: app/controllers/CControllerPopupLldOperation.php:351
 msgid "New operation"
-msgstr ""
+msgstr "Nouvelle opération"
 
 #: app/views/administration.regex.list.php:36
 msgid "New regular expression"
-msgstr "Nouvelle expression régulière"
+msgstr "Nouvelle expression rationnelle"
 
 #: app/views/popup.service.edit.php:391 app/views/popup.service.edit.php:403
 msgid "New service"
-msgstr ""
+msgstr "Nouveau service"
 
 #: app/controllers/CControllerPopupServiceTimeEdit.php:119
 msgid "New service time"
@@ -11898,7 +11886,7 @@ msgstr "Nouvelle période de maintenance"
 
 #: app/views/popup.condition.common.php:120
 msgid "New tag name"
-msgstr ""
+msgstr "Nouveau nom d’étiquette"
 
 #: include/views/js/monitoring.sysmaps.js.php:181
 msgid "New triggers"
@@ -11907,7 +11895,7 @@ msgstr "Nouveaux déclencheurs"
 #: app/views/monitoring.dashboard.view.php:179
 #: app/views/monitoring.host.dashboard.view.php:112 jsLoader.php:191
 msgid "Next page"
-msgstr ""
+msgstr "Page suivante"
 
 #: include/classes/setup/CSetupWizard.php:331
 #: include/classes/setup/CSetupWizard.php:589
@@ -11926,9 +11914,8 @@ msgstr "Prochaine étape"
 #: app/views/hintbox.eventlist.php:178 app/views/hintbox.eventlist.php:182
 #: app/views/monitoring.widget.problems.view.php:264
 #: app/views/monitoring.widget.problems.view.php:268
-#: app/views/popup.condition.common.php:679
-#: app/views/popup.lldoperation.php:85 app/views/popup.lldoperation.php:97
-#: app/views/popup.massupdate.item.php:328
+#: app/views/popup.condition.common.php:679 app/views/popup.lldoperation.php:85
+#: app/views/popup.lldoperation.php:97 app/views/popup.massupdate.item.php:328
 #: app/views/popup.massupdate.item.php:337
 #: app/views/popup.massupdate.item.php:379
 #: app/views/popup.massupdate.trigger.php:64 include/actions.inc.php:33
@@ -11938,8 +11925,7 @@ msgstr "Prochaine étape"
 #: include/classes/screens/CScreenProblem.php:1245 include/events.inc.php:198
 #: include/events.inc.php:202 include/events.inc.php:392
 #: include/events.inc.php:396 include/triggers.inc.php:996
-#: include/triggers.inc.php:1001
-#: include/views/configuration.graph.list.php:206
+#: include/triggers.inc.php:1001 include/views/configuration.graph.list.php:206
 #: include/views/configuration.host.prototype.list.php:142
 #: include/views/configuration.host.prototype.list.php:158
 #: include/views/configuration.httpconf.list.php:188
@@ -11957,27 +11943,27 @@ msgstr "Non"
 #: include/classes/api/services/CGraphPrototype.php:39
 #, c-format
 msgid "No \"%1$s\" given for graph prototype."
-msgstr "Aucun \"%1$s\" donné pour le prototype de graphique."
+msgstr "Aucun « %1$s » donné pour le prototype de graphique."
 
 #: include/classes/api/services/CGraph.php:39
 #, c-format
 msgid "No \"%1$s\" given for graph."
-msgstr "Aucun \"%1$s\" donné pour le graphique."
+msgstr "Aucun « %1$s » donné pour le graphique."
 
 #: include/classes/api/services/CMap.php:1041
 #, c-format
 msgid "No \"%1$s\" given for map."
-msgstr "Aucun \"%1$s\" donné pour la carte."
+msgstr "Aucun « %1$s » donné pour la carte."
 
 #: include/classes/api/services/CDiscoveryRule.php:1847
 #, c-format
 msgid "No \"%2$s\" given for a filter condition of discovery rule \"%1$s\"."
-msgstr "Aucun \"%2$s\" donné pour la condition de filtre de la règle de découverte \"%1$s\"."
+msgstr "Aucun « %2$s » donné pour la condition de filtre de la règle de découverte « %1$s »."
 
 #: include/classes/api/services/CDiscoveryRule.php:1813
 #, c-format
 msgid "No \"%2$s\" given for the filter of discovery rule \"%1$s\"."
-msgstr "Aucun \"%2$s\" donné pour le filtre de règle de découverte \"%1$s\"."
+msgstr "Aucun « %2$s » donné pour le filtre de règle de découverte « %1$s »."
 
 #: include/classes/api/services/CItemGeneral.php:572
 msgid "No SNMP OID specified."
@@ -11985,11 +11971,11 @@ msgstr "Aucun OID SNMP spécifié."
 
 #: include/classes/api/services/CItemGeneral.php:542
 msgid "No authentication user name specified."
-msgstr "Aucun nom d'utilisateur d'authentification spécifié."
+msgstr "Aucun nom d’utilisateur d’authentification spécifié."
 
 #: app/views/popup.import.compare.php:173
 msgid "No changes."
-msgstr ""
+msgstr "Aucun changement."
 
 #: app/views/configuration.correlation.edit.php:54
 #: include/views/configuration.action.edit.php:56
@@ -12014,7 +12000,7 @@ msgstr "Pas de données."
 #: include/classes/api/services/CHostPrototype.php:1752
 #, c-format
 msgid "No default interface for \"%1$s\" type on \"%2$s\"."
-msgstr "Aucune interface par défaut pour le type \"%1$s\" sur \"%2$s\"."
+msgstr "Aucune interface par défaut pour le type « %1$s » sur « %2$s »."
 
 #: include/classes/core/CJsonRpc.php:197 include/classes/core/CJsonRpc.php:202
 #: include/classes/core/CJsonRpc.php:207
@@ -12028,7 +12014,7 @@ msgstr "Aucun identifiant de règle de découverte fourni."
 #: app/views/administration.user.edit.php:578
 #: app/views/administration.userrole.edit.php:253
 msgid "No enabled modules found."
-msgstr ""
+msgstr "Aucun module activé n’a été trouvé."
 
 #: app/partials/configuration.host.edit.html.php:431
 #: app/partials/configuration.host.edit.html.php:444
@@ -12046,12 +12032,12 @@ msgstr "Pas de chiffrement"
 #: app/controllers/CControllerPopupImport.php:127
 #: include/classes/helpers/CUploadFile.php:159
 msgid "No file was uploaded."
-msgstr "Aucun fichier n'a été téléversé."
+msgstr "Aucun fichier n’a été téléversé."
 
 #: include/graphs.inc.php:153
 #, c-format
 msgid "No graph item with graph ID \"%1$s\"."
-msgstr ""
+msgstr "Aucun élément de graphique n’a l’identifiant « %1$s »."
 
 #: app/views/monitoring.widget.favgraphs.view.php:26
 msgid "No graphs added."
@@ -12059,7 +12045,7 @@ msgstr "Aucun graphique ajouté."
 
 #: include/classes/api/services/CDiscoveryRule.php:639
 msgid "No host IDs given."
-msgstr "Aucun identifiant d'hôte fourni."
+msgstr "Aucun identifiant d’hôte fourni."
 
 #: app/controllers/CControllerWidgetUrlView.php:51
 msgid "No host selected."
@@ -12068,12 +12054,12 @@ msgstr "Aucun hôte sélectionné."
 #: include/hosts.inc.php:546
 #, c-format
 msgid "No host with host ID \"%1$s\"."
-msgstr ""
+msgstr "Aucun hôte n’a l’identifiant d’hôte « %1$s »."
 
 #: include/classes/api/services/CMapElement.php:176
 #, c-format
 msgid "No icon for map element \"\"%1$s\"."
-msgstr ""
+msgstr "Aucune icône pour l’élément de carte « %1$s »."
 
 #: include/views/monitoring.sysmap.edit.php:115
 msgid "No image"
@@ -12092,16 +12078,16 @@ msgstr "Aucune interface trouvée."
 
 #: jsLoader.php:319
 msgid "No interfaces are defined."
-msgstr ""
+msgstr "Aucune interface n’est définie."
 
 #: app/controllers/CControllerActionOperationValidate.php:169
 msgid "No inventory mode specified for action operation."
-msgstr "Aucun mode d'inventaire spécifié pour l'opération d'action."
+msgstr "Aucun mode d’inventaire spécifié pour l’opération d’action."
 
 #: include/items.inc.php:742
 #, c-format
 msgid "No item with item ID \"%1$s\"."
-msgstr ""
+msgstr "Aucun élément avec l’identifiant « %1$s »."
 
 #: chart3.php:145 chart7.php:56
 msgid "No items defined."
@@ -12122,17 +12108,17 @@ msgstr "Aucune correspondance trouvée"
 
 #: app/controllers/CControllerModuleScan.php:128
 msgid "No new modules discovered"
-msgstr ""
+msgstr "Aucun module découvert"
 
 #: include/classes/api/services/CAction.php:2769
 #, c-format
 msgid "No operations defined for action \"%1$s\"."
-msgstr ""
+msgstr "Aucune opération n’est définie pour l’action « %1$s »."
 
 #: include/classes/api/services/CUser.php:1550
 #: include/classes/api/services/CUser.php:2054
 msgid "No permissions for system access."
-msgstr "Aucune permission pour l'accès au système."
+msgstr "Aucune permission pour l’accès au système."
 
 #: include/classes/api/clients/CLocalApiClient.php:105
 #: include/classes/api/services/CAuthentication.php:88
@@ -12171,7 +12157,7 @@ msgstr "Aucune permission pour l'accès au système."
 #: include/classes/api/services/CUser.php:258
 #, c-format
 msgid "No permissions to call \"%1$s.%2$s\"."
-msgstr ""
+msgstr "Aucune permission d’appeler « %1$s.%2$s »."
 
 #: app/controllers/CControllerChartsView.php:132
 #: app/controllers/CControllerChartsView.php:154
@@ -12346,15 +12332,15 @@ msgstr ""
 #: include/classes/screens/CScreenHttpTestDetails.php:46
 #: include/func.inc.php:1488 items.php:1160
 msgid "No permissions to referred object or it does not exist!"
-msgstr "Aucune permission pour l'objet appelé ou il n'existe pas !"
+msgstr "Aucune permission pour l’objet appelé ou il n’existe pas !"
 
 #: include/classes/api/services/CItemGeneral.php:550
 msgid "No private key file specified."
-msgstr "Aucun fichier de clé privée spécifié."
+msgstr "Aucun fichier de clef privée spécifié."
 
 #: jsLoader.php:173
 msgid "No problems"
-msgstr ""
+msgstr "Aucun problème"
 
 #: app/views/configuration.discovery.edit.php:54
 msgid "No proxy"
@@ -12362,12 +12348,12 @@ msgstr "Aucun proxy"
 
 #: include/classes/api/services/CItemGeneral.php:547
 msgid "No public key file specified."
-msgstr "Aucun fichier de clé publique spécifié."
+msgstr "Aucun fichier de clef publique spécifié."
 
 #: app/controllers/CControllerActionOperationValidate.php:110
 #: include/classes/api/services/CAction.php:2826
 msgid "No recipients specified for action operation message."
-msgstr ""
+msgstr "Aucun destinataire n’est spécifié pour le message d’opération d’action."
 
 #: include/classes/widgets/CWidgetConfig.php:286 jsLoader.php:165
 msgid "No refresh"
@@ -12375,7 +12361,7 @@ msgstr "Pas de rafraîchissement"
 
 #: app/controllers/CControllerActionOperationValidate.php:129
 msgid "No script specified for action operation command."
-msgstr "Aucun script spécifié pour la commande d'opération d'action."
+msgstr "Aucun script spécifié pour la commande d’opération d’action."
 
 #: triggers.php:513
 msgid "No target selected"
@@ -12388,12 +12374,12 @@ msgstr "Aucune cible sélectionnée."
 #: app/controllers/CControllerActionOperationValidate.php:142
 #: include/classes/api/services/CAction.php:2837
 msgid "No targets specified for action operation global script."
-msgstr ""
+msgstr "Aucune cible n’est spécifiée pour le script global d’opération d’action."
 
 #: include/triggers.inc.php:91
 #, c-format
 msgid "No trigger with trigger ID \"%1$s\"."
-msgstr ""
+msgstr "Aucun déclencheur n’a l’identifiant de déclencheur « %1$s »."
 
 #: chart4.php:42
 msgid "No triggers defined."
@@ -12405,7 +12391,7 @@ msgstr "Pas de valeur"
 
 #: include/classes/validators/CApiInputValidator.php:1136
 msgid "Non-boolean flags are deprecated."
-msgstr "Les drapeaux non-booléens sont obsolètes."
+msgstr "Les drapeaux non booléens sont obsolètes."
 
 #: app/partials/administration.usergroup.grouprights.html.php:72
 #: app/partials/monitoring.problem.filter.php:211
@@ -12465,31 +12451,31 @@ msgstr "Non acquitté"
 #: app/partials/trigoverview.table.left.php:62
 #: app/partials/trigoverview.table.top.php:61
 msgid "Not all results are displayed. Please provide more specific search criteria."
-msgstr ""
+msgstr "Les résultats ne sont tous affichés. Veuillez fournir des critères de recherche plus précis."
 
 #: include/classes/api/services/CTrigger.php:1045
 #: include/classes/api/services/CTriggerPrototype.php:852
 #, c-format
 msgid "Not all templates are linked to \"%1$s\"."
-msgstr ""
+msgstr "Les modèles ne sont pas tous liés à « %1$s »."
 
 #: include/classes/api/services/CUser.php:577
 msgid "Not allowed to set language for user \"guest\"."
-msgstr ""
+msgstr "La réglage de la langue de l’utilisateur « invité » n’est pas autorisé."
 
 #: include/classes/api/services/CUser.php:569
 msgid "Not allowed to set password for user \"guest\"."
-msgstr "Configuration du mot de passe de l'utilisateur \"guest\" interdite."
+msgstr "Configuration du mot de passe de l’utilisateur « guest » interdite."
 
 #: include/classes/api/services/CUser.php:580
 msgid "Not allowed to set theme for user \"guest\"."
-msgstr ""
+msgstr "La réglage du thème de l’utilisateur « invité » n’est pas autorisé."
 
 #: include/classes/api/clients/CLocalApiClient.php:164
 #: include/classes/api/clients/CLocalApiClient.php:192
 #: include/classes/api/clients/CLocalApiClient.php:218
 msgid "Not authorized."
-msgstr ""
+msgstr "Non autorisé."
 
 #: app/views/monitoring.widget.hostavail.view.php:34
 #: app/views/monitoring.widget.hostavail.view.php:62
@@ -12511,7 +12497,7 @@ msgstr "Éléments non hérités"
 #: include/items.inc.php:182
 #: include/views/configuration.host.discovery.list.php:158
 msgid "Not supported"
-msgstr "Non supporté"
+msgstr "Non géré"
 
 #: app/views/popup.service.edit.php:226
 #: app/views/popup.service.time.edit.php:122
@@ -12542,11 +12528,11 @@ msgstr "Notifier tous les participants"
 
 #: include/func.inc.php:230
 msgid "Nov"
-msgstr "Nov"
+msgstr "nov."
 
 #: include/func.inc.php:110 include/func.inc.php:247 jsLoader.php:241
 msgid "November"
-msgstr "Novembre"
+msgstr "novembre"
 
 #: include/classes/data/CItemData.php:1068
 msgid "Number of CPUs. Returns integer"
@@ -12554,48 +12540,48 @@ msgstr "Nombre de processeurs. Retourne un entier"
 
 #: include/classes/data/CItemData.php:1312
 msgid "Number of available DS paths, <url> - VMware service URL, <uuid> - VMware hypervisor host name, <datastore> - Datastore name, <partitionid> - internal id of physical device from vmware.hv.datastore.discovery"
-msgstr ""
+msgstr "Nombre de chemins d’accès à la banque de données disponibles, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware, <datastore> — nom de la banque de données (datastore), <partitionid> — identifiant interne du périphérique physique issu de vmware.hv.datastore.discovery"
 
 #: include/classes/data/CItemData.php:904
 msgid "Number of currently open file descriptors. Returns integer"
-msgstr ""
+msgstr "Nombre de descripteurs de fichiers actuellement ouverts. Retourne un entier"
 
 #: include/classes/data/CItemData.php:1644
 msgid "Number of enabled items on the host."
-msgstr "Nombre d'éléments activés sur l'hôte."
+msgstr "Nombre d’éléments activés sur l’hôte."
 
 #: app/partials/administration.system.info.php:40
 msgid "Number of hosts (enabled/disabled)"
-msgstr ""
+msgstr "Nombre d’hôtes (activés/désactivés)"
 
 #: app/partials/administration.system.info.php:55
 msgid "Number of items (enabled/disabled/not supported)"
-msgstr "Nombre d'éléments (activés/désactivés/non supportés)"
+msgstr "Nombre d’éléments (activés, désactivés, non gérés)"
 
 #: include/classes/data/CItemData.php:1668
 msgid "Number of items in Zabbix database."
-msgstr "Nombre d'éléments dans la base de données Zabbix."
+msgstr "Nombre d’éléments dans la base de données Zabbix."
 
 #: include/classes/data/CItemData.php:1696
 msgid "Number of items in proxy history that are not yet sent to the server"
-msgstr "Nombre d'éléments dans l'historique du proxy qui ne sont pas encore envoyés au serveur"
+msgstr "Nombre d’éléments dans l’historique du proxy qui ne sont pas encore envoyés au serveur"
 
 #: include/classes/data/CItemData.php:1700
 msgid "Number of items in the queue which are delayed by from to to seconds, inclusive."
-msgstr "Nombre d'éléments dans la queue qui rencontrent un délai de from à to secondes, incluses."
+msgstr "Nombre d’éléments dans la queue qui rencontrent un délai de from à to secondes, incluses."
 
 #: include/classes/data/CItemData.php:1612
 #: include/classes/data/CItemData.php:1712
 msgid "Number of items in the queue which are delayed in Zabbix server or proxy by \"from\" till \"to\" seconds, inclusive."
-msgstr "Nombre d'éléments de la file d'attente qui sont retardés sur le serveur Zabbix ou le proxy de \"from\" jusqu'à \"to\" en secondes, inclusif."
+msgstr "Nombre d’éléments de la file d’attente qui sont retardés sur le serveur Zabbix ou le proxy de « from » jusqu’à « to » en secondes, inclusif."
 
 #: include/classes/data/CItemData.php:1664
 msgid "Number of monitored hosts"
-msgstr "Nombre d'hôtes supervisés"
+msgstr "Nombre d’hôtes supervisés"
 
 #: include/classes/data/CItemData.php:940
 msgid "Number of out-of-window collisions. Returns integer"
-msgstr "Nombre de collisions out-of-window. Retourne un entier"
+msgstr "Nombre de collisions hors plage. Retourne un entier"
 
 #: include/views/monitoring.sysmap.edit.php:153
 msgid "Number of problems"
@@ -12607,15 +12593,15 @@ msgstr "Nombre de problèmes et détailler le plus critique"
 
 #: include/classes/data/CItemData.php:1344
 msgid "Number of processor cores on VMware hypervisor, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Nombre de cœurs de processeur sur un hyperviseur VMware, <url> - URL du service VMware, <uuid> - nom d'hôte de l'hyperviseur VMware"
+msgstr "Nombre de cœurs de processeur sur un hyperviseur VMware, <url> — URL du service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1348
 msgid "Number of processor threads on VMware hypervisor, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Nombre de threads de processeur sur un hyperviseur VMware, <url> - URL du service VMware, <uuid> - nom d'hôte de l'hyperviseur VMware"
+msgstr "Nombre de fils d’exécution (threads) de processeur sur un hyperviseur VMware, <url> — URL du service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1432
 msgid "Number of processors on VMware virtual machine, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Nombre de processeurs sur un hyperviseur VMware, <url> - URL du service VMware, <uuid> - nom d'hôte de l'hyperviseur VMware"
+msgstr "Nombre de processeurs sur un hyperviseur VMware, <url> — URL du service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:279
 msgid "Number of rows"
@@ -12623,16 +12609,16 @@ msgstr "Nombre de lignes"
 
 #: include/views/reports.toptriggers.php:86
 msgid "Number of status changes"
-msgstr "Nombre de changements d'états"
+msgstr "Nombre de changements d’états"
 
 #: include/classes/screens/CScreenHttpTest.php:114
 #: include/views/configuration.httpconf.list.php:135
 msgid "Number of steps"
-msgstr "Nombre d'étapes"
+msgstr "Nombre d’étapes"
 
 #: app/partials/administration.system.info.php:50
 msgid "Number of templates"
-msgstr ""
+msgstr "Nombre de modèles"
 
 #: app/partials/administration.system.info.php:67
 msgid "Number of triggers (enabled/disabled [problem/ok])"
@@ -12644,19 +12630,19 @@ msgstr "Nombre de déclencheurs dans la base de données Zabbix."
 
 #: include/classes/data/CItemData.php:1672
 msgid "Number of unsupported items in Zabbix database."
-msgstr "Nombre d'éléments non supportés dans la base de données Zabbix."
+msgstr "Nombre d’éléments non pris en charge dans la base de données Zabbix."
 
 #: include/classes/data/CItemData.php:1648
 msgid "Number of unsupported items on the host."
-msgstr "Nombre d'éléments non supportés sur l'hôte."
+msgstr "Nombre d’éléments non pris en charge sur l’hôte."
 
 #: app/partials/administration.system.info.php:84
 msgid "Number of users (online)"
-msgstr "Nombre d'utilisateurs (en ligne)"
+msgstr "Nombre d’utilisateurs (en ligne)"
 
 #: include/classes/data/CItemData.php:1144
 msgid "Number of users logged in. Returns integer"
-msgstr "Nombre d'utilisateurs connectés. Retourne un entier"
+msgstr "Nombre d’utilisateurs connectés. Retourne un entier"
 
 #: include/classes/data/CItemData.php:1624
 msgid "Number of values stored in table HISTORY."
@@ -12688,11 +12674,11 @@ msgstr "Nombre de valeurs stockées dans la table TRENDS_UINT."
 
 #: include/classes/data/CItemData.php:1416
 msgid "Number of virtual machines on VMware hypervisor, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Nombre de machines virtuelles sur un hyperviseur VMware, <url> - URL du service VMware, <uuid> - nom d'hôte de l'hyperviseur VMware"
+msgstr "Nombre de machines virtuelles sur un hyperviseur VMware, <url> — URL du service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1224
 msgid "Number or percentage of inodes. Returns integer for number; float for percentage"
-msgstr "Nombre ou pourcentage des i-nœuds. Retourne un entier pour le nombre, un flottant pour le pourcentage"
+msgstr "Nombre ou pourcentage des i‐nœuds. Retourne un entier pour le nombre, un flottant pour le pourcentage"
 
 #: include/items.inc.php:1850 include/items.inc.php:1854
 #: include/items.inc.php:1858
@@ -12743,19 +12729,19 @@ msgstr "Un événement OK ferme"
 #: include/views/configuration.trigger.prototype.edit.php:295
 #: include/views/configuration.triggers.edit.php:320
 msgid "OK event generation"
-msgstr "Génération d'événement OK"
+msgstr "Génération d’événement OK"
 
 #: include/hosts.inc.php:299
 msgid "OOB IP address"
-msgstr "Hôte - Adresse IP OOB"
+msgstr "Adresse IP hors bande"
 
 #: include/hosts.inc.php:309
 msgid "OOB router"
-msgstr "Hôte - Routeur OOB"
+msgstr "Routeur hors bande"
 
 #: include/hosts.inc.php:304
 msgid "OOB subnet mask"
-msgstr "Hôte - Masque de sous-réseau OOB"
+msgstr "Masque de sous‑réseau hors bande"
 
 #: app/views/popup.triggerwizard.php:104
 msgid "OR"
@@ -12763,23 +12749,23 @@ msgstr "OU"
 
 #: include/hosts.inc.php:119 include/views/inventory.host.list.php:88
 msgid "OS"
-msgstr "OS"
+msgstr "SE"
 
 #: include/hosts.inc.php:124
 msgid "OS (Full details)"
-msgstr "OS (détails complet)"
+msgstr "SE (détails complets)"
 
 #: include/hosts.inc.php:129
 msgid "OS (Short)"
-msgstr "OS (Court)"
+msgstr "SE (court)"
 
 #: app/views/popup.lldoperation.php:46
 msgid "Object"
-msgstr ""
+msgstr "Sujet"
 
 #: include/func.inc.php:229
 msgid "Oct"
-msgstr "Oct"
+msgstr "oct."
 
 #: include/items.inc.php:1855
 msgid "Octal to decimal"
@@ -12787,7 +12773,7 @@ msgstr "Octal vers décimal"
 
 #: include/func.inc.php:109 include/func.inc.php:246 jsLoader.php:240
 msgid "October"
-msgstr "Octobre"
+msgstr "octobre"
 
 #: app/views/administration.proxy.list.php:167
 #: include/views/monitoring.sysmap.constructor.php:51
@@ -12806,20 +12792,20 @@ msgstr "Inactif"
 #: include/views/js/configuration.httpconf.edit.js.php:103 jsLoader.php:403
 #: report2.php:507
 msgid "Ok"
-msgstr "Ok"
+msgstr "OK"
 
 #: include/classes/helpers/CCorrelationHelper.php:52
 #: include/classes/helpers/CCorrelationHelper.php:117
 msgid "Old event tag name"
-msgstr ""
+msgstr "Ancien nom d’étiquette d’événement"
 
 #: include/classes/helpers/CCorrelationHelper.php:56
 msgid "Old event tag value"
-msgstr "Ancienne valeur du tag d'événement"
+msgstr "Ancienne valeur de l’étiquette d’événement"
 
 #: app/views/popup.condition.common.php:118
 msgid "Old tag name"
-msgstr ""
+msgstr "Ancien nom d’étiquette"
 
 #: app/views/administration.proxy.list.php:166
 #: include/views/monitoring.sysmap.constructor.php:51
@@ -12829,7 +12815,7 @@ msgstr "Actif"
 
 #: app/views/administration.trigdisplay.edit.php:94
 msgid "On status change triggers blink for"
-msgstr "Au changement d'état, clignoter pendant"
+msgstr "Au changement d’état, clignoter pendant"
 
 #: app/views/administration.user.edit.php:670
 msgid "Once"
@@ -12846,11 +12832,11 @@ msgstr "Une fois uniquement"
 #: app/views/js/popup.service.edit.js.php:235
 #: app/views/popup.service.time.edit.php:47
 msgid "One-time downtime"
-msgstr "Temps d'arrêt unique"
+msgstr "Temps d’arrêt unique"
 
 #: include/classes/api/services/CDRule.php:488
 msgid "Only Zabbix agent, SNMPv1, SNMPv2 and SNMPv3 checks can be made unique."
-msgstr "Seules les vérifications d'agents Zabbix, SNMPv1, SNMPv2 et SNMPv3 peuvent être mises uniques."
+msgstr "Seules les vérifications d’agents Zabbix, SNMPv1, SNMPv2 et SNMPv3 peuvent être mises uniques."
 
 #: include/classes/api/services/CMap.php:666
 #: include/classes/api/services/CMap.php:1120
@@ -12875,7 +12861,7 @@ msgstr "Une seule vérification peut être unique."
 
 #: include/classes/api/services/CItemGeneral.php:1602
 msgid "Only one not supported value check is allowed."
-msgstr ""
+msgstr "Une seule vérification de valeur non prise en charge est autorisée."
 
 #: include/classes/api/services/CItemGeneral.php:1421
 #: include/classes/api/services/CItemGeneral.php:1470
@@ -12890,23 +12876,23 @@ msgstr[1] "Seulement les problèmes sélectionnés"
 
 #: app/views/monitoring.service.list.edit.php:90
 msgid "Only services without children"
-msgstr ""
+msgstr "Services sans fils uniquement"
 
 #: app/views/monitoring.service.list.edit.php:98
 msgid "Only services without problem tags"
-msgstr ""
+msgstr "Services sans étiquette de problème uniquement"
 
 #: include/classes/api/services/CDashboard.php:414
 msgid "Only super admins can set dashboard owner."
-msgstr "Seul les super-admin peuvent spécifier le propriétaire d'un tableau de bord."
+msgstr "Seul les super‐administrateurs peuvent spécifier le propriétaire d’un tableau de bord."
 
 #: include/classes/api/services/CReport.php:334
 msgid "Only super admins can set report owner."
-msgstr ""
+msgstr "Seuls les super‑admins peuvent définir le propriétaire du rapport."
 
 #: app/partials/administration.system.info.php:68
 msgid "Only triggers assigned to enabled hosts and depending on enabled items are counted"
-msgstr "Seuls les déclencheurs assignés à des hôtes activés et dépendant d'éléments activés sont comptés"
+msgstr "Seuls les déclencheurs assignés à des hôtes activés et dépendant d’éléments activés sont comptés"
 
 #: include/httptest.inc.php:421
 msgid "Opera"
@@ -12914,37 +12900,37 @@ msgstr "Opera"
 
 #: include/classes/data/CItemData.php:1116
 msgid "Operating system information. Returns string"
-msgstr "Informations du système d'exploitation. Retourne une chaîne"
+msgstr "Informations du système d’exploitation. Retourne une chaîne"
 
 #: app/partials/popup.operations.php:41 app/views/popup.service.edit.php:65
 msgid "Operation"
-msgstr ""
+msgstr "Opération"
 
 #: include/classes/api/services/CAction.php:2795
 #, c-format
 msgid "Operation \"%1$s\" already exists for action \"%2$s\"."
-msgstr ""
+msgstr "L’opération « %1$s » existe déjà pour l’action « %2$s »."
 
 #: actionconf.php:378
 #, c-format
 msgid "Operation \"%1$s\" already exists."
-msgstr ""
+msgstr "L’opération « %1$s » existe déjà."
 
 #: include/classes/mvc/CController.php:209 include/validate.inc.php:308
 msgid "Operation cannot be performed due to unauthorized request."
-msgstr "L'opération ne peut pas être effectuée en raison d'une requête non autorisée."
+msgstr "L’opération ne peut pas être effectuée en raison d’une requête non autorisée."
 
 #: jsLoader.php:127
 msgid "Operation details"
-msgstr "Détails de l'opération"
+msgstr "Détails de l’opération"
 
 #: app/controllers/CControllerActionOperationValidate.php:151
 msgid "Operation has no group to operate."
-msgstr "L'opération n'a pas de groupe à exploiter."
+msgstr "L’opération n’a pas de groupe à exploiter."
 
 #: app/controllers/CControllerActionOperationValidate.php:160
 msgid "Operation has no template to operate."
-msgstr "L'opération n'a pas de modèle à exploiter."
+msgstr "L’opération n’a pas de modèle à exploiter."
 
 #: app/views/monitoring.widget.problems.view.php:64 include/blocks.inc.php:579
 #: include/classes/screens/CScreenProblem.php:890
@@ -12954,7 +12940,7 @@ msgstr "L'opération n'a pas de modèle à exploiter."
 #: include/views/configuration.triggers.edit.php:106
 #: include/views/configuration.triggers.list.php:193
 msgid "Operational data"
-msgstr ""
+msgstr "Données opérationnelles"
 
 #: app/views/configuration.correlation.edit.php:140
 #: app/views/configuration.correlation.list.php:77
@@ -12997,7 +12983,7 @@ msgstr "Opérateur"
 
 #: app/views/popup.triggerexpr.php:113
 msgid "Operator functions"
-msgstr ""
+msgstr "Fonctions d’exploitation"
 
 #: app/views/administration.mediatype.edit.php:345
 msgid "Options"
@@ -13113,12 +13099,12 @@ msgstr "Statistiques de trafic sortant sur une interface réseau. Retourne un en
 
 #: app/views/popup.scriptexec.php:47
 msgid "Output"
-msgstr ""
+msgstr "Sortie"
 
 #: include/classes/api/services/CDashboardGeneral.php:333
 #, c-format
 msgid "Overlapping widgets at X:%3$d, Y:%4$d on page #%2$d of dashboard \"%1$s\"."
-msgstr ""
+msgstr "Chevauchement de widgets aux coordonnées x = %3$d, y = %4$d de la page nᵒ %2$d du tableau de bord « %1$s »."
 
 #: include/views/configuration.item.edit.php:811
 #: include/views/configuration.item.edit.php:848
@@ -13128,11 +13114,11 @@ msgstr "Surchargé par"
 
 #: app/controllers/CControllerPopupLldOverride.php:130
 msgid "Override"
-msgstr ""
+msgstr "Remplacer"
 
 #: app/views/administration.housekeeping.edit.php:127
 msgid "Override item history period"
-msgstr "Surcharger la période d'historique des éléments"
+msgstr "Surcharger la période d’historique des éléments"
 
 #: app/views/administration.housekeeping.edit.php:144
 msgid "Override item trend period"
@@ -13141,7 +13127,7 @@ msgstr "Surcharger la période de tendances des éléments"
 #: app/controllers/CControllerPopupLldOverride.php:91
 #, c-format
 msgid "Override with name \"%1$s\" already exists."
-msgstr ""
+msgstr "Remplacement par le nom « %1$s » existe déjà."
 
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:402
 #: include/classes/widgets/views/widget.svggraph.form.view.php:297
@@ -13170,39 +13156,39 @@ msgstr "PHP LDAP"
 #: include/classes/setup/CFrontendSetup.php:534
 #: include/classes/validators/CLdapAuthValidator.php:76
 msgid "PHP LDAP extension missing."
-msgstr "L'extension PHP LDAP est manquante."
+msgstr "L’extension PHP LDAP est manquante."
 
 #: include/classes/setup/CFrontendSetup.php:547
 msgid "PHP OpenSSL"
-msgstr ""
+msgstr "Extension OpenSSL de PHP"
 
 #: include/classes/setup/CFrontendSetup.php:551
 msgid "PHP OpenSSL extension missing."
-msgstr ""
+msgstr "L’extension OpenSSL de PHP est absente."
 
 #: include/classes/setup/CFrontendSetup.php:290
 msgid "PHP bcmath"
-msgstr "bcmath pour PHP"
+msgstr "Extension bcmath pour PHP"
 
 #: include/classes/setup/CFrontendSetup.php:294
 msgid "PHP bcmath extension missing (PHP configuration parameter --enable-bcmath)."
-msgstr "L'extension PHP bcmath manque (Paramètre de configuration de PHP --enable-bcmath)."
+msgstr "L’extension PHP bcmath manque (paramètre de configuration de PHP --enable-bcmath)."
 
 #: include/classes/setup/CFrontendSetup.php:574
 msgid "PHP ctype"
-msgstr "ctype pour PHP"
+msgstr "Extension ctype pour PHP"
 
 #: include/classes/setup/CFrontendSetup.php:578
 msgid "PHP ctype extension missing (PHP configuration parameter --enable-ctype)."
-msgstr "L'extension PHP ctype manque (Paramètre de configuration de PHP --enable-ctype)."
+msgstr "L’extension PHP ctype manque (paramètre de configuration de PHP --enable-ctype)."
 
 #: include/classes/setup/CFrontendSetup.php:237
 msgid "PHP databases support"
-msgstr "support de bases de données par PHP"
+msgstr "Bases de données prises en charge par PHP"
 
 #: include/classes/setup/CFrontendSetup.php:370
 msgid "PHP gd"
-msgstr "gd pour PHP"
+msgstr "Extension gd pour PHP"
 
 #: include/classes/setup/CFrontendSetup.php:456
 msgid "PHP gd FreeType support"
@@ -13210,19 +13196,19 @@ msgstr "Support FreeType pour PHP gd"
 
 #: include/classes/setup/CFrontendSetup.php:460
 msgid "PHP gd FreeType support missing."
-msgstr "Le support de FreeType manque dans PHP gd."
+msgstr "La prise en charge de FreeType est absente de PHP gd."
 
 #: include/classes/setup/CFrontendSetup.php:437
 msgid "PHP gd GIF image support missing."
-msgstr "Support d'image PHP gd GIF manquant."
+msgstr "Support d’image PHP gd GIF manquant."
 
 #: include/classes/setup/CFrontendSetup.php:433
 msgid "PHP gd GIF support"
-msgstr "Support d'image PHP gd GIF"
+msgstr "Support d’image PHP gd GIF"
 
 #: include/classes/setup/CFrontendSetup.php:420
 msgid "PHP gd JPEG image support missing."
-msgstr "Le support des images JPEG manque dans PHP gd."
+msgstr "La prise en charge des images JPEG manque dans PHP gd."
 
 #: include/classes/setup/CFrontendSetup.php:416
 msgid "PHP gd JPEG support"
@@ -13230,7 +13216,7 @@ msgstr "Support JPEG dans PHP gd"
 
 #: include/classes/setup/CFrontendSetup.php:397
 msgid "PHP gd PNG image support missing."
-msgstr "Le support des images PNG manque dans PHP gd."
+msgstr "La prise en charge des images PNG manque dans PHP gd."
 
 #: include/classes/setup/CFrontendSetup.php:393
 msgid "PHP gd PNG support"
@@ -13238,31 +13224,31 @@ msgstr "Support PNG dans PHP gd"
 
 #: include/classes/setup/CFrontendSetup.php:374
 msgid "PHP gd extension missing (PHP configuration parameter --with-gd)."
-msgstr "L'extension PHP gd manque (Paramètre de configuration de PHP --with-gd)."
+msgstr "L’extension PHP gd manque (paramètre de configuration de PHP --with-gd)."
 
 #: include/classes/setup/CFrontendSetup.php:625
 msgid "PHP gettext"
-msgstr "gettext pour PHP"
+msgstr "Extension gettext pour PHP"
 
 #: include/classes/setup/CFrontendSetup.php:629
 msgid "PHP gettext extension missing (PHP configuration parameter --with-gettext). Translations will not be available."
-msgstr "L'extension PHP gettext manque (Paramètre de configuration de PHP --with-gettext). Les traductions ne seront pas disponibles."
+msgstr "L’extension PHP gettext manque (paramètre de configuration de PHP --with-gettext). Les traductions ne seront pas disponibles."
 
 #: include/classes/setup/CFrontendSetup.php:479
 msgid "PHP libxml"
-msgstr "libxml pour PHP"
+msgstr "Extension libxml pour PHP"
 
 #: include/classes/setup/CFrontendSetup.php:483
 msgid "PHP libxml extension missing."
-msgstr "L'extension PHP libxml manque."
+msgstr "L’extension PHP libxml manque."
 
 #: include/classes/setup/CFrontendSetup.php:307
 msgid "PHP mbstring"
-msgstr "mbstring pour PHP"
+msgstr "Extension mbstring pour PHP"
 
 #: include/classes/setup/CFrontendSetup.php:311
 msgid "PHP mbstring extension missing (PHP configuration parameter --enable-mbstring)."
-msgstr "L'extension PHP mbstring manque (Paramètre de configuration de PHP --enable-mbstring)."
+msgstr "L’extension PHP mbstring manque (paramètre de configuration de PHP --enable-mbstring)."
 
 #: include/classes/setup/CFrontendSetup.php:120
 #: include/classes/setup/CFrontendSetup.php:139
@@ -13274,12 +13260,12 @@ msgstr "L'extension PHP mbstring manque (Paramètre de configuration de PHP --en
 #: include/classes/setup/CFrontendSetup.php:642
 #, c-format
 msgid "PHP option \"%1$s\""
-msgstr "Option PHP \"%1$s\""
+msgstr "Option PHP « %1$s »"
 
 #: include/classes/setup/CFrontendSetup.php:646
 #, c-format
 msgid "PHP option \"%1$s\" must be set to \"%2$s\""
-msgstr "L'optoin PHP \"%1$s\" doit être configurée sur \"%2$s\""
+msgstr "L’option PHP « %1$s » doit être configurée sur « %2$s »"
 
 #: include/classes/setup/CFrontendSetup.php:591
 msgid "PHP session"
@@ -13287,11 +13273,11 @@ msgstr "Session PHP"
 
 #: include/classes/setup/CFrontendSetup.php:612
 msgid "PHP session auto start must be disabled (PHP directive \"session.auto_start\")."
-msgstr "Le démarrage automatique de session PHP doit être désactivé (directive PHP \"session.auto_start)."
+msgstr "Le démarrage automatique de session PHP doit être désactivé (directive PHP « session.auto_start)."
 
 #: include/classes/setup/CFrontendSetup.php:595
 msgid "PHP session extension missing (PHP configuration parameter --enable-session)."
-msgstr "L'extension PHP session manque (Paramètre de configuration de PHP --enable-session)."
+msgstr "L’extension PHP session manque (paramètre de configuration de PHP --enable-session)."
 
 #: include/classes/setup/CFrontendSetup.php:345
 msgid "PHP sockets"
@@ -13299,7 +13285,7 @@ msgstr "Sockets pour PHP"
 
 #: include/classes/setup/CFrontendSetup.php:349
 msgid "PHP sockets extension missing (PHP configuration parameter --enable-sockets)."
-msgstr "L'extension PHP sockets manque (Paramètre de configuration de PHP --enable-sockets)."
+msgstr "L’extension PHP sockets manque (paramètre de configuration de PHP --enable-sockets)."
 
 #: include/classes/setup/CFrontendSetup.php:332
 msgid "PHP string function overloading must be disabled."
@@ -13311,19 +13297,19 @@ msgstr "Version de PHP"
 
 #: include/classes/setup/CFrontendSetup.php:513
 msgid "PHP xmlreader"
-msgstr "xmlreader pour PHP"
+msgstr "Extension XMLReader pour PHP"
 
 #: include/classes/setup/CFrontendSetup.php:517
 msgid "PHP xmlreader extension missing."
-msgstr "L'extension PHP xmlreader manque."
+msgstr "L’extension PHP xmlreader manque."
 
 #: include/classes/setup/CFrontendSetup.php:496
 msgid "PHP xmlwriter"
-msgstr "xmlwriter pour PHP"
+msgstr "Extension XMLWriter pour PHP"
 
 #: include/classes/setup/CFrontendSetup.php:500
 msgid "PHP xmlwriter extension missing."
-msgstr "L'extension PHP xmlwriter manque."
+msgstr "L’extension PHP xmlwriter manque."
 
 #: include/discovery.inc.php:52
 msgid "POP"
@@ -13378,11 +13364,11 @@ msgstr "Identité PSK"
 #: jsLoader.php:140
 #, c-format
 msgid "Page %1$d"
-msgstr ""
+msgstr "Page %1$d"
 
 #: app/views/dashboard.page.properties.edit.php:55
 msgid "Page display period"
-msgstr ""
+msgstr "Fréquence de rafraîchissement de la page"
 
 #: app/controllers/CControllerWidgetIteratorGraphPrototypeView.php:46
 #: include/validate.inc.php:435
@@ -13392,7 +13378,7 @@ msgstr "La page a reçu des données incorrectes"
 #: include/classes/helpers/CPagerHelper.php:159
 msgctxt "page navigation"
 msgid "Pager"
-msgstr ""
+msgstr "Pagination"
 
 #: app/partials/administration.system.info.php:30
 #: app/views/administration.mediatype.edit.php:103
@@ -13411,7 +13397,7 @@ msgstr "Paramètre"
 #: include/classes/validators/CApiInputValidator.php:1232
 #, c-format
 msgid "Parameter \"%1$s\" is deprecated."
-msgstr "Le paramètre \"%1$s\" est obsolète."
+msgstr "Le paramètre « %1$s » est obsolète."
 
 #: app/views/administration.mediatype.edit.php:211
 #: app/views/administration.script.edit.php:179
@@ -13425,7 +13411,7 @@ msgstr "Paramètres"
 #: app/controllers/CControllerActionOperationValidate.php:76
 #: include/classes/api/services/CAction.php:2807
 msgid "Parameters \"esc_step_from\" and \"esc_step_to\" must be set together."
-msgstr ""
+msgstr "Les paramètres « esc_step_from » et « esc_step_to » doivent être tous les deux définis."
 
 #: include/views/configuration.host.discovery.edit.php:52
 #: include/views/configuration.host.prototype.edit.php:61
@@ -13442,10 +13428,10 @@ msgid "Parent items"
 msgstr "Éléments parents"
 
 #: app/partials/monitoring.service.list.edit.php:40
-#: app/partials/monitoring.service.list.php:34
-#: app/partials/service.info.php:62 app/views/popup.service.edit.php:54
+#: app/partials/monitoring.service.list.php:34 app/partials/service.info.php:62
+#: app/views/popup.service.edit.php:54
 msgid "Parent services"
-msgstr ""
+msgstr "Services parents"
 
 #: app/partials/configuration.tags.tab.php:42
 msgid "Parent templates"
@@ -13458,12 +13444,12 @@ msgstr "Déclencheurs parents"
 
 #: include/views/configuration.httpconf.edit.php:57
 msgid "Parent web scenarios"
-msgstr "Scénario web parent"
+msgstr "Scénario Web parent"
 
 #: include/classes/api/services/CService.php:1392
 #, c-format
 msgid "Parent-child relation conflict in services \"%1$s\" and \"%2$s\"."
-msgstr ""
+msgstr "Relation père‑fils en conflit pour les services « %1$s » et « %2$s »."
 
 #: app/views/popup.httpstep.php:58
 #: include/views/configuration.host.discovery.edit.php:97
@@ -13474,7 +13460,7 @@ msgstr "Analyser"
 
 #: include/classes/core/CJsonRpc.php:171
 msgid "Parse error"
-msgstr "Erreur d'analyse"
+msgstr "Erreur d’analyse"
 
 #: app/views/administration.proxy.edit.php:73
 #: app/views/administration.proxy.list.php:55
@@ -13516,21 +13502,21 @@ msgstr "Mot de passe (une autre fois)"
 
 #: app/views/administration.user.edit.php:169
 msgid "Password is not mandatory for non internal authentication type."
-msgstr "Le mot de passe n'est pas obligatoire pour le type d'authentification non interne."
+msgstr "Le mot de passe n’est pas obligatoire pour le type d’authentification non interne."
 
 #: app/views/administration.authentication.edit.php:44
 msgid "Password must contain"
-msgstr ""
+msgstr "Les mots de passe doivent contenir"
 
 #: app/views/administration.authentication.edit.php:38
 msgid "Password policy"
-msgstr ""
+msgstr "Politique de mots de passe"
 
 #: app/views/administration.authentication.edit.php:46
 #: app/views/administration.authentication.edit.php:95
 #: app/views/administration.user.edit.php:151
 msgid "Password requirements:"
-msgstr ""
+msgstr "Contrainte des mots de passe :"
 
 #: jsLoader.php:166 jsLoader.php:280
 msgid "Paste"
@@ -13539,12 +13525,12 @@ msgstr "Coller"
 #: app/views/js/configuration.dashboard.edit.js.php:217
 #: app/views/js/monitoring.dashboard.view.js.php:302
 msgid "Paste page"
-msgstr ""
+msgstr "Coller la page"
 
 #: app/views/js/configuration.dashboard.edit.js.php:210
 #: app/views/js/monitoring.dashboard.view.js.php:295 jsLoader.php:141
 msgid "Paste widget"
-msgstr ""
+msgstr "Coller le widget"
 
 #: jsLoader.php:281
 msgid "Paste without external links"
@@ -13553,7 +13539,7 @@ msgstr "Coller sans les liens externes"
 #: app/controllers/CControllerPopupTriggerExpr.php:877
 #: app/views/monitoring.charts.view.php:106
 msgid "Pattern"
-msgstr ""
+msgstr "Motif"
 
 #: actionconf.php:82 include/views/configuration.action.edit.php:163
 msgid "Pause operations for suppressed problems"
@@ -13562,11 +13548,11 @@ msgstr "Suspendre les opérations des problèmes supprimés"
 #: include/classes/debug/CProfiler.php:163
 #, c-format
 msgid "Peak memory usage: %1$s"
-msgstr "Pic d'utilisation de la mémoire : %1$s"
+msgstr "Pic d’utilisation de la mémoire : %1$s"
 
 #: include/classes/data/CItemData.php:1428
 msgid "Percent of time the virtual machine is unable to run because it is contending for access to the physical CPU(s), <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr ""
+msgstr "Pourcentage de temps durant lequel la machine virtuelle ne peut s’exécuter car elle est en conflit pour accéder au(x) processeur(s) physique(s), <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:213
 msgid "Percentage"
@@ -13574,11 +13560,11 @@ msgstr "Pourcentage"
 
 #: include/classes/data/CItemData.php:1512
 msgid "Percentage of host physical memory that has been consumed, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr ""
+msgstr "Pourcentage de la mémoire de l’hôte qui a été consommé, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1436
 msgid "Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU, <url> - VMware service URL, <uuid> - VMware virtual machine host name, <instance> - CPU instance"
-msgstr ""
+msgstr "Pourcentage de temps durant lequel la machine virtuelle était prête mais ne pouvait s’exécuter à cause d’un conflit d’accès au processeur physique, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware, <instance> — instance de processeur"
 
 #: graphs.php:55 include/views/configuration.graph.edit.php:150
 msgid "Percentile line (left)"
@@ -13590,12 +13576,12 @@ msgstr "Ligne de centile (droite)"
 
 #: include/classes/data/CItemData.php:932
 msgid "Performs a DNS query. Returns character string with the required type of information"
-msgstr "Réalise une requête DNS. Retourne une chaîne de caractères avec le type d'information requis"
+msgstr "Réalise une requête DNS. Retourne une chaîne de caractères avec le type d’information requis"
 
 #: app/partials/scheduledreport.formgrid.html.php:83
 #: app/partials/scheduledreport.table.html.php:42
-#: app/views/popup.lldoperation.php:116
-#: app/views/popup.massupdate.item.php:227 app/views/popup.triggerexpr.php:181
+#: app/views/popup.lldoperation.php:116 app/views/popup.massupdate.item.php:227
+#: app/views/popup.triggerexpr.php:181
 #: include/views/configuration.host.discovery.edit.php:632
 #: include/views/configuration.item.edit.php:735
 #: include/views/configuration.item.prototype.edit.php:714
@@ -13606,7 +13592,7 @@ msgstr "Période"
 #: app/controllers/CControllerPopupTriggerExpr.php:95
 #: app/controllers/CControllerPopupTriggerExpr.php:1050
 msgid "Period shift"
-msgstr ""
+msgstr "Décalage de période"
 
 #: app/views/popup.maintenance.period.php:69
 #: app/views/popup.service.time.edit.php:38
@@ -13634,7 +13620,7 @@ msgstr "Permissions"
 
 #: app/views/administration.user.edit.php:451
 msgid "Permissions can be assigned for user groups only."
-msgstr "Les permissions ne peuvent être assignées qu'aux groupes d'utilisateurs."
+msgstr "Les permissions ne peuvent être assignées qu’aux groupes d’utilisateurs."
 
 #: include/locales.inc.php:67
 msgid "Persian (fa_IR)"
@@ -13666,24 +13652,24 @@ msgstr "Jouer un son"
 #: include/classes/setup/CSetupWizard.php:741
 #, c-format
 msgid "Please check configuration parameters. If all is correct, press \"%1$s\" button, or \"%2$s\" button to change configuration parameters."
-msgstr "Veuillez vérifier les paramètres de configuration. Si tout est correct, appuyez sur le bouton \"%1$s\" ; sinon, le bouton \"%2$s\" pour changer les paramètres."
+msgstr "Veuillez vérifier les paramètres de configuration. Si tout est correct, appuyez sur le bouton « %1$s » ; sinon, le bouton « %2$s » pour changer les paramètres."
 
 #: app/views/js/popup.massupdate.js.php:414
 msgid "Please confirm that you want to remove all macros."
-msgstr ""
+msgstr "Veuillez confirmer que vous souhaitez supprimer toutes les macros."
 
 #: app/views/js/popup.massupdate.js.php:417
 msgid "Please confirm that you want to remove all value mappings."
-msgstr ""
+msgstr "Veuillez confirmer que vous souhaitez supprimer toutes les correspondances de valeurs."
 
 #: include/classes/setup/CSetupWizard.php:589
 #, c-format
 msgid "Please create database manually, and set the configuration parameters for connection to this database. Press \"%1$s\" button when done."
-msgstr "Veiullez créer la base de données manuellement et configurer les paramètres de connexion. Appuyez sur le bouton \"%1$s\" quand c'est fait."
+msgstr "Veiullez créer la base de données manuellement et configurer les paramètres de connexion. Appuyez sur le bouton « %1$s » quand c’est fait."
 
 #: include/classes/setup/CSetupWizard.php:177
 msgid "Please enable \"allow_url_fopen\" directive."
-msgstr ""
+msgstr "Veuillez activer la directive « allow_url_fopen »."
 
 #: jsLoader.php:269
 msgid "Please select two elements"
@@ -13717,7 +13703,7 @@ msgstr "Polonais (pl_PL)"
 
 #: include/views/configuration.item.edit.php:952
 msgid "Populates host inventory field"
-msgstr "Remplit le champ d'inventaire d'hôte"
+msgstr "Remplit le champ d’inventaire d’hôte"
 
 #: app/controllers/CControllerPopupItemTest.php:1310
 #: app/partials/monitoring.host.filter.php:113
@@ -13732,7 +13718,7 @@ msgstr "Port"
 
 #: include/classes/api/services/CHostInterface.php:842
 msgid "Port cannot be empty for host interface."
-msgstr "Le port ne peut pas être vide pour l'interface hôte."
+msgstr "Le port ne peut pas être vide pour l’interface hôte."
 
 #: app/views/popup.discovery.check.php:56
 msgid "Port range"
@@ -13756,20 +13742,20 @@ msgstr "Type POST"
 
 #: include/classes/data/CItemData.php:1392
 msgid "Power usage , <url> - VMware service URL, <uuid> - VMware hypervisor host name, <max> - Maximum allowed power usage"
-msgstr ""
+msgstr "Consommation, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware, <max> — consommation maximale autorisée"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:832
 msgid "Power value"
-msgstr ""
+msgstr "Valeur de puissance"
 
 #: include/classes/setup/CSetupWizard.php:70
 #: include/classes/setup/CSetupWizard.php:739
 msgid "Pre-installation summary"
-msgstr "Résumé pré-installation"
+msgstr "Résumé préinstallation"
 
 #: app/views/popup.triggerexpr.php:114
 msgid "Prediction functions"
-msgstr ""
+msgstr "Fonctions de prédiction"
 
 #: app/views/popup.massupdate.item.php:494
 #: include/views/configuration.host.discovery.edit.php:939
@@ -13805,7 +13791,7 @@ msgstr "Aperçu"
 #: app/partials/scheduledreport.formgrid.html.php:86
 #: app/partials/scheduledreport.table.html.php:56
 msgid "Previous day"
-msgstr ""
+msgstr "Jour précédent"
 
 #: app/partials/scheduledreport.formgrid.html.php:88
 #: app/partials/scheduledreport.table.html.php:58 include/func.inc.php:2403
@@ -13815,7 +13801,7 @@ msgstr "Mois précédent"
 #: app/views/monitoring.dashboard.view.php:161
 #: app/views/monitoring.host.dashboard.view.php:94 jsLoader.php:192
 msgid "Previous page"
-msgstr ""
+msgstr "Page précédente"
 
 #: app/views/popup.itemtestedit.view.php:282
 msgid "Previous value"
@@ -13833,31 +13819,31 @@ msgstr "Année précédente"
 
 #: include/hosts.inc.php:399
 msgid "Primary POC cell"
-msgstr "Contact Principal - Mobile"
+msgstr "Contact Principal — Mobile"
 
 #: include/hosts.inc.php:384
 msgid "Primary POC email"
-msgstr "Contact Principal - Courriel"
+msgstr "Contact Principal — Courriel"
 
 #: include/hosts.inc.php:379
 msgid "Primary POC name"
-msgstr "Contact Principal - Nom"
+msgstr "Contact Principal — Nom"
 
 #: include/hosts.inc.php:409
 msgid "Primary POC notes"
-msgstr "Contact Principal - Notes"
+msgstr "Contact Principal — Notes"
 
 #: include/hosts.inc.php:389
 msgid "Primary POC phone A"
-msgstr "Contact Principal - Téléphone 1"
+msgstr "Contact Principal — Téléphone 1"
 
 #: include/hosts.inc.php:394
 msgid "Primary POC phone B"
-msgstr "Contact Principal - Téléphone 2"
+msgstr "Contact Principal — Téléphone 2"
 
 #: include/hosts.inc.php:404
 msgid "Primary POC screen name"
-msgstr "Contact Principal - Identifiant"
+msgstr "Contact Principal — Identifiant"
 
 #: app/partials/configuration.host.interface.row.php:179
 #: app/views/popup.discovery.check.php:117
@@ -13882,7 +13868,7 @@ msgstr "Privé"
 #: include/views/configuration.item.edit.php:669
 #: include/views/configuration.item.prototype.edit.php:651
 msgid "Private key file"
-msgstr "Fichier de clé privée"
+msgstr "Fichier de clef privée"
 
 #: app/partials/configuration.host.edit.html.php:310
 #: app/views/popup.massupdate.host.php:157
@@ -13938,7 +13924,7 @@ msgstr "Hôtes problématiques"
 
 #: include/actions.inc.php:360
 msgid "Problem is not suppressed"
-msgstr "Le problème n'est pas supprimé"
+msgstr "Le problème n’est pas supprimé"
 
 #: include/actions.inc.php:43 include/actions.inc.php:359
 msgid "Problem is suppressed"
@@ -13951,7 +13937,7 @@ msgstr "Problème sur"
 #: app/views/popup.mediatype.message.php:52
 #: include/classes/helpers/CMediatypeHelper.php:64
 msgid "Problem recovery"
-msgstr ""
+msgstr "Résolution du problème"
 
 #: include/actions.inc.php:2062
 msgid "Problem resolved"
@@ -13960,12 +13946,12 @@ msgstr "Problème résolu"
 #: app/views/popup.service.edit.php:58 app/views/popup.service.edit.php:288
 #: app/views/popup.services.php:61
 msgid "Problem tags"
-msgstr ""
+msgstr "Étiquettes de problème"
 
 #: app/views/popup.mediatype.message.php:55
 #: include/classes/helpers/CMediatypeHelper.php:79
 msgid "Problem update"
-msgstr ""
+msgstr "Mise à jour du problème"
 
 #: app/controllers/CControllerProblemView.php:151
 #: app/partials/monitoring.host.view.html.php:33
@@ -13992,15 +13978,15 @@ msgstr "Problèmes par gravité"
 
 #: include/classes/data/CItemData.php:1016
 msgid "Process CPU utilization percentage. Returns float"
-msgstr ""
+msgstr "Pourcentage d’utilisation du processeur par le processus. Retourne en flottant"
 
 #: app/views/administration.mediatype.edit.php:234
 msgid "Process tags"
-msgstr ""
+msgstr "Étiquettes de processus"
 
 #: include/classes/helpers/CMenuHelper.php:371
 msgid "Profile"
-msgstr ""
+msgstr "Profil"
 
 #: include/items.inc.php:1902 include/items.inc.php:1906
 msgid "Prometheus"
@@ -14026,7 +14012,7 @@ msgstr "Propriétés"
 #: include/classes/helpers/CVaultHelper.php:107
 #, c-format
 msgid "Provided URL \"%1$s\" is invalid."
-msgstr "L'URL fourni \"%1$s\" est invalide."
+msgstr "L’URL fourni « %1$s » est invalide."
 
 #: app/controllers/CControllerPopupGeneric.php:157
 #: app/views/administration.proxy.edit.php:28
@@ -14053,22 +14039,22 @@ msgstr "Proxy"
 #: include/classes/api/services/CProxy.php:606
 #, c-format
 msgid "Proxy \"%1$s\" already exists."
-msgstr ""
+msgstr "Le proxy « %1$s » existe déjà."
 
 #: include/classes/import/importers/CHostImporter.php:313
 #, c-format
 msgid "Proxy \"%1$s\" for host \"%2$s\" does not exist."
-msgstr "Le proxy \"%1$s\" pour l'hôte \"%2$s\" n'existe pas."
+msgstr "Le proxy « %1$s » pour l’hôte « %2$s » n’existe pas."
 
 #: include/classes/api/services/CProxy.php:471
 #, c-format
 msgid "Proxy \"%1$s\" is used by action \"%2$s\"."
-msgstr "Le proxy \"%1$s\" est utilisé par l'action \"%2$s\"."
+msgstr "Le proxy « %1$s » est utilisé par l’action « %2$s »."
 
 #: include/classes/api/services/CProxy.php:428
 #, c-format
 msgid "Proxy \"%1$s\" is used by discovery rule \"%2$s\"."
-msgstr "Le proxy \"%1$s\" est utilisé par la règle de découverte \"%2$s\"."
+msgstr "Le proxy « %1$s » est utilisé par la règle de découverte « %2$s »."
 
 #: app/controllers/CControllerProxyCreate.php:114
 msgid "Proxy added"
@@ -14107,7 +14093,7 @@ msgstr "Public"
 #: include/views/configuration.item.edit.php:638
 #: include/views/configuration.item.prototype.edit.php:621
 msgid "Public key"
-msgstr "Clé publique"
+msgstr "Clef publique"
 
 #: app/views/administration.script.edit.php:144
 #: app/views/popup.massupdate.item.php:189
@@ -14115,7 +14101,7 @@ msgstr "Clé publique"
 #: include/views/configuration.item.edit.php:660
 #: include/views/configuration.item.prototype.edit.php:642
 msgid "Public key file"
-msgstr "Fichier de clé publique"
+msgstr "Fichier de clef publique"
 
 #: app/views/popup.httpstep.php:64
 #: include/views/configuration.host.discovery.edit.php:171
@@ -14130,7 +14116,7 @@ msgstr "Champs de requête"
 #: include/classes/helpers/CMenuHelper.php:293
 #: include/classes/helpers/CRoleHelper.php:387
 msgid "Queue"
-msgstr "File d'attente"
+msgstr "File d’attente"
 
 #: app/views/administration.queue.details.php:27
 #: app/views/administration.queue.details.php:39
@@ -14138,7 +14124,7 @@ msgstr "File d'attente"
 #: app/views/administration.queue.overview.proxy.php:39
 #: include/classes/helpers/CMenuHelper.php:299
 msgid "Queue details"
-msgstr ""
+msgstr "Détails de la file d’attente"
 
 #: app/views/administration.queue.details.php:33
 #: app/views/administration.queue.overview.php:27
@@ -14146,7 +14132,7 @@ msgstr ""
 #: app/views/administration.queue.overview.proxy.php:33
 #: include/classes/helpers/CMenuHelper.php:295
 msgid "Queue overview"
-msgstr ""
+msgstr "Aperçu de la file d’attente"
 
 #: app/views/administration.queue.details.php:36
 #: app/views/administration.queue.overview.php:36
@@ -14154,7 +14140,7 @@ msgstr ""
 #: app/views/administration.queue.overview.proxy.php:36
 #: include/classes/helpers/CMenuHelper.php:297
 msgid "Queue overview by proxy"
-msgstr ""
+msgstr "Aperçu de la file d’attente par le proxy"
 
 #: app/views/hintbox.eventlist.php:100
 #: app/views/monitoring.widget.problems.view.php:93
@@ -14202,12 +14188,12 @@ msgstr "Lecture seule"
 #: app/views/administration.user.edit.php:550
 #: app/views/administration.userrole.edit.php:179
 msgid "Read-only access to services"
-msgstr ""
+msgstr "Accès aux services en lecture seule"
 
 #: app/views/administration.user.edit.php:559
 #: app/views/administration.userrole.edit.php:203
 msgid "Read-only access to services with tag"
-msgstr ""
+msgstr "Accès en lecture seule aux services étiquetés"
 
 #: app/partials/administration.usergroup.grouprights.html.php:69
 #: app/views/administration.usergroup.edit.php:131
@@ -14216,23 +14202,23 @@ msgstr ""
 #: include/users.inc.php:421 include/views/js/monitoring.sysmap.edit.js.php:59
 #: include/views/js/monitoring.sysmap.edit.js.php:93
 msgid "Read-write"
-msgstr "Lecture-écriture"
+msgstr "Lecture‐écriture"
 
 #: app/views/administration.user.edit.php:483
 #: app/views/administration.user.edit.php:491
 #: app/views/administration.user.edit.php:505
 #: app/views/administration.userrole.edit.php:138
 msgid "Read-write access to services"
-msgstr ""
+msgstr "Accès aux services en lecture‑écriture"
 
 #: app/views/administration.user.edit.php:514
 #: app/views/administration.userrole.edit.php:162
 msgid "Read-write access to services with tag"
-msgstr ""
+msgstr "Accès en lecture‑écriture aux services étiquetés"
 
 #: include/classes/data/CItemData.php:924
 msgid "Reads modbus data. Returns various types"
-msgstr ""
+msgstr "Lit les données modbus. Retourne des types divers"
 
 #: include/actions.inc.php:60
 msgid "Received value"
@@ -14260,16 +14246,16 @@ msgstr "Destinataire"
 
 #: app/controllers/CControllerPopupScheduledReportSubscriptionEdit.php:89
 msgid "Recipient already exists."
-msgstr ""
+msgstr "Le destinataire existe déjà."
 
 #: include/views/administration.auditacts.list.php:30
 msgid "Recipients"
-msgstr ""
+msgstr "Destinataires"
 
 #: app/views/reports.auditlog.list.php:73
 #: app/views/reports.auditlog.list.php:95
 msgid "Recordset ID"
-msgstr ""
+msgstr "Identifiant du jeu de résultats"
 
 #: app/views/administration.user.edit.php:682
 #: include/classes/screens/CScreenProblem.php:1067
@@ -14291,7 +14277,7 @@ msgstr "Expression de récupération"
 #: include/forms.inc.php:1918 include/forms.inc.php:1925
 #: include/forms.inc.php:1935
 msgid "Recovery expression syntax error."
-msgstr "Erreur de syntaxe dans l'expression de récupération."
+msgstr "Erreur de syntaxe dans l’expression de récupération."
 
 #: include/views/configuration.action.edit.php:393
 msgid "Recovery operations"
@@ -14321,12 +14307,12 @@ msgstr "Intervalle de rafraîchissement"
 #: app/views/administration.token.edit.php:107
 #: app/views/administration.user.token.edit.php:89
 msgid "Regenerate"
-msgstr ""
+msgstr "Regénérer"
 
 #: app/views/administration.token.edit.php:108
 #: app/views/administration.user.token.edit.php:90
 msgid "Regenerate selected API token? Previously generated token will become invalid."
-msgstr ""
+msgstr "Régénérer le jeton d’API sélectionné ? Le jeton précédent sera invalidé."
 
 #: include/forms.inc.php:353
 msgid "Regular"
@@ -14336,44 +14322,44 @@ msgstr "Normal"
 #: app/views/popup.lldoverride.php:101 include/items.inc.php:1803
 #: include/views/configuration.host.discovery.edit.php:742
 msgid "Regular expression"
-msgstr "Expression régulière"
+msgstr "Expression rationnelle"
 
 #: include/classes/api/services/CRegexp.php:196
 #, c-format
 msgid "Regular expression \"%1$s\" already exists."
-msgstr ""
+msgstr "L’expression rationnelle « %1$s » existe déjà."
 
 #: app/controllers/CControllerRegExCreate.php:67
 msgid "Regular expression added"
-msgstr "Expression régulière ajoutée"
+msgstr "Expression rationnelle ajoutée"
 
 #: app/controllers/CControllerRegExDelete.php:50
 msgid "Regular expression deleted"
 msgid_plural "Regular expressions deleted"
-msgstr[0] "Expression régulière supprimée"
-msgstr[1] "Expressions régulière supprimées"
+msgstr[0] "Expression rationnelle supprimée"
+msgstr[1] "Expressions rationnelles supprimées"
 
 #: app/controllers/CControllerRegExTest.php:72
 msgid "Regular expression must be a string"
-msgstr "L'expression régulière doit être une chaîne"
+msgstr "L’expression rationnelle doit être une chaîne"
 
 #: app/controllers/CControllerRegExUpdate.php:80
 msgid "Regular expression updated"
-msgstr "Expression régulière modifiée"
+msgstr "Expression rationnelle modifiée"
 
 #: app/views/administration.regex.edit.php:29
 #: app/views/administration.regex.list.php:31
 #: include/classes/helpers/CMenuHelper.php:237 include/html.inc.php:892
 msgid "Regular expressions"
-msgstr "Expressions régulières"
+msgstr "Expressions rationnelles"
 
 #: app/controllers/CControllerPopupScheduledReportList.php:52
 msgid "Related reports"
-msgstr ""
+msgstr "Rapports liés"
 
 #: jsLoader.php:149
 msgid "Release to create a widget."
-msgstr ""
+msgstr "Relâchez pour créer un widget."
 
 #: include/views/general.login.php:77
 msgid "Remember me for 30 days"
@@ -14522,7 +14508,7 @@ msgstr "Supprimer"
 #: app/partials/massupdate.macros.tab.php:127
 #: app/partials/massupdate.valuemaps.tab.php:98
 msgid "Remove all"
-msgstr ""
+msgstr "Tout supprimer"
 
 #: app/views/administration.authentication.edit.php:125
 msgid "Remove domain name"
@@ -14530,19 +14516,19 @@ msgstr "Supprimer le nom de domaine"
 
 #: app/controllers/CControllerFavouriteCreate.php:64 include/html.inc.php:147
 msgid "Remove from favorites"
-msgstr ""
+msgstr "Supprimer des préférés"
 
 #: include/actions.inc.php:1034
 msgid "Remove from host group"
-msgstr "Retirer du groupe d'hôtes"
+msgstr "Retirer du groupe d’hôtes"
 
 #: include/actions.inc.php:717
 msgid "Remove from host groups"
-msgstr "Retirer du groupe d'hôte"
+msgstr "Retirer du groupe d’hôte"
 
 #: include/actions.inc.php:690 include/actions.inc.php:1030
 msgid "Remove host"
-msgstr "Supprimer l'hôte"
+msgstr "Supprimer l’hôte"
 
 #: app/views/monitoring.widget.favgraphs.view.php:51
 #: app/views/monitoring.widget.favmaps.view.php:39
@@ -14553,7 +14539,7 @@ msgstr "Supprimer, %1$s"
 
 #: app/controllers/CControllerPopupImportCompare.php:159
 msgid "Removed"
-msgstr ""
+msgstr "Supprimé"
 
 #: jsLoader.php:339
 #, c-format
@@ -14563,18 +14549,18 @@ msgstr "Supprimé, %1$s"
 
 #: app/partials/massupdate.valuemaps.tab.php:96
 msgid "Rename"
-msgstr ""
+msgstr "Renommer"
 
 #: app/controllers/CControllerPopupScheduledReportCreate.php:70
 #: app/controllers/CControllerScheduledReportCreate.php:82
 #: app/controllers/CControllerScheduledReportUpdate.php:86
 #: app/partials/scheduledreport.formgrid.html.php:135
 msgid "Repeat on"
-msgstr ""
+msgstr "Répéter sur"
 
 #: app/partials/scheduledreport.table.html.php:41
 msgid "Repeats"
-msgstr ""
+msgstr "Répète"
 
 #: app/views/popup.massupdate.host.php:47
 #: app/views/popup.massupdate.host.php:88
@@ -14599,39 +14585,39 @@ msgstr "Remplacer les dépendances"
 #: app/controllers/CControllerPopupTriggerExpr.php:647
 #: app/controllers/CControllerPopupTriggerExpr.php:882
 msgid "Replacement"
-msgstr ""
+msgstr "Remplacement"
 
 #: include/classes/api/services/CReport.php:256
 #, c-format
 msgid "Report \"%1$s\" already exists."
-msgstr ""
+msgstr "Un rapport « %1$s » existe déjà."
 
 #: app/views/js/reports.scheduledreport.edit.js.php:74
 msgid "Report generated by other users will be changed to the current user."
-msgstr ""
+msgstr "Les rapports générés par d’autres utilisateurs seront réattribué à l’utilisateur actuel."
 
 #: app/controllers/CControllerPopupScheduledReportTest.php:97
 msgid "Report generating test failed."
-msgstr ""
+msgstr "Le test de génération de rapport a échoué."
 
 #: app/controllers/CControllerPopupScheduledReportTest.php:94
 msgid "Report generating test successful."
-msgstr ""
+msgstr "Test de génération de rapport réussi."
 
 #: app/views/popup.scheduledreport.subscription.php:107
 #, c-format
 msgid "Report is currently generated by \"%1$s\"."
-msgstr ""
+msgstr "Le rapport est actuellement généré par « %1$s »."
 
 #: app/views/popup.scheduledreport.test.php:52
 #, c-format
 msgid "Report sending failed for: %1$s."
-msgstr ""
+msgstr "L’envoi du rapport à %1$s a échoué."
 
 #: app/views/popup.scheduledreport.test.php:44
 #, c-format
 msgid "Report was successfully sent to: %1$s."
-msgstr ""
+msgstr "Le rapport a bien été envoyé à %1$s."
 
 #: include/classes/helpers/CMenuHelper.php:132
 #: include/classes/helpers/CRoleHelper.php:278
@@ -14669,7 +14655,7 @@ msgstr "Requis"
 
 #: app/views/administration.script.edit.php:242
 msgid "Required host permissions"
-msgstr "Permissions d'hôte requses"
+msgstr "Permissions d’hôte requses"
 
 #: app/views/administration.proxy.list.php:83
 msgid "Required performance (vps)"
@@ -14688,7 +14674,7 @@ msgstr "Performance serveur requise, nouvelles valeurs par seconde"
 #: include/views/configuration.item.edit.php:414
 #: include/views/configuration.item.prototype.edit.php:399
 msgid "Required status codes"
-msgstr "Code d'état requis"
+msgstr "Code d’état requis"
 
 #: app/views/popup.httpstep.php:170
 msgid "Required string"
@@ -14705,7 +14691,7 @@ msgstr "Réinitialiser"
 #: app/views/js/administration.miscconfig.edit.js.php:42
 #: app/views/js/administration.trigdisplay.edit.js.php:48
 msgid "Reset all fields to default values?"
-msgstr "Réinitialiser tous les champs à leur valeur par défaut ?"
+msgstr "Réinitialiser tous les champs à leur valeur par défaut ?"
 
 #: app/views/js/administration.audit.settings.edit.js.php:41
 #: app/views/js/administration.gui.edit.js.php:31
@@ -14730,7 +14716,7 @@ msgstr "Réinitialiser aux valeurs par défaut"
 
 #: jsLoader.php:172
 msgid "Reset to initial view"
-msgstr ""
+msgstr "Réinitialiser à la vue initiale"
 
 #: jsLoader.php:291
 msgid "Resolved"
@@ -14746,7 +14732,7 @@ msgstr "Résolu par"
 #: include/classes/screens/CScreenProblem.php:990
 #, c-format
 msgid "Resolved by correlation rule \"%1$s\"."
-msgstr "Résolu par la règle de corrélation \"%1$s\"."
+msgstr "Résolu par la règle de corrélation « %1$s »."
 
 #: app/views/monitoring.widget.problems.view.php:157
 #: include/classes/screens/CScreenProblem.php:993
@@ -14756,13 +14742,13 @@ msgstr "Résolu par la règle de corrélation."
 #: app/views/monitoring.widget.problems.view.php:164
 #: include/classes/screens/CScreenProblem.php:1000
 msgid "Resolved by inaccessible user."
-msgstr ""
+msgstr "Résolu par un utilisateur inaccessible."
 
 #: app/views/monitoring.widget.problems.view.php:163
 #: include/classes/screens/CScreenProblem.php:999
 #, c-format
 msgid "Resolved by user \"%1$s\"."
-msgstr "Résolu par l'utilisateur \"%1$s\"."
+msgstr "Résolu par l’utilisateur « %1$s »."
 
 #: app/views/reports.auditlog.list.php:64
 #: app/views/reports.auditlog.list.php:92
@@ -14771,11 +14757,11 @@ msgstr "Ressource"
 
 #: app/views/reports.auditlog.list.php:67
 msgid "Resource ID"
-msgstr ""
+msgstr "Identifiant de ressource"
 
 #: app/views/popup.mediatypetest.edit.php:46 app/views/popup.scriptexec.php:47
 msgid "Response"
-msgstr ""
+msgstr "Réponse"
 
 #: include/classes/screens/CScreenHttpTestDetails.php:84
 msgid "Response code"
@@ -14787,11 +14773,11 @@ msgstr "Temps de réponse"
 
 #: app/controllers/CControllerPopupMediatypeTestSend.php:162
 msgid "Response type: JSON"
-msgstr ""
+msgstr "Type de la réponse : JSON"
 
 #: app/controllers/CControllerPopupMediatypeTestSend.php:162
 msgid "Response type: String"
-msgstr ""
+msgstr "Type de la réponse : String"
 
 #: app/views/administration.regex.edit.php:123
 #: app/views/administration.regex.edit.php:128
@@ -14806,7 +14792,7 @@ msgstr "Résultat"
 #: app/controllers/CControllerPopupItemTestSend.php:418
 #, c-format
 msgid "Result converted to %1$s"
-msgstr ""
+msgstr "Résultat converti à %1$s"
 
 #: app/views/js/administration.regex.edit.js.php:176
 #: include/classes/helpers/CRegexHelper.php:30
@@ -14824,7 +14810,7 @@ msgstr "Type de résultat"
 
 #: app/views/js/popup.itemtestedit.view.js.php:321
 msgid "Result with value map applied"
-msgstr ""
+msgstr "Résultat avec application de la correspondance de valeurs"
 
 #: app/views/popup.httpstep.php:158
 #: include/views/configuration.host.discovery.edit.php:370
@@ -14835,7 +14821,7 @@ msgstr "Mode de récupération"
 
 #: include/classes/data/CItemData.php:1176
 msgid "Retrieving contents of a file. Returns text"
-msgstr "Récupère le contenu d'un fichier. Retourne du texte"
+msgstr "Récupère le contenu d’un fichier. Retourne du texte"
 
 #: include/views/general.warning.php:32
 msgid "Retry"
@@ -14843,31 +14829,31 @@ msgstr "Réessayer"
 
 #: include/classes/data/CItemData.php:884
 msgid "Return a JSON array with LLD macros describing the MBean objects or their attributes. Can be used for LLD."
-msgstr ""
+msgstr "Retourne un tableau JSON contenant les macros LLD décrivant les objets MBean ou leurs attributs. Peut être utilisé avec la découverte de bas niveau."
 
 #: include/classes/data/CItemData.php:888
 msgid "Return a JSON array with MBean objects or their attributes. Compared to jmx.discovery it does not define LLD macros. Can be used for LLD."
-msgstr ""
+msgstr "Retourne un tableau JSON contenant les objets MBean ou leurs attributs. Comparé à jmx.discovery, cela ne définit pas les macros LLD. Peut être utilisé avec la découverte de bas niveau."
 
 #: include/classes/data/CItemData.php:860
 msgid "Return first column of the first row of the SQL query result."
-msgstr "Retourne la première colonne de la première ligne du résultat d'une requête SQL."
+msgstr "Retourne la première colonne de la première ligne du résultat d’une requête SQL."
 
 #: include/classes/data/CItemData.php:892
 msgid "Return value of an attribute of MBean object."
-msgstr "Retourne la valeur d'un attribut d'un objet MBean."
+msgstr "Retourne la valeur d’un attribut d’un objet MBean."
 
 #: include/classes/data/CItemData.php:1196
 msgid "Returns 4-digit string containing octal number with Unix permissions"
-msgstr ""
+msgstr "Retourne une chaîne contenant les 4 chiffres de la valeur octale des permissions UNIX"
 
 #: include/classes/data/CItemData.php:876
 msgid "Returns ICMP ping response time in seconds. Example: 0.02"
-msgstr "Retourne le temps de réponse au ping ICMP en secondes. Exemple : 0.02"
+msgstr "Retourne le temps de réponse au ping ICMP en secondes. Exemple : 0.02"
 
 #: include/classes/data/CItemData.php:1660
 msgid "Returns a JSON array describing the host network interfaces configured in Zabbix. Can be used for LLD."
-msgstr ""
+msgstr "Retourne un tableau JSON décrivant les interfaces réseau de l’hôte configuré dans Zabbix. Peut être utilisé avec la découverte de bas niveau."
 
 #: include/classes/data/CItemData.php:1616
 #: include/classes/data/CItemData.php:1716
@@ -14876,23 +14862,23 @@ msgstr "Retourne un objet JSON contenant les métriques internes du serveur Zabb
 
 #: include/classes/data/CItemData.php:1656
 msgid "Returns availability of a particular type of checks on the host. Value of this item corresponds to availability icons in the host list. Valid types are: agent, snmp, ipmi, jmx."
-msgstr "Retourne la disponibilité d'un type particulier de vérification sur l'hôte. La valeur correspond aux icônes de disponibilité dans la liste d'hôtes. Les types valides sont: agent, snmp, ipmi, jmx."
+msgstr "Retourne la disponibilité d’un type particulier de vérification sur l’hôte. La valeur correspond aux icônes de disponibilité dans la liste d’hôtes. Les types valides sont : agent, snmp, ipmi et jmx."
 
 #: include/classes/data/CItemData.php:1652
 msgid "Returns current maintenance status of the host."
-msgstr "Retourne l'état de maintenance actuel de l'hôte."
+msgstr "Retourne l’état de maintenance actuel de l’hôte."
 
 #: include/classes/data/CItemData.php:1676
 msgid "Returns information associated with Zabbix Java gateway. Valid params are: ping, version."
-msgstr "Retourne les informations associées avec la passerelle Java de Zabbix. Les params valides sont : ping, version."
+msgstr "Retourne les informations associées avec la passerelle Java de Zabbix. Les paramètres valides sont : ping, version."
 
 #: include/classes/data/CItemData.php:980
 msgid "Returns number of TCP sockets that match parameters. Returns integer"
-msgstr ""
+msgstr "Retourne le nombre de sockets TCP qui correspondent aux paramètres. Renvoie un entier"
 
 #: include/classes/data/CItemData.php:996
 msgid "Returns number of UDP sockets that match parameters. Returns integer"
-msgstr ""
+msgstr "Retourne le nombre de sockets UDP qui correspondent aux paramètres. Renvoie un entier"
 
 #: include/classes/data/CItemData.php:872
 msgid "Returns percentage of lost ICMP ping packets."
@@ -14900,7 +14886,7 @@ msgstr "Retourne le pourcentage de paquets ICMP ping perdus."
 
 #: include/classes/html/CMacroValue.php:94
 msgid "Revert changes"
-msgstr ""
+msgstr "Annuler les modifications"
 
 #: include/classes/widgets/CWidgetHelper.php:783
 #: include/classes/widgets/CWidgetHelper.php:858
@@ -14928,7 +14914,7 @@ msgstr "Rogner à droite"
 #: app/views/administration.user.edit.php:406
 #: app/views/administration.user.edit.php:416
 msgid "Role"
-msgstr ""
+msgstr "Rôle"
 
 #: include/locales.inc.php:71
 msgid "Romanian (ro_RO)"
@@ -14937,7 +14923,7 @@ msgstr "Roumain (ro_RO)"
 #: app/partials/monitoring.service.list.edit.php:55
 #: app/partials/monitoring.service.list.php:52
 msgid "Root cause"
-msgstr ""
+msgstr "Cause initiale"
 
 #: include/classes/widgets/forms/CWidgetForm.php:81
 msgid "Rows"
@@ -14954,26 +14940,26 @@ msgstr "Règles"
 #: include/actions.inc.php:635 include/actions.inc.php:813
 #, c-format
 msgid "Run script \"%1$s\" on Zabbix server"
-msgstr ""
+msgstr "Exécuter le script « %1$s » sur le serveur Zabbix"
 
 #: include/actions.inc.php:648 include/actions.inc.php:826
 #, c-format
 msgid "Run script \"%1$s\" on current host"
-msgstr ""
+msgstr "Exécuter le script « %1$s » sur l’hôte actuel"
 
 #: include/actions.inc.php:679 include/actions.inc.php:857
 #, c-format
 msgid "Run script \"%1$s\" on host groups"
-msgstr ""
+msgstr "Exécuter le script « %1$s » sur les groupes d’hôtes"
 
 #: include/actions.inc.php:661 include/actions.inc.php:839
 #, c-format
 msgid "Run script \"%1$s\" on hosts"
-msgstr ""
+msgstr "Exécuter le script « %1$s » sur les hôtes"
 
 #: include/classes/data/CItemData.php:1104
 msgid "Run specified command on the host. Returns text result of the command; 1 - with mode as nowait (regardless of command result)"
-msgstr "Exécute la commande spécifiée sur l'hôte. Retourne le résultat textuel de la commande ; 1 - dans le mode nowait (indépendamment du résultat de la commande)"
+msgstr "Exécute la commande spécifiée sur l’hôte. Retourne le résultat textuel de la commande ; 1 — dans le mode nowait (indépendamment du résultat de la commande)"
 
 #: include/locales.inc.php:72
 msgid "Russian (ru_RU)"
@@ -14991,18 +14977,17 @@ msgstr "D"
 
 #: app/views/administration.authentication.edit.php:336
 msgid "SAML settings"
-msgstr ""
+msgstr "Paramètres SAML"
 
 #: app/partials/monitoring.service.list.edit.php:56
-#: app/partials/monitoring.service.list.php:53
-#: app/partials/service.info.php:72 app/views/popup.service.edit.php:242
-#: app/views/popup.service.edit.php:345
+#: app/partials/monitoring.service.list.php:53 app/partials/service.info.php:72
+#: app/views/popup.service.edit.php:242 app/views/popup.service.edit.php:345
 msgid "SLA"
 msgstr "SLA"
 
 #: app/views/administration.authentication.edit.php:236
 msgid "SLO service URL"
-msgstr ""
+msgstr "URL de service SLO"
 
 #: include/media.inc.php:26
 msgid "SMS"
@@ -15015,7 +15000,7 @@ msgstr "SMTP"
 #: app/views/administration.mediatype.edit.php:74
 #: app/views/administration.mediatype.list.php:92
 msgid "SMTP email"
-msgstr "adresse SMTP"
+msgstr "Adresse de courriel SMTP"
 
 #: app/views/administration.mediatype.edit.php:69
 #: app/views/administration.mediatype.list.php:91
@@ -15025,7 +15010,7 @@ msgstr "SMTP helo"
 #: app/views/administration.mediatype.edit.php:61
 #: app/views/administration.mediatype.list.php:90
 msgid "SMTP server"
-msgstr "serveur SMTP"
+msgstr "Serveur SMTP"
 
 #: app/views/administration.mediatype.edit.php:66
 msgid "SMTP server port"
@@ -15050,7 +15035,7 @@ msgstr "OID SNMP"
 
 #: include/items.inc.php:89
 msgid "SNMP agent"
-msgstr ""
+msgstr "Agent SNMP"
 
 #: app/controllers/CControllerPopupItemTest.php:1295
 #: app/partials/configuration.host.interface.row.php:91
@@ -15069,57 +15054,57 @@ msgstr "Trap SNMP"
 
 #: include/classes/api/services/CItemGeneral.php:566
 msgid "SNMP trap key is invalid."
-msgstr "La clé du trap SNMP est invalide."
+msgstr "La clef du trap SNMP est invalide."
 
 #: app/partials/configuration.host.interface.row.php:76
 #: app/views/popup.itemtestedit.view.php:125
 msgid "SNMP version"
-msgstr ""
+msgstr "Version de SNMP"
 
 #: include/items.inc.php:1302
 #, c-format
 msgid "SNMPv%1$d"
-msgstr ""
+msgstr "SNMPv%1$d"
 
 #: app/partials/configuration.host.interface.row.php:81
 #: app/views/popup.itemtestedit.view.php:133
 msgid "SNMPv1"
-msgstr ""
+msgstr "SNMPv1"
 
 #: include/discovery.inc.php:57
 msgid "SNMPv1 agent"
-msgstr "agent SNMPv1"
+msgstr "Agent SNMPv1"
 
 #: app/partials/configuration.host.interface.row.php:82
 #: app/views/popup.itemtestedit.view.php:134
 msgid "SNMPv2"
-msgstr ""
+msgstr "SNMPv2"
 
 #: include/discovery.inc.php:58
 msgid "SNMPv2 agent"
-msgstr "agent SNMPv2"
+msgstr "Agent SNMPv2"
 
 #: app/partials/configuration.host.interface.row.php:83
 #: app/views/popup.itemtestedit.view.php:135
 msgid "SNMPv3"
-msgstr ""
+msgstr "SNMPv3"
 
 #: include/discovery.inc.php:59
 msgid "SNMPv3 agent"
-msgstr "agent SNMPv3"
+msgstr "Agent SNMPv3"
 
 #: app/views/administration.authentication.edit.php:249
 msgid "SP entity ID"
-msgstr ""
+msgstr "Identifiant d’identité du SP"
 
 #: app/views/administration.authentication.edit.php:257
 msgid "SP name ID format"
-msgstr ""
+msgstr "Format de l’indentifiant de nom du SP"
 
 #: include/classes/debug/CProfiler.php:158
 #, c-format
 msgid "SQL count: %1$s (selects: %2$s | executes: %3$s)"
-msgstr "Compte SQL : %1$s (selects: %2$s | executes : %3$s)"
+msgstr "Compte SQL : %1$s (selects : %2$s | executes : %3$s)"
 
 #: include/items.inc.php:1770
 #: include/views/configuration.host.discovery.edit.php:610
@@ -15131,12 +15116,12 @@ msgstr "Requête SQL"
 #: include/classes/db/DB.php:975
 #, c-format
 msgid "SQL statement execution has failed \"%1$s\""
-msgstr "L'exécution de l'instruction SQL a échoué \"%1$s\""
+msgstr "L’exécution de l’instruction SQL a échoué « %1$s »"
 
 #: include/classes/db/DB.php:643 include/classes/db/DB.php:702
 #, c-format
 msgid "SQL statement execution has failed \"%1$s\"."
-msgstr "L'exécution de l'instruction SQL a échoué\"%1$s\"."
+msgstr "L’exécution de l’instruction SQL a échoué : « %1$s »."
 
 #: app/views/administration.script.edit.php:116
 #: app/views/administration.script.list.php:144 include/discovery.inc.php:47
@@ -15159,14 +15144,14 @@ msgstr "Fichier de certificat SSL"
 #: include/views/configuration.item.edit.php:515
 #: include/views/configuration.item.prototype.edit.php:499
 msgid "SSL key file"
-msgstr "Fichier de clé SSL"
+msgstr "Fichier de clef SSL"
 
 #: include/views/configuration.host.discovery.edit.php:459
 #: include/views/configuration.httpconf.edit.php:187
 #: include/views/configuration.item.edit.php:523
 #: include/views/configuration.item.prototype.edit.php:507
 msgid "SSL key password"
-msgstr "Mot de passe de la clé SSL"
+msgstr "Mot de passe de la clef SSL"
 
 #: app/views/administration.mediatype.edit.php:87
 #: include/views/configuration.host.discovery.edit.php:432
@@ -15174,7 +15159,7 @@ msgstr "Mot de passe de la clé SSL"
 #: include/views/configuration.item.edit.php:499
 #: include/views/configuration.item.prototype.edit.php:483
 msgid "SSL verify host"
-msgstr "Vérifier l'hôte SSL"
+msgstr "Vérifier l’hôte SSL"
 
 #: app/views/administration.mediatype.edit.php:86
 #: include/views/configuration.host.discovery.edit.php:424
@@ -15190,7 +15175,7 @@ msgstr "SSL/TLS"
 
 #: app/views/administration.authentication.edit.php:230
 msgid "SSO service URL"
-msgstr ""
+msgstr "URL de service SSO"
 
 #: app/views/administration.mediatype.edit.php:82
 msgid "STARTTLS"
@@ -15214,11 +15199,11 @@ msgstr "Samedi"
 
 #: app/views/popup.tabfilter.edit.php:80
 msgid "Save"
-msgstr ""
+msgstr "Enregistrer"
 
 #: include/classes/html/CTabFilter.php:95
 msgid "Save as"
-msgstr ""
+msgstr "Enregistrer sous"
 
 #: app/views/configuration.dashboard.edit.php:65
 #: app/views/monitoring.dashboard.view.php:146
@@ -15228,11 +15213,11 @@ msgstr "Sauvegarder les modifications"
 #: include/classes/setup/CSetupWizard.php:857
 #, c-format
 msgid "Save it as \"%1$s\""
-msgstr "L'enregistrer sous \"%1$s\""
+msgstr "L’enregistrer sous « %1$s »"
 
 #: app/views/administration.module.list.php:34
 msgid "Scan directory"
-msgstr ""
+msgstr "Analyser le répertoire"
 
 #: include/views/configuration.httpconf.edit.php:235
 msgid "Scenario"
@@ -15240,7 +15225,7 @@ msgstr "Scénario"
 
 #: app/partials/configuration.tags.tab.php:135
 msgid "Scenario tags"
-msgstr ""
+msgstr "Étiquettes de scénarios"
 
 #: include/views/configuration.maintenance.edit.php:45
 msgid "Schedule"
@@ -15253,37 +15238,37 @@ msgstr "Vérification planifiée"
 #: app/controllers/CControllerAuditLogList.php:236
 #: app/views/reports.scheduledreport.edit.php:57
 msgid "Scheduled report"
-msgstr ""
+msgstr "Rapport planifié"
 
 #: app/controllers/CControllerScheduledReportCreate.php:145
 msgid "Scheduled report added"
-msgstr ""
+msgstr "Rapport planifié ajouté"
 
 #: app/controllers/CControllerPopupScheduledReportCreate.php:129
 msgid "Scheduled report created"
-msgstr ""
+msgstr "Rapport planifié créé"
 
 #: app/controllers/CControllerScheduledReportDelete.php:67
 msgid "Scheduled report deleted"
 msgid_plural "Scheduled reports deleted"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Rapport planifié supprimé"
+msgstr[1] "Rapports planifiés supprimés"
 
 #: app/controllers/CControllerScheduledReportDisable.php:74
 msgid "Scheduled report disabled"
 msgid_plural "Scheduled reports disabled"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Rapport planifié désactivé"
+msgstr[1] "Rapports planifiés désactivés"
 
 #: app/controllers/CControllerScheduledReportEnable.php:74
 msgid "Scheduled report enabled"
 msgid_plural "Scheduled reports enabled"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Rapport planifié activé"
+msgstr[1] "Rapports planifiés activés"
 
 #: app/controllers/CControllerScheduledReportUpdate.php:147
 msgid "Scheduled report updated"
-msgstr ""
+msgstr "Rapport planifié mis à jour"
 
 #: app/controllers/CControllerScheduledReportEdit.php:309
 #: app/controllers/CControllerScheduledReportList.php:148
@@ -15292,11 +15277,10 @@ msgstr ""
 #: include/classes/helpers/CMenuHelper.php:106
 #: include/classes/helpers/CRoleHelper.php:347
 msgid "Scheduled reports"
-msgstr ""
+msgstr "Rapports planifiés"
 
 #: app/views/js/popup.massupdate.tmpl.js.php:84
-#: app/views/popup.lldoperation.php:125
-#: app/views/popup.massupdate.item.php:235
+#: app/views/popup.lldoperation.php:125 app/views/popup.massupdate.item.php:235
 #: include/views/configuration.host.discovery.edit.php:638
 #: include/views/configuration.item.edit.php:743
 #: include/views/configuration.item.edit.php:750
@@ -15310,7 +15294,7 @@ msgstr "Planification"
 #: app/views/administration.script.list.php:48
 #: app/views/administration.script.list.php:75
 msgid "Scope"
-msgstr ""
+msgstr "Portée"
 
 #: app/views/popup.acknowledge.edit.php:53
 msgctxt "selected problems"
@@ -15333,7 +15317,7 @@ msgstr "Script"
 #: include/classes/api/services/CScript.php:1346
 #, c-format
 msgid "Script \"%1$s\" already exists."
-msgstr "Le script \"%1$s\" existe déjà."
+msgstr "Le script « %1$s » existe déjà."
 
 #: app/controllers/CControllerScriptCreate.php:150
 msgid "Script added"
@@ -15347,11 +15331,11 @@ msgstr[1] "Script supprimé"
 
 #: app/views/js/popup.scriptexec.js.php:47
 msgid "Script execution log"
-msgstr ""
+msgstr "Journal d’exécution du script"
 
 #: app/controllers/CControllerPopupScriptExec.php:116
 msgid "Script execution successful."
-msgstr ""
+msgstr "Exécution du script réussie."
 
 #: app/views/administration.mediatype.edit.php:95
 #: app/views/administration.mediatype.list.php:96
@@ -15393,51 +15377,51 @@ msgstr "Expression de recherche vide"
 
 #: app/views/monitoring.charts.view.php:103
 msgid "Search type"
-msgstr ""
+msgstr "Type de recherche"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1060
 msgid "Season"
-msgstr ""
+msgstr "Saison"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1075
 msgid "Season deviation window"
-msgstr ""
+msgstr "Fenêtre d’écart saisonnier"
 
 #: include/hosts.inc.php:434
 msgid "Secondary POC cell"
-msgstr "Contact Secondaire - Mobile"
+msgstr "Contact Secondaire — Mobile"
 
 #: include/hosts.inc.php:419
 msgid "Secondary POC email"
-msgstr "Contact Secondaire - Courriel"
+msgstr "Contact Secondaire — Courriel"
 
 #: include/hosts.inc.php:414
 msgid "Secondary POC name"
-msgstr "Contact Secondaire - Nom"
+msgstr "Contact Secondaire — Nom"
 
 #: include/hosts.inc.php:444
 msgid "Secondary POC notes"
-msgstr "Contact Secondaire - Notes"
+msgstr "Contact Secondaire — Notes"
 
 #: include/hosts.inc.php:424
 msgid "Secondary POC phone A"
-msgstr "Contact Secondaire - Téléphone 1"
+msgstr "Contact Secondaire — Téléphone 1"
 
 #: include/hosts.inc.php:429
 msgid "Secondary POC phone B"
-msgstr "Contact Secondaire - Téléphone 2"
+msgstr "Contact Secondaire — Téléphone 2"
 
 #: include/hosts.inc.php:439
 msgid "Secondary POC screen name"
-msgstr "Contact Secondaire - Identifiant"
+msgstr "Contact Secondaire — Identifiant"
 
 #: include/classes/html/CMacroValue.php:157
 msgid "Secret text"
-msgstr ""
+msgstr "Texte secret"
 
 #: app/views/administration.miscconfig.edit.php:98
 msgid "Security"
-msgstr ""
+msgstr "Sécurité"
 
 #: app/partials/configuration.host.interface.row.php:127
 #: app/views/popup.discovery.check.php:92
@@ -15511,7 +15495,7 @@ msgstr "Sélectionné, %1$s, lecture seule, en position %2$d de %3$d"
 
 #: jsLoader.php:275
 msgid "Send backward"
-msgstr "Envoyer vers l'arrière"
+msgstr "Envoyer vers l’arrière"
 
 #: include/actions.inc.php:1027
 msgid "Send message"
@@ -15519,7 +15503,7 @@ msgstr "Envoi message"
 
 #: include/actions.inc.php:622 include/actions.inc.php:800
 msgid "Send message to user groups"
-msgstr "Envoyer le message aux groupes d'utilisateurs"
+msgstr "Envoyer le message aux groupes d’utilisateurs"
 
 #: include/actions.inc.php:604 include/actions.inc.php:782
 msgid "Send message to users"
@@ -15536,15 +15520,15 @@ msgstr "Envoyer"
 
 #: jsLoader.php:276
 msgid "Send to back"
-msgstr "Envoyer à l'arrière"
+msgstr "Envoyer à l’arrière"
 
 #: app/partials/popup.operations.php:82
 msgid "Send to user groups"
-msgstr ""
+msgstr "Envoyer aux groupes d’utilisateurs"
 
 #: app/partials/popup.operations.php:102
 msgid "Send to users"
-msgstr ""
+msgstr "Envoyer aux utilisateurs"
 
 #: include/actions.inc.php:2128
 #: include/views/administration.auditacts.list.php:77
@@ -15553,7 +15537,7 @@ msgstr "Envoyé"
 
 #: include/func.inc.php:228
 msgid "Sep"
-msgstr "Sep"
+msgstr "sept."
 
 #: include/classes/widgets/forms/CWidgetFormProblemHosts.php:123
 #: include/classes/widgets/forms/CWidgetFormProblemsBySv.php:179
@@ -15565,11 +15549,11 @@ msgstr "Séparé"
 #: include/classes/widgets/forms/CWidgetFormProblemsBySv.php:141
 #: include/classes/widgets/forms/CWidgetFormProblems.php:161
 msgid "Separately"
-msgstr ""
+msgstr "Séparément"
 
 #: include/func.inc.php:108 include/func.inc.php:245 jsLoader.php:239
 msgid "September"
-msgstr "Septembre"
+msgstr "septembre"
 
 #: include/hosts.inc.php:134 include/views/inventory.host.list.php:89
 msgid "Serial number A"
@@ -15610,23 +15594,23 @@ msgstr "Service"
 #: include/classes/api/services/CService.php:1469
 #, c-format
 msgid "Service \"%1$s\" acceptable SLA must have no more than 4 digits after the decimal point."
-msgstr ""
+msgstr "Un niveau de service (SLA) acceptable pour le service « %1$s » doit avoir plus de quatre décimales."
 
 #: include/classes/api/services/CService.php:1523
 #: include/classes/api/services/CService.php:1563
 #, c-format
 msgid "Service \"%1$s\" cannot have problem tags and children at the same time."
-msgstr ""
+msgstr "Le service « %1$s » ne peut avoir des étiquettes de problème et des fils en même temps."
 
 #: include/classes/api/services/CService.php:1496
 #, c-format
 msgid "Service \"%1$s\" cannot show SLA for the selected status calculation rule."
-msgstr ""
+msgstr "Le service « %1$s » ne peut afficher le niveau de service de la règle de calcul de statut sélectionnée."
 
 #: include/classes/helpers/CMenuHelper.php:175
 #: include/views/configuration.action.list.php:28
 msgid "Service actions"
-msgstr ""
+msgstr "Actions de service"
 
 #: app/controllers/CControllerServiceCreate.php:173
 msgid "Service created"
@@ -15634,23 +15618,22 @@ msgstr "Service créé"
 
 #: app/views/administration.housekeeping.edit.php:58
 msgid "Service data storage period"
-msgstr ""
+msgstr "Durée de stockage des données de service"
 
 #: app/controllers/CControllerServiceDelete.php:69
-#, fuzzy
 msgid "Service deleted"
 msgid_plural "Services deleted"
 msgstr[0] "Service supprimé"
-msgstr[1] "Service supprimé"
+msgstr[1] "Services supprimés"
 
 #: app/views/administration.userrole.edit.php:144
 #: app/views/administration.userrole.edit.php:185
 msgid "Service list"
-msgstr ""
+msgstr "Liste des services"
 
 #: include/actions.inc.php:68
 msgid "Service name"
-msgstr ""
+msgstr "Nom du service"
 
 #: include/actions.inc.php:57
 msgid "Service port"
@@ -15659,24 +15642,24 @@ msgstr "Port du service"
 #: app/views/popup.mediatype.message.php:61
 #: include/classes/helpers/CMediatypeHelper.php:119
 msgid "Service recovery"
-msgstr ""
+msgstr "Reprise du service"
 
 #: app/controllers/CControllerServiceTimeValidate.php:96
 #: include/classes/api/services/CService.php:1695
 msgid "Service start time must be less than end time."
-msgstr "L'heure de démarrage du service doit être antérieure à l'heure de fin."
+msgstr "L’heure de démarrage du service doit être antérieure à l’heure de fin."
 
 #: app/views/popup.condition.common.php:153
 msgid "Service tag name"
-msgstr ""
+msgstr "Nom de l’étiquette de service"
 
 #: app/views/popup.condition.common.php:156
 msgid "Service tag value"
-msgstr ""
+msgstr "Valeur de l’étiquette de service"
 
 #: app/controllers/CControllerPopupServiceTimeEdit.php:119
 msgid "Service time"
-msgstr ""
+msgstr "Heure du service"
 
 #: app/views/popup.service.edit.php:251
 msgid "Service times"
@@ -15689,7 +15672,7 @@ msgstr "Type de service"
 #: app/views/popup.mediatype.message.php:64
 #: include/classes/helpers/CMediatypeHelper.php:140
 msgid "Service update"
-msgstr ""
+msgstr "Mise à jour du service"
 
 #: app/controllers/CControllerServiceUpdate.php:189
 msgid "Service updated"
@@ -15698,7 +15681,7 @@ msgstr "Service mis à jour"
 #: include/classes/api/services/CRole.php:536
 #, c-format
 msgid "Service with ID \"%2$s\" is not available for user role \"%1$s\"."
-msgstr ""
+msgstr "Le service dont l’identifiant est « %2$s » n’est pas disponible pour le rôle d’utilisateur « %1$s »."
 
 #: app/controllers/CControllerServiceListEdit.php:178
 #: app/controllers/CControllerServiceListEditRefresh.php:152
@@ -15719,11 +15702,11 @@ msgstr "Les services forment une dépendance circulaire."
 
 #: app/controllers/CControllerPopupMassupdateService.php:150
 msgid "Services updated"
-msgstr ""
+msgstr "Services mis à jour"
 
 #: include/classes/core/ZBase.php:244 include/classes/core/ZBase.php:471
 msgid "Session initialization error."
-msgstr ""
+msgstr "Erreur d’initialisation de la session."
 
 #: include/classes/api/services/CUser.php:1696
 #: include/classes/api/services/CUser.php:1710
@@ -15740,32 +15723,32 @@ msgstr "Définir une période personnalisée"
 #: app/views/js/popup.itemtestedit.view.js.php:371 include/forms.inc.php:1417
 #: include/views/js/item.preprocessing.js.php:68
 msgid "Set error to"
-msgstr "Positionner l'erreur à"
+msgstr "Positionner l’erreur à"
 
 #: app/views/administration.token.edit.php:76
 #: app/views/administration.user.token.edit.php:58
 msgid "Set expiration date and time"
-msgstr ""
+msgstr "Définir la date et l’heure de l’expiration"
 
 #: include/actions.inc.php:1037
 msgid "Set host inventory mode"
-msgstr "Configurer le mode d'inventaire d'hôte"
+msgstr "Configurer le mode d’inventaire d’hôte"
 
 #: include/classes/html/CInputSecret.php:80 jsLoader.php:409
 msgid "Set new value"
-msgstr ""
+msgstr "Définir une nouvelle valeur"
 
 #: app/views/popup.service.statusrule.edit.php:38
 msgid "Set status to"
-msgstr ""
+msgstr "Définir le statut à"
 
 #: include/classes/helpers/CServiceHelper.php:28
 msgid "Set status to OK"
-msgstr ""
+msgstr "Définir le statut à OK"
 
 #: jsLoader.php:171
 msgid "Set this view as default"
-msgstr ""
+msgstr "Définir cette vue comme vue par défaut"
 
 #: app/views/js/popup.itemtestedit.view.js.php:365 include/forms.inc.php:1416
 #: include/views/js/item.preprocessing.js.php:67
@@ -15782,13 +15765,13 @@ msgstr "La définition du protocole LDAP a échoué."
 
 #: include/classes/validators/CLdapAuthValidator.php:82
 msgid "Setting LDAP referrals to \"Off\" failed."
-msgstr "La définition des références LDAP sur \"Off\" a échoué."
+msgstr "La définition des références LDAP sur « Off » a échoué."
 
 #: app/controllers/CControllerAuditLogList.php:238
 #: include/classes/setup/CSetupWizard.php:66
 #: include/classes/setup/CSetupWizard.php:624
 msgid "Settings"
-msgstr ""
+msgstr "Paramètres"
 
 #: app/controllers/CControllerPopupGeneric.php:178
 #: app/controllers/CControllerPopupGeneric.php:192
@@ -15826,8 +15809,7 @@ msgctxt "screen reader"
 msgid "Severity changed"
 msgstr "La criticité a changé"
 
-#: include/actions.inc.php:1754
-#: include/classes/screens/CScreenProblem.php:1221
+#: include/actions.inc.php:1754 include/classes/screens/CScreenProblem.php:1221
 msgid "Severity changes"
 msgstr "Changements de gravité"
 
@@ -15838,7 +15820,7 @@ msgstr "La criticité a diminué"
 
 #: jsLoader.php:152
 msgid "Severity filter"
-msgstr ""
+msgstr "Filtre de gravité"
 
 #: include/actions.inc.php:1780
 msgctxt "screen reader"
@@ -15853,7 +15835,7 @@ msgstr "Forme"
 
 #: app/views/monitoring.dashboard.list.php:99
 msgid "Shared"
-msgstr ""
+msgstr "Partagé"
 
 #: include/views/monitoring.sysmap.edit.php:414 jsLoader.php:363
 msgid "Sharing"
@@ -15864,7 +15846,7 @@ msgstr "Partage"
 #: include/classes/api/services/CMap.php:1261
 #, c-format
 msgid "Sharing option \"%1$s\" is missing a value for map \"%2$s\"."
-msgstr "La valeur est manquante pour l'option de partage \"%1$s\" de la carte \"%2$s\"."
+msgstr "La valeur est manquante pour l’option de partage « %1$s » de la carte « %2$s »."
 
 #: app/partials/monitoring.problem.filter.php:222
 #: include/classes/widgets/forms/CWidgetFormProblems.php:139
@@ -15892,7 +15874,7 @@ msgstr "Afficher les détails"
 
 #: include/classes/widgets/CWidgetHelper.php:53
 msgid "Show header"
-msgstr ""
+msgstr "Afficher l’en‑tête"
 
 #: app/partials/monitoring.host.filter.php:134
 #: include/classes/widgets/forms/CWidgetFormHostAvail.php:62
@@ -15919,13 +15901,13 @@ msgstr "Afficher les lignes"
 
 #: app/views/popup.tabfilter.edit.php:34
 msgid "Show number of records"
-msgstr ""
+msgstr "Afficher le nombre d’enregistrements"
 
 #: app/partials/monitoring.problem.filter.php:240
 #: include/classes/widgets/forms/CWidgetFormProblemsBySv.php:139
 #: include/classes/widgets/forms/CWidgetFormProblems.php:159
 msgid "Show operational data"
-msgstr ""
+msgstr "Afficher les données opérationnelles"
 
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:299
 msgid "Show problems"
@@ -15940,7 +15922,7 @@ msgstr "Afficher sélections"
 #: include/classes/html/widget/CWidget.php:153
 #: include/classes/html/widget/CWidget.php:156
 msgid "Show sidebar"
-msgstr ""
+msgstr "Afficher la barre latérale"
 
 #: app/partials/monitoring.host.filter.php:140
 #: app/partials/monitoring.problem.filter.php:249
@@ -15957,11 +15939,11 @@ msgstr "Afficher les problèmes supprimés"
 #: app/partials/monitoring.problem.filter.php:232
 #: include/classes/widgets/forms/CWidgetFormProblems.php:117
 msgid "Show tags"
-msgstr "Voir les tags"
+msgstr "Voir les étiquettes"
 
 #: app/views/administration.gui.edit.php:117
 msgid "Show technical errors"
-msgstr ""
+msgstr "Afficher les erreurs techniques"
 
 #: include/classes/widgets/forms/CWidgetFormPlainText.php:68
 msgid "Show text as HTML"
@@ -15980,7 +15962,7 @@ msgstr "Afficher les déclencheurs"
 #: app/partials/monitoring.problem.filter.php:255
 #: include/classes/widgets/forms/CWidgetFormProblems.php:184
 msgid "Show unacknowledged only"
-msgstr "Afficher les non-acquittés seulement"
+msgstr "Afficher les non‐acquittés seulement"
 
 #: include/classes/widgets/forms/CWidgetFormNavTree.php:51
 msgid "Show unavailable maps"
@@ -16000,23 +15982,23 @@ msgstr "Affiché"
 
 #: include/classes/html/widget/CWidget.php:160
 msgid "Sidebar control"
-msgstr ""
+msgstr "Contrôle de la barre latérale"
 
 #: app/views/administration.authentication.edit.php:265
 msgid "Sign"
-msgstr ""
+msgstr "Signer"
 
 #: include/views/general.login.php:65 include/views/general.login.php:80
 msgid "Sign in"
-msgstr "S'enregistrer"
+msgstr "S’enregistrer"
 
 #: include/views/general.login.php:46
 msgid "Sign in with HTTP"
-msgstr "Connectez-vous avec HTTP"
+msgstr "Connectez‐vous avec HTTP"
 
 #: include/views/general.login.php:50
 msgid "Sign in with Single Sign-On (SAML)"
-msgstr ""
+msgstr "Authentification unique SSO (SAML)"
 
 #: include/classes/helpers/CMenuHelper.php:389
 #: include/classes/helpers/CMenuHelper.php:392
@@ -16051,39 +16033,39 @@ msgstr "Seul"
 
 #: include/hosts.inc.php:364
 msgid "Site ZIP / postal"
-msgstr "Site - Code postal"
+msgstr "Site — Code postal"
 
 #: include/hosts.inc.php:334
 msgid "Site address A"
-msgstr "Site - Adresse 1"
+msgstr "Site — adresse 1"
 
 #: include/hosts.inc.php:339
 msgid "Site address B"
-msgstr "Site - Adresse 2"
+msgstr "Site — adresse 2"
 
 #: include/hosts.inc.php:344
 msgid "Site address C"
-msgstr "Site - Adresse 3"
+msgstr "Site — adresse 3"
 
 #: include/hosts.inc.php:349
 msgid "Site city"
-msgstr "Site - Ville"
+msgstr "Site — ville"
 
 #: include/hosts.inc.php:359
 msgid "Site country"
-msgstr "Site - Pays"
+msgstr "Site — pays"
 
 #: include/hosts.inc.php:374
 msgid "Site notes"
-msgstr "Site - Notes"
+msgstr "Site — notes"
 
 #: include/hosts.inc.php:369
 msgid "Site rack location"
-msgstr "Site - Localisation baie"
+msgstr "Site — localisation de la baie"
 
 #: include/hosts.inc.php:354
 msgid "Site state / province"
-msgstr "Site - État / province"
+msgstr "Site — état / province"
 
 #: include/views/js/monitoring.sysmaps.js.php:455
 msgid "Size"
@@ -16092,12 +16074,12 @@ msgstr "Taille"
 #: include/classes/server/CZabbixServer.php:530
 #, c-format
 msgid "Size of the response received from Zabbix server \"%1$s\" exceeds the allowed size of %2$s bytes. This value can be increased in the ZBX_SOCKET_BYTES_LIMIT constant in include/defines.inc.php."
-msgstr "La taille de la réponse reçue du serveur Zabbix \"%1$s\" dépasse la taille autorisée de %2$s octets. Cette valeur peut être augmentée dans la constante ZBX_SOCKET_BYTES_LIMIT dans include/defines.inc.php."
+msgstr "La taille de la réponse reçue du serveur Zabbix « %1$s » dépasse la taille autorisée de %2$s octets. Cette valeur peut être augmentée dans la constante ZBX_SOCKET_BYTES_LIMIT dans include/defines.inc.php."
 
 #: include/graphs.inc.php:459
 #, c-format
 msgid "Skipped copying of graph \"%1$s\" to host \"%2$s\"."
-msgstr "Copie du graphique \"%1$s\" sur l'hôte \"%2$s\" sautée."
+msgstr "Copie du graphique « %1$s » sur l’hôte « %2$s » sautée."
 
 #: include/locales.inc.php:73
 msgid "Slovak (sk_SK)"
@@ -16137,11 +16119,11 @@ msgstr "Application logicielle E"
 
 #: include/classes/data/CItemData.php:1112
 msgid "Software architecture information. Returns string"
-msgstr "Information sur l'architecture logicielle. Retourne une chaîne"
+msgstr "Information sur l’architecture logicielle. Retourne une chaîne"
 
 #: include/classes/api/managers/CHistoryManager.php:1272
 msgid "Some of the history for this item may be compressed, deletion is not available."
-msgstr ""
+msgstr "Une partie de l’historique de cet élément peut être compressée, la suppression n’est pas possible."
 
 #: include/classes/widgets/forms/CWidgetFormActionLog.php:30
 #: include/classes/widgets/forms/CWidgetFormProblems.php:199
@@ -16150,12 +16132,12 @@ msgstr "Classer les entrées par"
 
 #: app/views/popup.service.edit.php:107
 msgid "Sort order (0->999)"
-msgstr "Ordre de tri (0->999)"
+msgstr "Ordre de tri (0→999)"
 
 #: include/classes/api/CApiService.php:592
 #, c-format
 msgid "Sorting by field \"%1$s\" not allowed."
-msgstr "Tri par le champ \"%1$s\" non autorisé."
+msgstr "Tri par le champ « %1$s » non autorisé."
 
 #: include/classes/screens/CScreenHistory.php:271
 #: include/classes/widgets/forms/CWidgetFormGraph.php:31
@@ -16173,15 +16155,15 @@ msgstr "Espagnol (es_ES)"
 
 #: include/classes/helpers/CRoleHelper.php:171
 msgid "Specified role was not found."
-msgstr ""
+msgstr "Le rôle spécifié n’a pas été trouvé."
 
 #: include/classes/api/services/CAction.php:2932
 msgid "Specified script does not exist or you do not have rights on it for action operation command."
-msgstr "Le script spécifié n'existe pas ou vous n'avez pas les droits dessis pour une commande d'opération d'action."
+msgstr "Le script spécifié n’existe pas ou vous n’avez pas les droits dessis pour une commande d’opération d’action."
 
 #: app/views/monitoring.charts.view.php:172
 msgid "Specify host to see the graphs."
-msgstr ""
+msgstr "Spécifiez l’hôte pour voir les graphiques."
 
 #: app/views/popup.generic.php:142 include/views/monitoring.history.php:295
 msgid "Specify some filter condition to see the values."
@@ -16208,16 +16190,16 @@ msgstr "Éléments standards"
 
 #: app/partials/administration.ha.nodes.php:45
 msgid "Standby"
-msgstr ""
+msgstr "Veille"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:637
 #: app/controllers/CControllerPopupTriggerExpr.php:755
 msgid "Start"
-msgstr ""
+msgstr "Démarrer"
 
 #: app/partials/scheduledreport.formgrid.html.php:151
 msgid "Start date"
-msgstr ""
+msgstr "Date de démarrage"
 
 #: include/views/configuration.action.edit.php:175
 msgid "Start in"
@@ -16228,15 +16210,15 @@ msgstr "Démarrer dans"
 #: app/views/monitoring.host.dashboard.view.php:101
 #: app/views/monitoring.host.dashboard.view.php:165 jsLoader.php:143
 msgid "Start slideshow"
-msgstr ""
+msgstr "Démarrer le diaporama"
 
 #: app/views/dashboard.properties.edit.php:81
 msgid "Start slideshow automatically"
-msgstr ""
+msgstr "Démarrer le diaporama automatiquement"
 
 #: app/partials/scheduledreport.formgrid.html.php:107
 msgid "Start time"
-msgstr ""
+msgstr "Heure de démarrage"
 
 #: include/classes/validators/CLdapAuthValidator.php:81
 msgid "Starting TLS failed."
@@ -16262,7 +16244,7 @@ msgstr "Statique"
 
 #: include/classes/data/CItemData.php:1756
 msgid "Statistics and availability of Zabbix write cache. Cache - one of values (modes: all, float, uint, str, log, text, not supported), history (modes: pfree, free, total, used, pused), index (modes: pfree, free, total, used, pused), trend (modes: pfree, free, total, used, pused)."
-msgstr ""
+msgstr "Statistiques et disponibilité du cache d’écriture de Zabbix. Cache — une des valeurs (modes : all, float, uint, str, log, text, not supported), historique (modes : pfree, free, total, used, pused), index (modes: pfree, free, total, used, pused), tendance (modes : pfree, free, total, used, pused)."
 
 #: app/controllers/CControllerPopupGeneric.php:179
 #: app/controllers/CControllerPopupGeneric.php:193
@@ -16292,8 +16274,7 @@ msgstr ""
 #: app/views/configuration.correlation.list.php:78
 #: app/views/configuration.discovery.list.php:53
 #: app/views/configuration.discovery.list.php:81
-#: app/views/configuration.host.list.php:176
-#: app/views/hintbox.eventlist.php:74
+#: app/views/configuration.host.list.php:176 app/views/hintbox.eventlist.php:74
 #: app/views/monitoring.service.list.edit.php:80
 #: app/views/monitoring.service.list.php:79
 #: app/views/monitoring.widget.actionlog.view.php:38
@@ -16337,15 +16318,15 @@ msgstr "État"
 #: app/views/popup.service.edit.php:116 app/views/popup.service.edit.php:287
 #: app/views/popup.services.php:60
 msgid "Status calculation rule"
-msgstr ""
+msgstr "Règle de calcul du statut"
 
 #: app/views/popup.service.edit.php:120
 msgid "Status calculation rule and additional rules are only applicable if child services exist."
-msgstr ""
+msgstr "La règle de calcul du statut et les règles additionnelles ne sont applicables que si des services fils existent."
 
 #: include/views/configuration.httpconf.edit.php:206
 msgid "Status codes"
-msgstr "Codes d'état"
+msgstr "Codes d’état"
 
 #: include/classes/helpers/CMapHelper.php:291
 msgid "Status disabled"
@@ -16374,7 +16355,7 @@ msgstr "Statut problème"
 
 #: app/views/popup.service.edit.php:173
 msgid "Status propagation rule"
-msgstr ""
+msgstr "Règle de propagation du statut"
 
 #: include/actions.inc.php:1921
 #: include/classes/screens/CScreenHttpTestDetails.php:81
@@ -16385,21 +16366,21 @@ msgstr "Étape"
 #: include/views/configuration.httpconf.list.php:168
 #, c-format
 msgid "Step \"%1$s\" [%2$s of %3$s] failed: %4$s"
-msgstr "Étape \"%1$s\" [%2$s sur %3$s] échouée : %4$s"
+msgstr "Étape « %1$s » [%2$s sur %3$s] échouée : %4$s"
 
 #: app/controllers/CControllerActionOperationValidate.php:98
 #: app/partials/popup.operations.php:64
 msgid "Step duration"
-msgstr "Durée de l'étape"
+msgstr "Durée de l’étape"
 
 #: app/controllers/CControllerPopupHttpStep.php:145
 msgid "Step of web scenario"
-msgstr "Étape du scénario web"
+msgstr "Étape du scénario Web"
 
 #: app/controllers/CControllerPopupHttpStep.php:110
 #, c-format
 msgid "Step with name \"%1$s\" already exists."
-msgstr "L'étape nommée \"%1$s\" existe déjà."
+msgstr "L’étape nommée « %1$s » existe déjà."
 
 #: app/partials/popup.operations.php:51 httpconf.php:51
 #: include/views/configuration.action.edit.php:175
@@ -16416,18 +16397,18 @@ msgstr "Stop"
 #: app/views/popup.lldoverride.php:57
 #: include/views/configuration.host.discovery.edit.php:913
 msgid "Stop processing"
-msgstr ""
+msgstr "Arrêter l’excécution"
 
 #: app/views/monitoring.dashboard.view.php:167
 #: app/views/monitoring.dashboard.view.php:237
 #: app/views/monitoring.host.dashboard.view.php:100
 #: app/views/monitoring.host.dashboard.view.php:166 jsLoader.php:144
 msgid "Stop slideshow"
-msgstr ""
+msgstr "Arrêter le diaporama"
 
 #: app/partials/administration.ha.nodes.php:40
 msgid "Stopped"
-msgstr ""
+msgstr "Arrêté"
 
 #: app/views/popup.lldoperation.php:191 app/views/popup.lldoperation.php:212
 #: app/views/popup.massupdate.item.php:295
@@ -16437,16 +16418,16 @@ msgstr ""
 #: include/views/configuration.item.prototype.edit.php:768
 #: include/views/configuration.item.prototype.edit.php:783
 msgid "Storage period"
-msgstr ""
+msgstr "Période de stockage"
 
 #: include/classes/setup/CSetupWizard.php:496
 msgid "Store credentials in"
-msgstr ""
+msgstr "Enregistrer les identifiants dans"
 
 #: include/classes/setup/CSetupWizard.php:642
 #: include/classes/setup/CSetupWizard.php:643
 msgid "Stored in HashiCorp Vault secret"
-msgstr ""
+msgstr "Enregistré dans le coffre‑fort HashiCorp"
 
 #: include/hosts.inc.php:35
 msgid "Straight"
@@ -16454,16 +16435,16 @@ msgstr "Littéral"
 
 #: app/views/monitoring.charts.view.php:105
 msgid "Strict"
-msgstr ""
+msgstr "Strict"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:497
 #: include/triggers.inc.php:1596
 msgid "String"
-msgstr ""
+msgstr "Chaîne"
 
 #: app/views/popup.triggerexpr.php:115
 msgid "String functions"
-msgstr ""
+msgstr "Fonctions de chaînes"
 
 #: include/items.inc.php:1822 include/items.inc.php:1826
 #: include/items.inc.php:1830 include/items.inc.php:1834
@@ -16472,7 +16453,7 @@ msgstr "Données structurées"
 
 #: include/forms.inc.php:157
 msgid "Subfilter"
-msgstr "Sous-filtre"
+msgstr "Sous‐filtre"
 
 #: app/partials/popup.operations.php:152
 #: app/partials/scheduledreport.formgrid.html.php:169
@@ -16492,15 +16473,15 @@ msgstr "Sujet"
 
 #: jsLoader.php:378
 msgid "Submap"
-msgstr "Sous-carte"
+msgstr "Sous‐carte"
 
 #: app/controllers/CControllerPopupScheduledReportSubscriptionEdit.php:168
 msgid "Subscription"
-msgstr ""
+msgstr "Abonnement"
 
 #: app/partials/scheduledreport.formgrid.html.php:187
 msgid "Subscriptions"
-msgstr ""
+msgstr "Abonnements"
 
 #: include/items.inc.php:39
 msgid "Success Audit"
@@ -16512,7 +16493,7 @@ msgstr "Message de succès"
 
 #: include/classes/data/CItemData.php:960
 msgid "Sum of incoming and outgoing traffic statistics on network interface. Returns integer"
-msgstr "Somme des statistiques de trafic entrant et sortant sur l'interface réseau. Retourne un entier"
+msgstr "Somme des statistiques de trafic entrant et sortant sur l’interface réseau. Retourne un entier"
 
 #: include/func.inc.php:196
 msgid "Sun"
@@ -16524,7 +16505,7 @@ msgstr "Dimanche"
 
 #: include/users.inc.php:54
 msgid "Super admin"
-msgstr ""
+msgstr "Super admin"
 
 #: include/classes/helpers/CMenuHelper.php:330
 #: include/views/general.login.php:94
@@ -16534,11 +16515,11 @@ msgstr "Support"
 #: include/html.inc.php:972
 #, c-format
 msgid "Suppressed till: %1$s"
-msgstr "Supprimé jusqu'à: %1$s"
+msgstr "Supprimé jusqu’à : %1$s"
 
 #: include/classes/data/CItemData.php:1124
 msgid "Swap in (from device into memory) statistics. Returns integer"
-msgstr "Statistiques d'entrée de la swap (du périphérique à la mémoire). Retourne un entier"
+msgstr "Statistiques d’entrée de la swap (du périphérique à la mémoire). Retourne un entier"
 
 #: include/classes/data/CItemData.php:1128
 msgid "Swap out (from memory onto device) statistics. Returns integer"
@@ -16546,7 +16527,7 @@ msgstr "Statistiques de sortie de la swap (de la mémoire au périphérique). Re
 
 #: include/classes/data/CItemData.php:1132
 msgid "Swap space size in bytes or in percentage from total. Returns integer for bytes; float for percentage"
-msgstr "Taille de l'espace de swap en octets ou en pourcentage du total. Retourne un entier pour les octets ; un flottant pour le pourcentage"
+msgstr "Taille de l’espace de swap en octets ou en pourcentage du total. Retourne un entier pour les octets ; un flottant pour le pourcentage"
 
 #: include/locales.inc.php:75
 msgid "Swedish (sv_SE)"
@@ -16554,11 +16535,11 @@ msgstr "Suédois (sv_SE)"
 
 #: app/views/js/administration.authentication.edit.js.php:36
 msgid "Switching authentication method will reset all except this session! Continue?"
-msgstr "Changer de méthode d'authentification va réinitialiser toutes les sessions sauf celle-ci ! Continuer ?"
+msgstr "Changer de méthode d’authentification va réinitialiser toutes les sessions sauf celle‐ci ! Continuer ?"
 
 #: include/classes/helpers/CDateTimeZoneHelper.php:97
 msgid "System"
-msgstr ""
+msgstr "Système"
 
 #: include/classes/data/CItemData.php:1052
 msgid "System boot time. Returns integer (Unix timestamp)"
@@ -16581,7 +16562,7 @@ msgstr "Erreur système."
 
 #: include/classes/data/CItemData.php:1080
 msgid "System host name. Returns string"
-msgstr "Nom d'hôte du système. Retourne une chaîne"
+msgstr "Nom d’hôte du système. Retourne une chaîne"
 
 #: app/controllers/CControllerReportStatus.php:42
 #: app/views/report.status.php:30 include/classes/helpers/CMenuHelper.php:103
@@ -16596,11 +16577,11 @@ msgstr "Statistiques du système. Retourne un entier ou un flottant"
 
 #: include/classes/widgets/forms/CWidgetFormSystemInfo.php:31
 msgid "System stats"
-msgstr ""
+msgstr "Statistiques système"
 
 #: include/classes/data/CItemData.php:1100
 msgid "System time. Returns integer with type as UTC; string - with type as local"
-msgstr ""
+msgstr "Heure système. Renvoie un entier si l’heure est UTC ou une chaîne si l’heure est locale"
 
 #: include/classes/data/CItemData.php:1140
 msgid "System uptime in seconds. Returns integer"
@@ -16622,7 +16603,7 @@ msgstr "TCP"
 
 #: include/items.inc.php:98
 msgid "TELNET agent"
-msgstr "agent TELNET"
+msgstr "Agent TELNET"
 
 #: include/classes/screens/CScreenHttpTestDetails.php:190
 msgid "TOTAL"
@@ -16636,12 +16617,12 @@ msgstr "VRAI"
 #: include/classes/db/DB.php:220
 #, c-format
 msgid "Table \"%1$s\" does not exist."
-msgstr "La table \"%1$s\" n'existe pas."
+msgstr "La table « %1$s » n’existe pas."
 
 #: include/classes/db/DB.php:497
 #, c-format
 msgid "Table \"%1$s\" doesn't have a field named \"%2$s\"."
-msgstr "La table \"%1$s\" n'a pas de champ nommé \"%2$s\"."
+msgstr "La table « %1$s » n’a pas de champ nommé « %2$s »."
 
 #: app/controllers/CControllerPopupLldOperation.php:131
 #: app/controllers/CControllerUsergroupTagfilterAdd.php:47
@@ -16656,25 +16637,25 @@ msgstr "Étiquette"
 #: app/partials/monitoring.problem.filter.php:233
 #: include/classes/widgets/forms/CWidgetFormProblems.php:151
 msgid "Tag display priority"
-msgstr "Priorité d'affichage des tags"
+msgstr "Priorité d’affichage des étiquettes"
 
 #: app/views/administration.usergroup.edit.php:208
 msgid "Tag filter"
-msgstr "Filtre de tag"
+msgstr "Filtre d’étiquette"
 
 #: include/views/configuration.trigger.prototype.edit.php:509
 #: include/views/configuration.triggers.edit.php:536
 msgid "Tag for matching"
-msgstr "Tag pour la concordance"
+msgstr "Étiquette pour la concordance"
 
 #: app/partials/monitoring.problem.filter.php:219 include/actions.inc.php:65
 #: include/classes/widgets/forms/CWidgetFormProblems.php:137
 msgid "Tag name"
-msgstr "Nom de tag"
+msgstr "Nom de l’étiquette"
 
 #: include/actions.inc.php:66
 msgid "Tag value"
-msgstr "Valeur du tag"
+msgstr "Valeur de l’étiquette"
 
 #: app/controllers/CControllerPopupLldOperation.php:138
 #: app/partials/administration.usergroup.tagfilters.html.php:29
@@ -16686,16 +16667,15 @@ msgstr "Valeur du tag"
 #: app/partials/monitoring.latest.view.html.php:71
 #: app/partials/monitoring.problem.filter.php:231
 #: app/partials/monitoring.service.list.edit.php:57
-#: app/partials/monitoring.service.list.php:54
-#: app/partials/service.info.php:80 app/views/configuration.host.list.php:156
-#: app/views/configuration.host.list.php:196
-#: app/views/hintbox.eventlist.php:77 app/views/monitoring.latest.view.php:90
+#: app/partials/monitoring.service.list.php:54 app/partials/service.info.php:80
+#: app/views/configuration.host.list.php:156
+#: app/views/configuration.host.list.php:196 app/views/hintbox.eventlist.php:77
+#: app/views/monitoring.latest.view.php:90
 #: app/views/monitoring.service.list.edit.php:108
 #: app/views/monitoring.service.list.php:91
 #: app/views/monitoring.web.view.php:87
 #: app/views/monitoring.widget.problems.view.php:68
-#: app/views/popup.lldoperation.php:262
-#: app/views/popup.massupdate.host.php:194
+#: app/views/popup.lldoperation.php:262 app/views/popup.massupdate.host.php:194
 #: app/views/popup.massupdate.host.php:287
 #: app/views/popup.massupdate.item.php:477
 #: app/views/popup.massupdate.item.php:493
@@ -16738,7 +16718,7 @@ msgstr "Valeur du tag"
 #: include/views/configuration.triggers.list.php:197
 #: include/views/js/monitoring.sysmaps.js.php:230
 msgid "Tags"
-msgstr "Tags"
+msgstr "Étiquettes"
 
 #: include/views/configuration.copy.elements.php:68
 #: include/views/configuration.trigger.prototype.edit.php:197
@@ -16779,19 +16759,19 @@ msgstr "Modèle"
 #: include/classes/import/importers/CTemplateImporter.php:79
 #, c-format
 msgid "Template \"%1$s\" already exists."
-msgstr "Le modèle \"%1$s\" existe déjà."
+msgstr "Le modèle « %1$s » existe déjà."
 
 #: include/classes/api/services/CHostGroup.php:1348
 #: include/classes/api/services/CTemplate.php:441
 #: include/classes/api/services/CTemplate.php:1154
 #, c-format
 msgid "Template \"%1$s\" cannot be without host group."
-msgstr "Le modèle \"%1$s\" ne peut pas ne pas avoir de groupe d'hôte."
+msgstr "Le modèle « %1$s » ne peut pas ne pas avoir de groupe d’hôtes."
 
 #: include/classes/import/importers/CHostImporter.php:54
 #, c-format
 msgid "Template \"%1$s\" for host \"%2$s\" does not exist."
-msgstr "Le modèle \"%1$s\" pour l'hôte \"%2$s\" n'existe pas."
+msgstr "Le modèle « %1$s » pour l’hôte « %2$s » n’existe pas."
 
 #: templates.php:204
 msgid "Template added"
@@ -16799,19 +16779,19 @@ msgstr "Modèle ajouté"
 
 #: app/views/popup.import.php:90
 msgid "Template and host properties that are inherited through template linkage will be unlinked and cleared."
-msgstr ""
+msgstr "Les propriétés des modèles et des hôtes héritées via une liaison de modèle seront dissociées et supprimées."
 
 #: include/classes/api/services/CHostBase.php:292
 msgid "Template cannot be linked to another template more than once even through other templates."
-msgstr "Un modèle ne peut pas être lié à un autre modèle plus d'une fois, même à travers d'autres modèles."
+msgstr "Un modèle ne peut pas être lié à un autre modèle plus d’une fois, même à travers d’autres modèles."
 
 #: app/controllers/CControllerAuditLogList.php:240
 msgid "Template dashboard"
-msgstr ""
+msgstr "Modèle de tableau de bord"
 
 #: app/views/popup.import.php:33
 msgid "Template dashboards"
-msgstr ""
+msgstr "Modèles de tableaux de bord"
 
 #: templates.php:426 templates.php:440 templates.php:473
 msgid "Template deleted"
@@ -16850,7 +16830,7 @@ msgstr "Valeur du modèle"
 #: include/classes/api/services/CTemplate.php:1209
 #, c-format
 msgid "Template with the same name \"%1$s\" already exists."
-msgstr "Un modèle avec le même nom \"%1$s\" existe déjà."
+msgstr "Un modèle avec le même nom « %1$s » existe déjà."
 
 #: include/classes/api/services/CHost.php:2055
 #: include/classes/api/services/CHost.php:2343
@@ -16858,7 +16838,7 @@ msgstr "Un modèle avec le même nom \"%1$s\" existe déjà."
 #: include/classes/api/services/CTemplate.php:1174
 #, c-format
 msgid "Template with the same visible name \"%1$s\" already exists."
-msgstr "Un modèle avec le même nom visible \"%1$s\" existe déjà."
+msgstr "Un modèle avec le même nom visible « %1$s » existe déjà."
 
 #: app/controllers/CControllerPopupGeneric.php:121
 #: app/controllers/CControllerPopupImportCompare.php:132
@@ -16892,7 +16872,7 @@ msgstr "Modèles"
 #: include/classes/api/services/CHostBase.php:205
 #, c-format
 msgid "Templates \"%1$s\" unlinked from hosts \"%2$s\"."
-msgstr "Les modèles \"%1$s\" sont déliés de l'hôte \"%2$s\"."
+msgstr "Les modèles « %1$s » sont déliés de l’hôte « %2$s »."
 
 #: app/controllers/CControllerPopupMassupdateTemplate.php:350
 msgid "Templates updated"
@@ -16927,7 +16907,7 @@ msgstr "Tester toutes les étapes"
 
 #: app/views/administration.authentication.edit.php:199
 msgid "Test authentication"
-msgstr "Tester l'authentification"
+msgstr "Tester l’authentification"
 
 #: app/views/administration.script.edit.php:258
 msgid "Test confirmation"
@@ -16943,23 +16923,23 @@ msgstr "Tester les expressions"
 
 #: app/controllers/CControllerPopupItemTestEdit.php:352
 msgid "Test item"
-msgstr ""
+msgstr "Élément de test"
 
 #: app/controllers/CControllerPopupMediatypeTestEdit.php:77
 #, c-format
 msgid "Test media type \"%1$s\""
-msgstr ""
+msgstr "Tester les médias de type « %1$s »"
 
 #: app/controllers/CControllerPopupItemTestEdit.php:109
 #: app/controllers/CControllerPopupItemTestGetValue.php:84
 #: app/controllers/CControllerPopupItemTestSend.php:151
 #, c-format
 msgid "Test of \"%1$s\" items is not supported."
-msgstr ""
+msgstr "Le test de l’élément « %1$s » n’est pas pris en charge."
 
 #: app/controllers/CControllerPopupScheduledReportTest.php:79
 msgid "Test report generating"
-msgstr ""
+msgstr "Génération du rapport de test"
 
 #: app/views/administration.regex.edit.php:119
 msgid "Test string"
@@ -16984,90 +16964,90 @@ msgstr "Texte"
 #: include/classes/api/clients/CLocalApiClient.php:89
 #, c-format
 msgid "The \"%1$s.%2$s\" method must be called without the \"auth\" parameter."
-msgstr "La méthode \"%1$s.%2$s\" doit être appelée sans le paramètre \"auth\"."
+msgstr "La méthode « %1$s.%2$s » doit être appelée sans le paramètre « auth »."
 
 #: app/views/administration.geomaps.edit.php:30
 msgid "The URL template is used to load and display the tile layer on geographical maps."
-msgstr ""
+msgstr "Le modèle d’URL est utilisé pour charger et afficher la couche de tuiles sur les cartes géographiques."
 
 #: include/classes/db/DbBackend.php:130
 #, c-format
 msgid "The Zabbix database version does not match current requirements. Your database version: %1$s. Required version: %2$s. Please contact your system administrator."
-msgstr ""
+msgstr "La version de la base de données Zabbix ne correspond pas aux prérequis. Version de la base de données actuelle : %1$s. Version requise : %2$s. Veuillez contacter votre administrateur système."
 
 #: include/classes/data/CItemData.php:1548
 msgid "The average time a read from the virtual disk takes, <url> - VMware service URL, <uuid> - VMware virtual machine host name, <instance> - disk device instance"
-msgstr ""
+msgstr "Durée moyenne d’une opération de lecture depuis le disque virtuel, <url>— URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware, <instance> — instance du périphérique disque"
 
 #: include/classes/data/CItemData.php:1552
 msgid "The average time a write to the virtual disk takes, <url> - VMware service URL, <uuid> - VMware virtual machine host name, <instance> - disk device instance"
-msgstr ""
+msgstr "Durée moyenne d’une opération d’écriture sur le disque virtuel, <url>— URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware, <instance> — instance du périphérique disque"
 
 #: app/controllers/CControllerHostEdit.php:240
 msgid "The cloned host contains user defined macros with type \"Secret text\". The value and type of these macros were reset."
-msgstr ""
+msgstr "L’hôte cloné contient des macros utilisateur de type « texte secret ». Les valeurs et types de ces macros ont été réinitialisés."
 
 #: host_prototypes.php:168
 msgid "The cloned host prototype contains user defined macros with type \"Secret text\". The value and type of these macros were reset."
-msgstr ""
+msgstr "Le prototype d’hôte cloné contient des macros utilisateur de type « texte secret ». Les valeurs et types de ces macros ont été réinitialisés."
 
 #: templates.php:180
 msgid "The cloned template contains user defined macros with type \"Secret text\". The value and type of these macros were reset."
-msgstr ""
+msgstr "Le modèle cloné contient des macros utilisateur de type « texte secret ». Les valeurs et types de ces macros ont été réinitialisés."
 
 #: app/views/administration.geomaps.edit.php:36
 msgid "The following placeholders are supported:"
-msgstr ""
+msgstr "Les marques substitutives suivantes sont prises en charge :"
 
 #: include/html.inc.php:688
 #, c-format
 msgid "The graph is not discovered anymore and will be deleted in %1$s (on %2$s at %3$s)."
-msgstr ""
+msgstr "Le graphique n’est à présent plus découvert et sera supprimé dans %1$s (le %2$s à %3$s)."
 
 #: include/html.inc.php:683
 msgid "The graph is not discovered anymore and will be deleted the next time discovery rule is processed."
-msgstr ""
+msgstr "Le graphique n’est à présent plus découvert et sera supprimé à la prochaine exécution de la règle de découverte."
 
 #: include/html.inc.php:634
 #, c-format
 msgid "The host group is not discovered anymore and will be deleted in %1$s (on %2$s at %3$s)."
-msgstr "Le groupe d'hôte n'est plus découvert et sera supprimé dans %1$s (le %2$s à %3$s)."
+msgstr "Le groupe d’hôte n’est plus découvert et sera supprimé dans %1$s (le %2$s à %3$s)."
 
 #: include/html.inc.php:629
 msgid "The host group is not discovered anymore and will be deleted the next time discovery rule is processed."
-msgstr "Le groupe d'hôte n'est plus découvert et sera supprimé la prochaine fois que la règle de découverte est traitée."
+msgstr "Le groupe d’hôte n’est plus découvert et sera supprimé la prochaine fois que la règle de découverte est traitée."
 
 #: include/html.inc.php:661
 #, c-format
 msgid "The host is not discovered anymore and will be deleted in %1$s (on %2$s at %3$s)."
-msgstr "L'hôte n'est plus découvert et sera supprimé dans %1$s (le %2$s à %3$s)."
+msgstr "L’hôte n’est plus découvert et sera supprimé dans %1$s (le %2$s à %3$s)."
 
 #: include/html.inc.php:656
 msgid "The host is not discovered anymore and will be deleted the next time discovery rule is processed."
-msgstr "L'hôte n'est plus découvert et sera supprimé la prochaine fois que la règle de découverte est traitée."
+msgstr "L’hôte n’est plus découvert et sera supprimé la prochaine fois que la règle de découverte est traitée."
 
 #: include/classes/api/services/CImage.php:555
 #, c-format
 msgid "The image is used in icon map %1$s."
 msgid_plural "The image is used in icon maps %1$s."
-msgstr[0] "L'image est utilisée dans l'icône de carte %1$s."
-msgstr[1] "L'image est utilisée dans les icônes de carte %1$s."
+msgstr[0] "L’image est utilisée dans l’icône de carte %1$s."
+msgstr[1] "L’image est utilisée dans les icônes de carte %1$s."
 
 #: include/classes/api/services/CImage.php:591
 #, c-format
 msgid "The image is used in map %1$s."
 msgid_plural "The image is used in maps %1$s."
-msgstr[0] "L'image est utilisée dans la carte %1$s."
-msgstr[1] "L'image est utilisée dans les cartes %1$s."
+msgstr[0] "L’image est utilisée dans la carte %1$s."
+msgstr[1] "L’image est utilisée dans les cartes %1$s."
 
 #: include/html.inc.php:742
 #, c-format
 msgid "The item is not discovered anymore and will be deleted in %1$s (on %2$s at %3$s)."
-msgstr "L'élément n'est plus découvert et sera supprimé dans %1$s (le %2$s à %3$s)."
+msgstr "L’élément n’est plus découvert et sera supprimé dans %1$s (le %2$s à %3$s)."
 
 #: include/html.inc.php:737
 msgid "The item is not discovered anymore and will be deleted the next time discovery rule is processed."
-msgstr "L'élément n'est plus découvert et sera supprimé la prochaine fois que la règle de découverte est traitée."
+msgstr "L’élément n’est plus découvert et sera supprimé la prochaine fois que la règle de découverte est traitée."
 
 #: include/classes/data/CItemData.php:1024
 msgid "The number of processes. Returns integer"
@@ -17076,29 +17056,29 @@ msgstr "Le nombre de processus. Retourne un entier"
 #: index_sso.php:193
 #, c-format
 msgid "The parameter \"%1$s\" is missing from the user attributes."
-msgstr ""
+msgstr "Le paramètre « %1$s » est absent des attributs d’utilisateur."
 
 #: include/classes/core/CJsonRpc.php:177
 msgid "The received JSON is not a valid JSON-RPC request."
-msgstr ""
+msgstr "L’objet JSON reçu ne correspond pas à une requête JSON-RPC correcte."
 
 #: include/classes/core/CJsonRpc.php:182
 msgid "The requested remote-procedure does not exist / is not available"
-msgstr "La remote-procedure demandée n'existe pas / n'est pas disponible"
+msgstr "La procédure à distance demandée n’existe pas ou n’est pas disponible"
 
 #: app/views/administration.token.view.php:52
 #: app/views/administration.user.token.view.php:51
 msgid "The token has expired. Please update the expiry date to use the token."
-msgstr ""
+msgstr "Le jeton a expiré.Veuillez mettre à jour la date d’expiration afin de pouvoir utiliser le jeton."
 
 #: include/html.inc.php:715
 #, c-format
 msgid "The trigger is not discovered anymore and will be deleted in %1$s (on %2$s at %3$s)."
-msgstr ""
+msgstr "Le déclencheur n’est à présent plus découvert et sera supprimé de %1$s (le %2$s à %3$s)."
 
 #: include/html.inc.php:710
 msgid "The trigger is not discovered anymore and will be deleted the next time discovery rule is processed."
-msgstr ""
+msgstr "Le déclencheur n’est à présent plus découvert et sera supprimé lors de la prochaine exécution de la règle de découverte."
 
 #: app/views/administration.user.edit.php:249
 msgid "Theme"
@@ -17111,7 +17091,7 @@ msgstr "Ce jour la semaine dernière"
 #: app/partials/configuration.host.edit.html.php:398
 #, c-format
 msgid "This field is automatically populated by item \"%1$s\"."
-msgstr ""
+msgstr "Ce champ est automatiquement renseigné par l’élément « %1$s »."
 
 #: app/controllers/CControllerPopupMediatypeTestEdit.php:82
 msgid "This is the test message from Zabbix"
@@ -17119,16 +17099,16 @@ msgstr "Ceci est un message de test de Zabbix"
 
 #: include/func.inc.php:2409
 msgid "This month"
-msgstr "Ce mois-ci"
+msgstr "Ce mois‐ci"
 
 #: include/func.inc.php:2410
 msgid "This month so far"
-msgstr "Ce mois-ci jusqu'à présent"
+msgstr "Ce mois‐ci jusqu’à présent"
 
 #: include/views/configuration.item.edit.php:124
 #: include/views/configuration.item.prototype.edit.php:109
 msgid "This type of information may not match the key."
-msgstr ""
+msgstr "Ce type d’information peut ne pas correspondre à la clef."
 
 #: include/func.inc.php:2407
 msgid "This week"
@@ -17136,7 +17116,7 @@ msgstr "Cette semaine"
 
 #: include/func.inc.php:2408
 msgid "This week so far"
-msgstr "Cette semaine jusqu'à présent"
+msgstr "Cette semaine jusqu’à présent"
 
 #: include/func.inc.php:2411
 msgid "This year"
@@ -17144,7 +17124,7 @@ msgstr "Cette année"
 
 #: include/func.inc.php:2412
 msgid "This year so far"
-msgstr "Cette année jusqu'à présent"
+msgstr "Cette année jusqu’à présent"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:261
 msgid "Threshold"
@@ -17164,15 +17144,15 @@ msgstr "Jeudi"
 
 #: app/views/administration.geomaps.edit.php:77
 msgid "Tile URL"
-msgstr ""
+msgstr "URL de tuile"
 
 #: app/views/administration.geomaps.edit.php:65
 msgid "Tile provider"
-msgstr ""
+msgstr "Fournisseur de tuiles"
 
 #: app/views/administration.geomaps.edit.php:58
 msgid "Tile provider attribution data displayed in a small text box on the map."
-msgstr ""
+msgstr "Les données d’attribution du fournisseur de tuiles affichées dans une petite zone de texte sur la carte."
 
 #: app/views/popup.service.time.edit.php:90
 #: app/views/popup.service.time.edit.php:141 report4.php:191
@@ -17186,12 +17166,12 @@ msgstr "À"
 #: app/views/monitoring.widget.problems.view.php:38
 #: app/views/popup.itemtestedit.view.php:270
 #: app/views/popup.service.time.edit.php:70
-#: app/views/popup.service.time.edit.php:98
-#: app/views/popup.triggerexpr.php:174 app/views/popup.triggerexpr.php:178
-#: app/views/reports.auditlog.list.php:89 include/actions.inc.php:1700
-#: include/actions.inc.php:1754 include/actions.inc.php:1827
-#: include/actions.inc.php:1921 include/actions.inc.php:1976
-#: include/blocks.inc.php:558 include/classes/screens/CScreenProblem.php:816
+#: app/views/popup.service.time.edit.php:98 app/views/popup.triggerexpr.php:174
+#: app/views/popup.triggerexpr.php:178 app/views/reports.auditlog.list.php:89
+#: include/actions.inc.php:1700 include/actions.inc.php:1754
+#: include/actions.inc.php:1827 include/actions.inc.php:1921
+#: include/actions.inc.php:1976 include/blocks.inc.php:558
+#: include/classes/screens/CScreenProblem.php:816
 #: include/classes/screens/CScreenProblem.php:1155
 #: include/classes/widgets/forms/CWidgetFormActionLog.php:31
 #: include/classes/widgets/forms/CWidgetFormActionLog.php:32
@@ -17204,20 +17184,20 @@ msgstr "Temps"
 
 #: include/classes/data/CItemData.php:1688
 msgid "Time a particular Zabbix process or a group of processes (identified by <type> and <mode>) spent in <state> in percentage."
-msgstr "Durée d'un processus Zabbix particulier ou d'un groupe de processus (identifié par <type> et <mode>) passé en pourcentage dans <state>."
+msgstr "Durée d’un processus Zabbix particulier ou d’un groupe de processus (identifié par <type> et <mode>) passé en pourcentage dans <state>."
 
 #: app/views/js/popup.mediatypetest.edit.js.php:103
 #: app/views/js/popup.scriptexec.js.php:44
 msgid "Time elapsed:"
-msgstr ""
+msgstr "Temps écoulé :"
 
 #: app/views/administration.gui.edit.php:129
 msgid "Time filter default period"
-msgstr ""
+msgstr "Période par défaut du filtre temporel"
 
 #: include/classes/data/CItemData.php:1692
 msgid "Time of proxy last access. Name - proxy name. Valid params are: lastaccess - Unix timestamp, delay - seconds."
-msgstr ""
+msgstr "Date du dernier accès du serveur mandataire (proxy). Nom — nom du proxy. Les paramètres valides sont : lastaccess — horodatage UNIX, delay — durée en secondes."
 
 #: include/actions.inc.php:51
 #: include/classes/widgets/views/widget.svggraph.form.view.php:293
@@ -17243,7 +17223,7 @@ msgstr "Type temps"
 
 #: app/views/administration.user.edit.php:248
 msgid "Time zone"
-msgstr ""
+msgstr "Fuseau horaire"
 
 #: app/views/administration.mediatype.edit.php:230
 #: app/views/administration.script.edit.php:197
@@ -17274,15 +17254,15 @@ msgstr "À"
 
 #: jsLoader.php:390
 msgid "To set a host interface select a single item type for all items"
-msgstr "Pour configurer une interface d'hôte, sélectionner un type d'élément pour tous les éléments"
+msgstr "Pour configurer une interface d’hôte, sélectionner un type d’élément pour tous les éléments"
 
 #: include/classes/screens/CScreenProblem.php:701 include/func.inc.php:2405
 msgid "Today"
-msgstr "Aujourd'hui"
+msgstr "Aujourd’hui"
 
 #: include/func.inc.php:2406
 msgid "Today so far"
-msgstr "Aujourd'hui jusqu'à présent"
+msgstr "Aujourd’hui jusqu’à présent"
 
 #: include/classes/widgets/forms/CWidgetFormDataOver.php:86
 #: include/classes/widgets/forms/CWidgetFormPlainText.php:43
@@ -17305,41 +17285,41 @@ msgstr "Total"
 #: include/classes/debug/CProfiler.php:153
 #, c-format
 msgid "Total Elasticsearch time: %1$s"
-msgstr "Temps total Elasticsearch: %1$s"
+msgstr "Temps total Elasticsearch : %1$s"
 
 #: include/classes/debug/CProfiler.php:149
 #, c-format
 msgid "Total SQL time: %1$s"
-msgstr "Temps SQL total : %1$s"
+msgstr "Temps SQL total : %1$s"
 
 #: include/classes/data/CItemData.php:1468
 msgid "Total time elapsed, in seconds, since last operating system boot-up, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr ""
+msgstr "Durée totale écoulée, en secondes, depuis le dernier amorçage du système d’exploitation, <url>— URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/debug/CProfiler.php:147
 #, c-format
 msgid "Total time: %1$s"
-msgstr "Temps total: %1$s"
+msgstr "Temps total : %1$s"
 
 #: include/classes/widgets/forms/CWidgetFormProblemsBySv.php:104
 msgid "Totals"
-msgstr ""
+msgstr "Totaux"
 
 #: app/controllers/CControllerPopupMediatypeTestSend.php:172
 msgid "Trace"
-msgstr ""
+msgstr "Trace"
 
 #: include/page_footer.php:40
 msgid "Transaction has not been closed. Aborting..."
-msgstr "La transaction n'a pas été fermée. Abandon..."
+msgstr "La transaction n’a pas été fermée. Abandon…"
 
 #: include/classes/data/CItemData.php:852
 msgid "Transform SQL query result into a JSON array for low-level discovery."
-msgstr ""
+msgstr "Transforme le résultat d’une requête SQL en un tableau JSON pour la découverte de bas niveau."
 
 #: include/classes/data/CItemData.php:856
 msgid "Transform SQL query result into a JSON array."
-msgstr ""
+msgstr "Transforme le résultat d’une requête SQL en un tableau JSON."
 
 #: include/classes/widgets/CWidgetHelper.php:774
 #: include/classes/widgets/CWidgetHelper.php:818
@@ -17370,12 +17350,11 @@ msgstr "Traiter comme 0"
 
 #: include/classes/data/CItemData.php:1720
 msgid "Trend function cache statistics. Valid parameters are: all, hits, phits, misses, pmisses, items, pitems and requests."
-msgstr ""
+msgstr "Statistiques du cache de la fonction de tendance (trend). Les paramètres valides sont : « all », « hits », « phits », « misses », « pmisses », « items », « pitems » et « requests »."
 
 #: app/controllers/CControllerPopupLldOperation.php:227
-#: app/views/popup.lldoperation.php:206
-#: app/views/popup.massupdate.item.php:307 disc_prototypes.php:139
-#: include/views/configuration.item.edit.php:858
+#: app/views/popup.lldoperation.php:206 app/views/popup.massupdate.item.php:307
+#: disc_prototypes.php:139 include/views/configuration.item.edit.php:858
 #: include/views/configuration.item.prototype.edit.php:777 items.php:84
 msgid "Trend storage period"
 msgstr "Période de stockage des tendances"
@@ -17404,26 +17383,26 @@ msgstr "Déclencheur"
 #: include/classes/api/services/CTriggerGeneral.php:636
 #, c-format
 msgid "Trigger \"%1$s\" already exists on \"%2$s\"."
-msgstr "Le déclencheur \"%1$s\" existe déjà sur \"%2$s\"."
+msgstr "Le déclencheur « %1$s » existe déjà sur « %2$s »."
 
 #: include/classes/api/services/CTriggerGeneral.php:1813
 #, c-format
 msgid "Trigger \"%1$s\" belongs to templates with different linkages."
-msgstr "Le déclencheur \"%1$s\" appartient à des modèles avec des liens différents."
+msgstr "Le déclencheur « %1$s » appartient à des modèles avec des liens différents."
 
 #: include/classes/import/CConfigurationImport.php:1830
 #, c-format
 msgid "Trigger \"%1$s\" depends on trigger \"%2$s\", which does not exist."
-msgstr "Le déclencheur \"%1$s\" dépend du déclencheur \"%2$s\", qui n'existe pas."
+msgstr "Le déclencheur « %1$s » dépend du déclencheur « %2$s », qui n’existe pas."
 
 #: app/controllers/CControllerMenuPopup.php:594
 msgid "Trigger URL"
-msgstr ""
+msgstr "URL du déclencheur"
 
 #: include/classes/helpers/CMenuHelper.php:170
 #: include/views/configuration.action.list.php:27
 msgid "Trigger actions"
-msgstr ""
+msgstr "Actions du déclencheur"
 
 #: triggers.php:296
 msgid "Trigger added"
@@ -17431,7 +17410,7 @@ msgstr "Déclencheur ajouté"
 
 #: include/classes/api/services/CTrigger.php:1088
 msgid "Trigger cannot be dependent on a trigger that is inherited from it."
-msgstr "Le déclencheur ne peut pas dépendre d'un déclencheur qui en hérite."
+msgstr "Le déclencheur ne peut pas dépendre d’un déclencheur qui en hérite."
 
 #: triggers.php:508
 msgid "Trigger copied"
@@ -17461,7 +17440,7 @@ msgstr[1] "Déclencheurs désactivés"
 #: app/views/administration.trigdisplay.edit.php:165
 #: include/classes/helpers/CMenuHelper.php:242 include/html.inc.php:894
 msgid "Trigger displaying options"
-msgstr "Options d'affichage des déclencheurs"
+msgstr "Options d’affichage des déclencheurs"
 
 #: triggers.php:457
 msgid "Trigger enabled"
@@ -17472,20 +17451,20 @@ msgstr[1] "Déclencheurs désactivés"
 #: include/classes/api/services/CHostBase.php:166
 #, c-format
 msgid "Trigger has items from template \"%1$s\" that is not linked to host."
-msgstr "Le déclencheur a des éléments du modèle \"%1$s\" qui n'est pas lié à l'hôte."
+msgstr "Le déclencheur a des éléments du modèle « %1$s » qui n’est pas lié à l’hôte."
 
 #: include/actions.inc.php:1267
 msgid "Trigger in \"unknown\" state"
-msgstr "Déclencheur dans l'état \"inconnu\""
+msgstr "Déclencheur dans l’état « inconnu »"
 
 #: include/classes/api/services/CHostBase.php:116
 #, c-format
 msgid "Trigger in template \"%1$s\" has dependency with trigger in template \"%2$s\"."
-msgstr "Le déclencheur du modèle \"%1$s\" a une dépendance au déclencheur du modèle \"%2$s\"."
+msgstr "Le déclencheur du modèle « %1$s » a une dépendance au déclencheur du modèle « %2$s »."
 
 #: include/views/monitoring.sysmap.edit.php:192
 msgid "Trigger label type"
-msgstr "Type d'étiquette de déclencheur"
+msgstr "Type d’étiquette de déclencheur"
 
 #: include/actions.inc.php:44
 msgid "Trigger name"
@@ -17506,27 +17485,27 @@ msgstr "Prototype du déclencheur"
 #: include/classes/api/services/CTriggerGeneral.php:637
 #, c-format
 msgid "Trigger prototype \"%1$s\" already exists on \"%2$s\"."
-msgstr "Le prototype de déclencheur \"%1$s\" existe déjà sur \"%2$s\"."
+msgstr "Le prototype de déclencheur « %1$s » existe déjà sur « %2$s »."
 
 #: include/classes/api/services/CTriggerGeneral.php:1817
 #, c-format
 msgid "Trigger prototype \"%1$s\" belongs to templates with different linkages."
-msgstr "Le prototype de déclencheur \"%1$s\" appartient à des modèles avec des liens différents."
+msgstr "Le prototype de déclencheur « %1$s » appartient à des modèles avec des liens différents."
 
 #: include/classes/api/services/CTriggerGeneral.php:1715
 #, c-format
 msgid "Trigger prototype \"%1$s\" contains item prototypes from multiple discovery rules."
-msgstr "Le prototype de déclencheur \"%1$s\" contient des prototypes d'éléments de règles de découverte multiples."
+msgstr "Le prototype de déclencheur « %1$s » contient des prototypes d’éléments de règles de découverte multiples."
 
 #: include/classes/import/CConfigurationImport.php:1511
 #, c-format
 msgid "Trigger prototype \"%1$s\" depends on trigger \"%2$s\", which does not exist."
-msgstr "Le prototype de déclencheur \"%1$s\" dépend du déclencheur \"%2$s\", qui n'existe pas."
+msgstr "Le prototype de déclencheur « %1$s » dépend du déclencheur « %2$s », qui n’existe pas."
 
 #: include/classes/api/services/CTriggerGeneral.php:1710
 #, c-format
 msgid "Trigger prototype \"%1$s\" must contain at least one item prototype."
-msgstr "Le prototype de déclencheur \"%1$s\" doit contenir au moins un prototype d'élément."
+msgstr "Le prototype de déclencheur « %1$s » doit contenir au moins un prototype d’élément."
 
 #: trigger_prototypes.php:247
 msgid "Trigger prototype added"
@@ -17534,7 +17513,7 @@ msgstr "Prototype de déclencheur ajouté"
 
 #: include/classes/api/services/CTriggerPrototype.php:909
 msgid "Trigger prototype cannot be dependent on a trigger that is inherited from it."
-msgstr "Le prototype de déclencheur ne peut pas dépendre d'un déclencheur qui en hérite."
+msgstr "Le prototype de déclencheur ne peut pas dépendre d’un déclencheur qui en hérite."
 
 #: trigger_prototypes.php:365
 msgid "Trigger prototype deleted"
@@ -17570,15 +17549,15 @@ msgstr "Sévérité du déclencheur"
 
 #: jsLoader.php:364
 msgid "Trigger status \"OK\""
-msgstr "État du déclencheur \"OK\""
+msgstr "État du déclencheur « OK »"
 
 #: jsLoader.php:365
 msgid "Trigger status \"Problem\""
-msgstr "État du déclencheur \"Problème\""
+msgstr "État du déclencheur « Problème »"
 
 #: app/partials/configuration.tags.tab.php:130
 msgid "Trigger tags"
-msgstr "Tags de déclencheur"
+msgstr "Étiquettes de déclencheur"
 
 #: app/controllers/CControllerPopupMassupdateTrigger.php:218 triggers.php:401
 msgid "Trigger updated"
@@ -17635,7 +17614,7 @@ msgstr "Turc (tr_TR)"
 #: include/classes/api/services/CItem.php:1012
 #, c-format
 msgid "Two items (\"%1$s\" and \"%2$s\") cannot populate one host inventory field \"%3$s\", this would lead to a conflict."
-msgstr "Deux éléments (\"%1$s\" et \"%2$s\") ne peuvent pas remplir un champ d'inventaire d'hôte \"%3$s\", cela mènerait à un conflit."
+msgstr "Deux éléments (« %1$s » et « %2$s ») ne peuvent pas remplir un champ d’inventaire d’hôte « %3$s », cela mènerait à un conflit."
 
 #: jsLoader.php:270
 msgid "Two map elements should be selected"
@@ -17656,9 +17635,8 @@ msgstr "Deux éléments de carte devraient être sélectionnés"
 #: app/views/popup.condition.common.php:47
 #: app/views/popup.condition.common.php:168
 #: app/views/popup.condition.common.php:657
-#: app/views/popup.dashboard.share.edit.php:123
-#: app/views/popup.generic.php:110 app/views/popup.lldoperation.php:114
-#: app/views/popup.massupdate.item.php:48
+#: app/views/popup.dashboard.share.edit.php:123 app/views/popup.generic.php:110
+#: app/views/popup.lldoperation.php:114 app/views/popup.massupdate.item.php:48
 #: app/views/popup.massupdate.item.php:225 app/views/popup.media.php:70
 #: app/views/popup.service.edit.php:226 app/views/popup.triggerwizard.php:47
 #: app/views/popup.triggerwizard.php:121 app/views/popup.valuemap.edit.php:51
@@ -17713,7 +17691,7 @@ msgstr "Type de calcul"
 #: include/views/configuration.item.prototype.edit.php:121
 #: include/views/configuration.item.prototype.edit.php:881
 msgid "Type of information"
-msgstr "Type d'information"
+msgstr "Type d’information"
 
 #: include/forms.inc.php:501
 msgid "Types"
@@ -17722,7 +17700,7 @@ msgstr "Types"
 #: include/classes/api/services/CRole.php:478
 #, c-format
 msgid "UI element \"%2$s\" is not available for user role \"%1$s\"."
-msgstr ""
+msgstr "L’élément d’interface utilisateur « %2$s » est pas disponible pour le rôle d’utilisateur « %1$s »."
 
 #: app/views/js/administration.regex.edit.js.php:194
 #: include/translateDefines.inc.php:25
@@ -17763,27 +17741,27 @@ msgstr "URL C"
 #: include/views/js/common.item.edit.js.php:200
 #: include/views/js/configuration.httpconf.edit.js.php:105
 msgid "URL is not properly encoded."
-msgstr "L'URL n'est pas correctement encodée."
+msgstr "L’URL n’est pas correctement encodée."
 
 #: include/classes/api/services/CMap.php:961
 #: include/classes/api/services/CMap.php:1436
 #, c-format
 msgid "URL name should be unique for map \"%1$s\"."
-msgstr "Le nom d'URL doit être unique pour la carte \"%1$s\"."
+msgstr "Le nom d’URL doit être unique pour la carte « %1$s »."
 
 #: include/html.inc.php:104
 msgid "URL parameter cannot be array."
-msgstr "Le paramètre de l'URL ne peut pas être un tableau."
+msgstr "Le paramètre de l’URL ne peut pas être un tableau."
 
 #: include/html.inc.php:110
 msgid "URL parameter name is empty."
-msgstr "Le paramètre de l'URL ne peut pas être vide."
+msgstr "Le paramètre de l’URL ne peut pas être vide."
 
 #: include/classes/api/services/CMap.php:955
 #: include/classes/api/services/CMap.php:1430
 #, c-format
 msgid "URL should have both \"name\" and \"url\" fields for map \"%1$s\"."
-msgstr "Les URLS doivent avoir les champs \"name\" et \"url\" pour la carte \"%1$s\"."
+msgstr "Les URLS doivent avoir les champs « name » et « url » pour la carte « %1$s »."
 
 #: include/views/js/monitoring.sysmaps.js.php:311
 #: include/views/monitoring.sysmap.edit.php:311 jsLoader.php:381
@@ -17793,7 +17771,7 @@ msgstr "URLs"
 #: include/classes/validators/CApiInputValidator.php:2599
 #: include/classes/validators/CApiInputValidator.php:2605
 msgid "UUIDv4 is expected"
-msgstr ""
+msgstr "Un UUIDv4 est attendu"
 
 #: include/locales.inc.php:77
 msgid "Ukrainian (uk_UA)"
@@ -17801,7 +17779,7 @@ msgstr "Ukrainien (uk_UA)"
 
 #: include/classes/core/CConfigFile.php:252
 msgid "Unable to change configuration file permissions to 0600."
-msgstr ""
+msgstr "Impossible de modifier les permissions UNIX du fichier de configuration à 0600."
 
 #: include/classes/core/CConfigFile.php:261
 msgid "Unable to create the configuration file."
@@ -17812,31 +17790,31 @@ msgstr "Impossible de créer le fichier de configuration."
 #: include/classes/db/PostgresqlDbBackend.php:61
 #, c-format
 msgid "Unable to determine current Zabbix database version: %1$s."
-msgstr ""
+msgstr "Impossible de déterminer la version de la base de données de Zabbix : %1$s."
 
 #: include/classes/helpers/CAuthenticationHelper.php:75
 msgid "Unable to load authentication API parameters."
-msgstr ""
+msgstr "Impossible de charger les paramètres de l’API d’authentification."
 
 #: include/classes/core/CConfigFile.php:187
 msgid "Unable to load database credentials from Vault."
-msgstr ""
+msgstr "Impossible de récupérer les identifiants de connexion à la base de données depuis le coffre‑fort."
 
 #: include/classes/helpers/CHousekeepingHelper.php:66
 msgid "Unable to load housekeeping API parameters."
-msgstr ""
+msgstr "Impossible de charger les paramètres de l’API d’entretien."
 
 #: include/classes/helpers/CSettingsHelper.php:113
 msgid "Unable to load settings API parameters."
-msgstr ""
+msgstr "Impossible de charger les paramètres de l’API de configuration."
 
 #: include/classes/core/CConfigFile.php:257
 msgid "Unable to overwrite the existing configuration file."
-msgstr "Impossible d'écrire par-dessus le fichier de configuration existant."
+msgstr "Impossible d’écraser le fichier de configuration existant."
 
 #: app/partials/administration.system.info.php:156
 msgid "Unable to retrieve database version."
-msgstr ""
+msgstr "Impossible de déterminer la version de la base de données."
 
 #: include/classes/db/DbBackend.php:147
 msgid "Unable to select configuration."
@@ -17844,15 +17822,15 @@ msgstr "Impossible de sélectionner la configuration."
 
 #: include/classes/helpers/CUploadFile.php:57
 msgid "Unable to upload file because \"file_uploads\" is disabled."
-msgstr "Impossible de téléverser un fichier car \"file_uploads\" est désactivé."
+msgstr "Impossible de téléverser un fichier car « file_uploads » est désactivé."
 
 #: app/views/popup.acknowledge.edit.php:91
 msgid "Unacknowledge"
-msgstr ""
+msgstr "Ne pas acquitter"
 
 #: include/actions.inc.php:2079
 msgid "Unacknowledged"
-msgstr ""
+msgstr "Non acquitté"
 
 #: app/views/administration.trigdisplay.edit.php:40
 msgid "Unacknowledged PROBLEM events"
@@ -17870,7 +17848,7 @@ msgstr "Non acquittés uniquement"
 
 #: app/partials/administration.ha.nodes.php:56
 msgid "Unavailable"
-msgstr ""
+msgstr "Indisponible"
 
 #: app/views/administration.user.list.php:249
 msgid "Unblock"
@@ -17878,12 +17856,12 @@ msgstr "Débloquer"
 
 #: app/views/administration.user.list.php:249
 msgid "Unblock selected users?"
-msgstr "Débloquer les utilisateurs sélectionnés ?"
+msgstr "Débloquer les utilisateurs sélectionnés ?"
 
 #: include/classes/core/ZBase.php:574
 #, c-format
 msgid "Unexpected response for action %1$s."
-msgstr ""
+msgstr "Réponse de l’action %1$s inattendue."
 
 #: app/views/js/configuration.host.edit.js.php:158
 #: app/views/js/configuration.host.list.js.php:130
@@ -17892,7 +17870,7 @@ msgstr ""
 #: app/views/js/popup.service.statusrule.edit.js.php:104
 #: app/views/js/popup.service.time.edit.js.php:82
 msgid "Unexpected server error."
-msgstr ""
+msgstr "Erreur du serveur inattendue."
 
 #: app/views/popup.massupdate.item.php:165
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:149
@@ -17916,15 +17894,14 @@ msgstr "Unités"
 #: include/classes/screens/CScreenHttpTestDetails.php:115
 #: include/discovery.inc.php:115 include/discovery.inc.php:151
 #: include/events.inc.php:45 include/events.inc.php:76
-#: include/graphs.inc.php:37 include/graphs.inc.php:67
-#: include/hosts.inc.php:47 include/hosts.inc.php:74 include/html.inc.php:287
+#: include/graphs.inc.php:37 include/graphs.inc.php:67 include/hosts.inc.php:47
+#: include/hosts.inc.php:74 include/html.inc.php:287
 #: include/httptest.inc.php:41 include/httptest.inc.php:58
-#: include/items.inc.php:45 include/items.inc.php:110
-#: include/items.inc.php:133 include/items.inc.php:167
-#: include/maintenances.inc.php:33 include/maps.inc.php:39
-#: include/triggers.inc.php:83 include/triggers.inc.php:1868
-#: include/users.inc.php:64 include/users.inc.php:87
-#: include/views/configuration.action.edit.php:233
+#: include/items.inc.php:45 include/items.inc.php:110 include/items.inc.php:133
+#: include/items.inc.php:167 include/maintenances.inc.php:33
+#: include/maps.inc.php:39 include/triggers.inc.php:83
+#: include/triggers.inc.php:1870 include/users.inc.php:64
+#: include/users.inc.php:87 include/views/configuration.action.edit.php:233
 #: include/views/configuration.triggers.list.php:77
 msgid "Unknown"
 msgstr "Inconnu"
@@ -17945,16 +17922,16 @@ msgstr "Erreur inconnue"
 #: app/controllers/CControllerPopupTriggerExpr.php:1301
 #: include/triggers.inc.php:1146
 msgid "Unknown host item, no such item in selected host"
-msgstr "Élément inconnu, cet élément n'existe pas dans l'hôte sélectionné"
+msgstr "Élément inconnu, cet élément n’existe pas dans l’hôte sélectionné"
 
 #: app/controllers/CControllerPopupTestTriggerExpr.php:46
 #: include/triggers.inc.php:1145
 msgid "Unknown host, no such host present in system"
-msgstr "Hôte inconnu, cet hôte n'est pas défini"
+msgstr "Hôte inconnu, cet hôte n’est pas défini"
 
 #: include/hosts.inc.php:474
 msgid "Unknown interface type."
-msgstr "Type d'interface inconnu."
+msgstr "Type d’interface inconnu."
 
 #: app/views/reports.auditlog.list.php:108
 msgid "Unknown resource"
@@ -17964,7 +17941,7 @@ msgstr "Ressource inconnue"
 #: include/views/configuration.httpconf.list.php:174
 #, c-format
 msgid "Unknown step failed: %1$s"
-msgstr "Une étape inconnue a échoué : %1$s"
+msgstr "Une étape inconnue a échoué : %1$s"
 
 #: include/items.inc.php:1416
 msgid "Unknown value type"
@@ -18004,37 +17981,37 @@ msgstr "Enlever la sourdine"
 #, c-format
 msgid "Unsupported charset or collation for table: %1$s."
 msgid_plural "Unsupported charset or collation for tables: %1$s."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Jeu de caractères ou classement de chaîne non pris en charge par la table : %1$s."
+msgstr[1] "Jeu de caractères ou classement de chaîne non pris en charge par les tables : %1$s."
 
 #: include/classes/import/readers/CImportReaderFactory.php:79
 #, c-format
 msgid "Unsupported import file extension \"%1$s\"."
-msgstr "Extension de fichier \"%1$s\" non supportée."
+msgstr "Extension de fichier « %1$s » non gérée."
 
 #: include/classes/import/readers/CImportReaderFactory.php:51
 #, c-format
 msgid "Unsupported import format \"%1$s\"."
-msgstr "Format d'import \"%1$s\" non supporté."
+msgstr "Format d’importation « %1$s » non pris en charge."
 
 #: app/controllers/CControllerActionOperationGet.php:53
 msgid "Unsupported operation."
-msgstr ""
+msgstr "Opération non prise en charge."
 
 #: include/classes/api/services/CDiscoveryRule.php:1848
 #, c-format
 msgid "Unsupported parameter \"%2$s\" for a filter condition of discovery rule \"%1$s\"."
-msgstr "Paramètre \"%2$s\" non supporté pour une condition de filtre de la règle de découverte \"%1$s\"."
+msgstr "Paramètre « %2$s » non pris en charge pour une condition de filtre de la règle de découverte « %1$s »."
 
 #: include/classes/api/services/CDiscoveryRule.php:1814
 #, c-format
 msgid "Unsupported parameter \"%2$s\" for the filter of discovery rule \"%1$s\"."
-msgstr "Paramètre \"%2$s\" non supporté pour le filtre de la règle de découverte \"%1$s\"."
+msgstr "Paramètre « %2$s » non pris en charge pour le filtre de la règle de découverte « %1$s »."
 
 #: app/controllers/CControllerPopupTabFilterEdit.php:98
 #: include/classes/services/CTabFilterProfile.php:95
 msgid "Untitled"
-msgstr ""
+msgstr "Sans titre"
 
 #: app/views/monitoring.widget.discovery.view.php:33
 msgctxt "discovery results in dashboard"
@@ -18111,15 +18088,14 @@ msgstr "Actualiser"
 #: app/partials/massupdate.macros.tab.php:86
 #: app/partials/massupdate.valuemaps.tab.php:33 app/views/popup.import.php:129
 msgid "Update existing"
-msgstr "Actualiser l'existant"
+msgstr "Actualiser l’existant"
 
 #: app/controllers/CControllerPopupLldOperation.php:153
 #: app/controllers/CControllerPopupLldOperation.php:208
 #: app/partials/configuration.filter.items.php:160
 #: app/views/configuration.discovery.edit.php:67
-#: app/views/popup.lldoperation.php:177
-#: app/views/popup.massupdate.item.php:285 disc_prototypes.php:60
-#: host_discovery.php:62 host_discovery.php:227
+#: app/views/popup.lldoperation.php:177 app/views/popup.massupdate.item.php:285
+#: disc_prototypes.php:60 host_discovery.php:62 host_discovery.php:227
 #: include/views/configuration.host.discovery.edit.php:620
 #: include/views/configuration.host.discovery.list.php:139
 #: include/views/configuration.httpconf.edit.php:70
@@ -18127,7 +18103,7 @@ msgstr "Actualiser l'existant"
 #: include/views/configuration.item.prototype.edit.php:702 items.php:61
 #: items.php:258
 msgid "Update interval"
-msgstr "Intervalle d'actualisation"
+msgstr "Intervalle d’actualisation"
 
 #: include/views/configuration.action.edit.php:469
 msgid "Update operations"
@@ -18141,12 +18117,12 @@ msgstr "Mise à jour du problème"
 #: app/controllers/CControllerAuditLogList.php:363
 #: app/controllers/CControllerPopupImportCompare.php:160
 msgid "Updated"
-msgstr ""
+msgstr "Mis à jour"
 
 #: include/classes/api/services/CHost.php:1256
 #, c-format
 msgid "Updated status of host \"%1$s\"."
-msgstr "État de l'hôte \"%1$s\" mis à jour."
+msgstr "État de l’hôte « %1$s » mis à jour."
 
 #: app/views/administration.image.edit.php:52
 msgid "Upload"
@@ -18176,7 +18152,7 @@ msgstr "Utiliser les requêtes de masse"
 
 #: app/views/administration.trigdisplay.edit.php:35
 msgid "Use custom event status colors"
-msgstr ""
+msgstr "Utiliser des couleurs de statuts d’événement personnalisées"
 
 #: app/views/administration.user.edit.php:294 app/views/popup.media.php:88
 msgid "Use if severity"
@@ -18184,7 +18160,7 @@ msgstr "Utiliser si sévérité"
 
 #: app/views/administration.miscconfig.edit.php:119
 msgid "Use iframe sandboxing"
-msgstr ""
+msgstr "Isoler les iframes dans un bac à sable"
 
 #: app/views/administration.mediatype.list.php:81
 #: app/views/administration.script.list.php:76
@@ -18209,42 +18185,42 @@ msgstr "Utilisateur"
 #: include/classes/api/services/CUserGroup.php:612
 #, c-format
 msgid "User \"%1$s\" cannot be without user group."
-msgstr "L'utilisateur \"%1$s\" ne peut pas ne pas avoir de groupe d'utilisateurs."
+msgstr "L’utilisateur « %1$s » ne peut pas ne pas avoir de groupe d’utilisateurs."
 
 #: include/classes/api/services/CUser.php:1331
 #, c-format
 msgid "User \"%1$s\" is dashboard \"%2$s\" owner."
-msgstr "L'utilisateur \"%1$s\" est le propriétaire du tableau de bord \"%2$s\"."
+msgstr "L’utilisateur « %1$s » est le propriétaire du tableau de bord « %2$s »."
 
 #: include/classes/api/services/CUser.php:1316
 #, c-format
 msgid "User \"%1$s\" is map \"%2$s\" owner."
-msgstr "L'utilisateur \"%1$s\" est le propriétaire de la carte \"%2$s\"."
+msgstr "L’utilisateur « %1$s » est le propriétaire de la carte « %2$s »."
 
 #: include/classes/api/services/CUser.php:1354
 #, c-format
 msgid "User \"%1$s\" is report \"%2$s\" owner."
-msgstr ""
+msgstr "L’utilisateur « %1$s » est le propriétaire du rapport « %2$s »."
 
 #: include/classes/api/services/CUser.php:1362
 #, c-format
 msgid "User \"%1$s\" is report \"%2$s\" recipient."
-msgstr ""
+msgstr "L’utilisateur « %1$s » est le destinataire du rapport « %2$s »."
 
 #: include/classes/api/services/CUser.php:1302
 #, c-format
 msgid "User \"%1$s\" is used in \"%2$s\" action."
-msgstr "L'utilisateur \"%1$s\" est utilisé dans l'action \"%2$s\"."
+msgstr "L’utilisateur « %1$s » est utilisé dans l’action « %2$s »."
 
 #: include/classes/api/services/CUser.php:1375
 #, c-format
 msgid "User \"%1$s\" is user on whose behalf report \"%2$s\" is created."
-msgstr ""
+msgstr "« %1$s » est l’utilisateur au nom duquel le rapport « %2$s » a été créé."
 
 #: app/controllers/CControllerUserUnblock.php:61
 #, c-format
 msgid "User \"%1$s\" unblocked."
-msgstr ""
+msgstr "L’utilisateur « %1$s » est débloqué."
 
 #: include/actions.inc.php:1976
 msgid "User action"
@@ -18256,27 +18232,27 @@ msgstr "Utilisateur ajouté"
 
 #: include/views/configuration.httpconf.edit.php:98
 msgid "User agent string"
-msgstr "Chaîne du \"user agent\""
+msgstr "Chaîne du « user agent »"
 
 #: include/classes/api/services/CUserGroup.php:534
 #: include/classes/api/services/CUser.php:979
 msgid "User cannot add himself to a disabled group or a group with disabled GUI access."
-msgstr "Un utilisateur ne peut pas s'ajouter à un groupe désactivé ou à un groupe sans accès GUI."
+msgstr "Un utilisateur ne peut pas s’ajouter à un groupe désactivé ou à un groupe sans accès GUI."
 
 #: app/views/administration.user.edit.php:409
 #: include/classes/api/services/CUser.php:966
 msgid "User cannot change own role."
-msgstr ""
+msgstr "Un utilisateur ne peut changer son propre rôle."
 
 #: app/views/administration.userrole.edit.php:61
 msgid "User cannot change the user type of own role."
-msgstr ""
+msgstr "Un utilisateur ne peut changer le type d’utilisateur de son propre rôle."
 
 #: app/controllers/CControllerUserDelete.php:56
 msgid "User deleted"
 msgid_plural "Users deleted"
 msgstr[0] "Utilisateur supprimé"
-msgstr[1] ""
+msgstr[1] "Utilisateurs supprimés"
 
 #: app/controllers/CControllerAuditLogList.php:244
 #: app/partials/js/scheduledreport.subscription.js.php:83
@@ -18286,59 +18262,59 @@ msgstr[1] ""
 #: app/views/administration.usergroup.edit.php:206
 #: app/views/administration.user.list.php:42
 msgid "User group"
-msgstr "Groupe d'utilisateurs"
+msgstr "Groupe d’utilisateurs"
 
 #: include/classes/api/services/CUserGroup.php:363
 #, c-format
 msgid "User group \"%1$s\" already exists."
-msgstr "Le groupe d'utilisateurs \"%1$s\" existe déjà."
+msgstr "Le groupe d’utilisateurs « %1$s » existe déjà."
 
 #: include/classes/api/services/CUserGroup.php:977
 #, c-format
 msgid "User group \"%1$s\" is report \"%2$s\" recipient."
-msgstr ""
+msgstr "Le groupe d’utilisateurs « %1$s » est le destinataire du rapport « %2$s »."
 
 #: include/classes/api/services/CUserGroup.php:942
 #, c-format
 msgid "User group \"%1$s\" is used in \"%2$s\" action."
-msgstr "Le groupe d'utilisateurs \"%1$s\" est utilisé dans l'action \"%2$s\"."
+msgstr "Le groupe d’utilisateurs « %1$s » est utilisé dans l’action « %2$s »."
 
 #: include/classes/api/services/CUserGroup.php:963
 #, c-format
 msgid "User group \"%1$s\" is used in configuration for database down messages."
-msgstr "Le groupe d'utilisateurs \"%1$s\" est utilisé dans la configuration pour les messages envoyés lorsque la base de données est arrêtée."
+msgstr "Le groupe d’utilisateurs « %1$s » est utilisé dans la configuration pour les messages envoyés lorsque la base de données est arrêtée."
 
 #: include/classes/api/services/CUserGroup.php:955
 #, c-format
 msgid "User group \"%1$s\" is used in script \"%2$s\"."
-msgstr "Le groupe d'utilisateurs \"%1$s\" est utilisé dans le script \"%2$s\"."
+msgstr "Le groupe d’utilisateurs « %1$s » est utilisé dans le script « %2$s »."
 
 #: app/controllers/CControllerUsergroupCreate.php:95
 msgid "User group added"
-msgstr ""
+msgstr "Groupe d’utilisateurs ajouté"
 
 #: app/controllers/CControllerUsergroupDelete.php:56
 msgid "User group deleted"
 msgid_plural "User groups deleted"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Groupe d’utilisateurs supprimé"
+msgstr[1] "Groupes d’utilisateurs supprimés"
 
 #: app/views/administration.miscconfig.edit.php:64
 msgid "User group for database down message"
-msgstr "Groupe d'utilisateurs destinataire du message d'arrêt de la base de données"
+msgstr "Groupe d’utilisateurs destinataire du message d’arrêt de la base de données"
 
 #: include/classes/api/services/CMap.php:784
 #: include/classes/api/services/CMap.php:1252
 #, c-format
 msgid "User group sharing is missing parameters: %1$s for map \"%2$s\"."
-msgstr "Le paramètre %1$s manque pour le partage de groupe d'utilisateurs pour la carte \"%2$s\"."
+msgstr "Le paramètre %1$s manque pour le partage de groupe d’utilisateurs pour la carte « %2$s »."
 
 #: app/controllers/CControllerUsergroupMassUpdate.php:66
 #: app/controllers/CControllerUsergroupUpdate.php:98
 msgid "User group updated"
 msgid_plural "User groups updated"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Groupe d’utilisateurs mis à jour"
+msgstr[1] "Groupes d’utilisateurs mis à jour"
 
 #: include/classes/api/services/CDashboard.php:482
 #: include/classes/api/services/CReport.php:463
@@ -18347,7 +18323,7 @@ msgstr[1] ""
 #: include/classes/api/services/CUser.php:741
 #, c-format
 msgid "User group with ID \"%1$s\" is not available."
-msgstr "Le groupe d'utilisateurs avec l'IS \"%1$s\" n'est pas disponible."
+msgstr "Le groupe d’utilisateurs avec l’IS « %1$s » n’est pas disponible."
 
 #: app/controllers/CControllerPopupGeneric.php:197
 #: app/views/administration.usergroup.edit.php:28
@@ -18357,11 +18333,11 @@ msgstr "Le groupe d'utilisateurs avec l'IS \"%1$s\" n'est pas disponible."
 #: include/classes/helpers/CRoleHelper.php:382
 #: include/views/monitoring.sysmap.edit.php:322
 msgid "User groups"
-msgstr "Groupes d'utilisateurs"
+msgstr "Groupes d’utilisateurs"
 
 #: include/classes/api/services/CUser.php:1252
 msgid "User is not allowed to delete himself."
-msgstr "Un utilisateur n'est pas autorisé à s'effacer lui-même."
+msgstr "Un utilisateur n’est pas autorisé à s’effacer lui‐même."
 
 #: app/partials/layout.htmlpage.aside.php:94
 msgid "User menu"
@@ -18376,11 +18352,11 @@ msgstr "Menu utilisateur"
 #: include/views/configuration.item.prototype.edit.php:453
 #: include/views/configuration.item.prototype.edit.php:635 items.php:94
 msgid "User name"
-msgstr "Nom d'utilisateur"
+msgstr "Nom d’utilisateur"
 
 #: app/views/administration.authentication.edit.php:206
 msgid "User password"
-msgstr "Mot de passe de l'utilisateur"
+msgstr "Mot de passe de l’utilisateur"
 
 #: app/controllers/CControllerUserProfileEdit.php:139
 #: app/views/administration.user.edit.php:38 include/html.inc.php:816
@@ -18392,31 +18368,31 @@ msgstr "Profil utilisateur"
 #: app/views/administration.userrole.edit.php:385
 #: app/views/administration.userrole.edit.php:387
 msgid "User role"
-msgstr ""
+msgstr "Rôle d’utilisateur"
 
 #: include/classes/api/services/CRole.php:414
 #, c-format
 msgid "User role \"%1$s\" already exists."
-msgstr ""
+msgstr "Le rôle d’utilisateur « %1$s » existe déjà."
 
 #: app/controllers/CControllerUserroleCreate.php:140
 msgid "User role created"
-msgstr ""
+msgstr "Rôle d’utilisateur créé"
 
 #: app/controllers/CControllerUserroleDelete.php:56
 msgid "User role deleted"
 msgid_plural "User roles deleted"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Rôle d’utilisateur supprimé"
+msgstr[1] "Rôles d’utilisateur supprimés"
 
 #: app/controllers/CControllerUserroleUpdate.php:164
 msgid "User role updated"
-msgstr ""
+msgstr "Rôle d’utilisateur mis à jour"
 
 #: include/classes/api/services/CUser.php:796
 #, c-format
 msgid "User role with ID \"%1$s\" is not available."
-msgstr ""
+msgstr "Le rôle d’utilisateur « %1$s » n’est pas disponible."
 
 #: app/controllers/CControllerPopupGeneric.php:321
 #: app/views/administration.user.list.php:73
@@ -18425,7 +18401,7 @@ msgstr ""
 #: include/classes/helpers/CMenuHelper.php:273
 #: include/classes/helpers/CRoleHelper.php:383
 msgid "User roles"
-msgstr ""
+msgstr "Rôles d’utilisateur"
 
 #: app/views/administration.housekeeping.edit.php:108
 msgid "User sessions"
@@ -18434,25 +18410,25 @@ msgstr "Sessions utilisateurs"
 #: include/classes/helpers/CMenuHelper.php:367
 #: include/classes/helpers/CMenuHelper.php:381
 msgid "User settings"
-msgstr ""
+msgstr "Paramètres utilisateur"
 
 #: include/classes/api/services/CMap.php:709
 #: include/classes/api/services/CMap.php:1178
 #, c-format
 msgid "User sharing is missing parameters: %1$s for map \"%2$s\"."
-msgstr "Le paramètre %1$s manque pour le partage d'utilisateur pour la carte \"%2$s\"."
+msgstr "Le paramètre %1$s manque pour le partage d’utilisateur pour la carte « %2$s »."
 
 #: app/views/administration.user.edit.php:420
 #: app/views/administration.userrole.edit.php:53
 #: app/views/administration.userrole.edit.php:68
 msgid "User type"
-msgstr "Type d'utilisateur"
+msgstr "Type d’utilisateur"
 
 #: app/controllers/CControllerUserUnblock.php:65
 msgid "User unblocked"
 msgid_plural "Users unblocked"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Utilisateur débloqué"
+msgstr[1] "Utilisateurs débloqués"
 
 #: app/controllers/CControllerUserProfileUpdate.php:118
 #: app/controllers/CControllerUserUpdate.php:124
@@ -18466,12 +18442,12 @@ msgstr "Utilisateur mis à jour"
 #: include/classes/api/services/CUserGroup.php:401
 #, c-format
 msgid "User with ID \"%1$s\" is not available."
-msgstr "L'utilisateur avec l'ID \"%1$s\" n'est pas disponible."
+msgstr "L’utilisateur avec l’ID « %1$s » n’est pas disponible."
 
 #: include/classes/api/services/CUser.php:700
 #, c-format
 msgid "User with username \"%1$s\" already exists."
-msgstr ""
+msgstr "Un utilisateur a déjà « %1$s » pour nom d’utilisateur."
 
 #: include/actions.inc.php:1827 include/actions.inc.php:1921
 msgid "User/Recipient"
@@ -18489,20 +18465,20 @@ msgstr "Utilisateur/Destinataire"
 #: include/views/configuration.host.prototype.edit.php:311
 #: include/views/general.login.php:70 index.php:32 items.php:210
 msgid "Username"
-msgstr "Nom d'utilisateur"
+msgstr "Nom d’utilisateur"
 
 #: app/views/administration.mediatype.edit.php:91
 msgid "Username and password"
-msgstr "Nom d'utilisateur et mot de passe"
+msgstr "Nom d’utilisateur et mot de passe"
 
 #: include/classes/setup/CSetupWizard.php:194
 #: include/classes/setup/CSetupWizard.php:774
 msgid "Username and password must be stored in Vault secret keys \"username\" and \"password\"."
-msgstr ""
+msgstr "Les nom d’utilisateur et mot de passe doivent être stockés dans les champs secrets « username » et « password » du coffre‑fort."
 
 #: app/views/administration.authentication.edit.php:241
 msgid "Username attribute"
-msgstr ""
+msgstr "Attribut de nom d’utilisateur"
 
 #: app/controllers/CControllerPopupGeneric.php:209
 #: app/views/administration.token.list.php:44
@@ -18524,248 +18500,248 @@ msgstr "Utilisateurs"
 
 #: include/classes/data/CItemData.php:1752
 msgid "VMware cache statistics. Valid modes are: total, free, pfree, used and pused."
-msgstr "statistiques du cache VMware. Les modes valides sont : total, free, pfree, used et pused."
+msgstr "Statistiques du cache VMware. Les modes valides sont : « total », « free », « pfree », « used » et « pused »."
 
 #: include/classes/data/CItemData.php:1240
 msgid "VMware cluster performance counter, <url> - VMware service URL, <id> - VMware cluster id, <path> - performance counter path, <instance> - performance counter instance"
-msgstr ""
+msgstr "Compteur de performance de la grappe de serveurs VMware <url> — URL de service VMware, <id> — identifiant de la grappe de serveurs VMware, <path> — chemin du compteur de performance, <instance> — instance du compteur de performance"
 
 #: include/classes/data/CItemData.php:1248
 msgid "VMware cluster status, <url> - VMware service URL, <name> - VMware cluster name"
-msgstr "État du cluster VMware, <url> - URL du service VMware, <name> - Nom du cluster VMware"
+msgstr "État de la grappe de serveurs VMware, <url> — URL de service VMware, <name> — nom de la grappe VMware"
 
 #: include/classes/data/CItemData.php:1272
 msgid "VMware datacenters and their IDs. Returns JSON"
-msgstr ""
+msgstr "Centres de données VMware et leurs identifiants. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1264
 #: include/classes/data/CItemData.php:1320
 msgid "VMware datastore capacity statistics in bytes or in percentage from total. Returns integer for bytes; float for percentage"
-msgstr "Statistiques de capacité du datastore VMware en octets ou en pourcentage du total. Retourne un entier pour les octets ; un flottant pour le pourcentage"
+msgstr "Statistiques de capacité de la banque de données (datastore) VMware en octets ou en pourcentage du total. Retourne un entier pour les octets ; un flottant pour le pourcentage"
 
 #: include/classes/data/CItemData.php:1256
 msgid "VMware datastore hypervisors list, <url> - VMware service URL, <datastore> - datastore name"
-msgstr ""
+msgstr "Liste des hyperviseurs de la banque de données VMware, <url> — URL de service VMware, <datastore> — nom de la banque de données"
 
 #: include/classes/data/CItemData.php:1260
 msgid "VMware datastore read statistics, <url> - VMware service URL, <datastore> - datastore name, <mode> - latency/maxlatency - average or maximum"
-msgstr ""
+msgstr "Statistiques de lecture de la banque de données VMware <url> — URL de service VMware, <datastore> — nom de la banque de données, <mode> — latency/maxlatency — moyenne ou maximum"
 
 #: include/classes/data/CItemData.php:1268
 msgid "VMware datastore write statistics, <url> - VMware service URL, <datastore> - datastore name, <mode> - latency/maxlatency - average or maximum"
-msgstr ""
+msgstr "Statistiques d’écriture sur la banque de données VMware <url> — URL de service VMware, <datastore> — nom de la banque de données, <mode> — latency/maxlatency — moyenne ou maximum"
 
 #: include/classes/data/CItemData.php:1276
 msgid "VMware event log, <url> - VMware service URL, <mode> - all (default), skip - skip processing of older data"
-msgstr "Journal des événements VMware, <url> - URL du service VMware, <mode> - all (tout - par défaut), skip - ignorer le traitement des données plus anciennes"
+msgstr "Journal des événements VMware, <url> — URL de service VMware, <mode> — all (tout — par défaut), skip — ignorer le traitement des données plus anciennes"
 
 #: include/classes/data/CItemData.php:1360
 msgid "VMware hypervisor BIOS UUID, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr ""
+msgstr "UUID du BIOS de l’hyperviseur VMware <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1400
 msgid "VMware hypervisor HW vendor state sensors, <url> - VMware service URL, <uuid> - VMware hypervisor host name. Returns JSON"
-msgstr ""
+msgstr "Capteurs d’état du matériel hébergeant l’hyperviseur VMware <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware. Retourne un objet JSON"
 
 #: include/classes/data/CItemData.php:1372
 msgid "VMware hypervisor ballooned memory size, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Taille de la mémoire \"balloon\" de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "Taille de la mémoire « balloon » de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1284
 msgid "VMware hypervisor cluster name, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Nom du cluster de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "Nom de la grappe de serveurs de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1300
 msgid "VMware hypervisor datacenter name, <url> - VMware service URL, <uuid> - VMware hypervisor host name. Returns string"
-msgstr ""
+msgstr "Nom du centre de données hébergeant l’hyperviseur VMware <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware. Retourne une chaîne de caractères"
 
 #: include/classes/data/CItemData.php:1316
 msgid "VMware hypervisor datastore read statistics, <url> - VMware service URL, <uuid> - VMware hypervisor host name, <datastore> - datastore name, <mode> - latency"
-msgstr "Statistiques de lecture du datastore de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware, <datastore> - nom du datastore, <mode> - latence"
+msgstr "Statistiques de lecture de la banque de données de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware, <datastore> — nom de la banque de données (datastore), <mode> — latence"
 
 #: include/classes/data/CItemData.php:1324
 msgid "VMware hypervisor datastore write statistics, <url> - VMware service URL, <uuid> - VMware hypervisor host name, <datastore> - datastore name, <mode> - latency"
-msgstr "Statistiques d'écriture du datastore de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware, <datastore> - nom du datastore, <mode> - latence"
+msgstr "Statistiques d’écriture de la banque de données de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware, <datastore> — nom de la banque de données (datastore), <mode> — latence"
 
 #: include/classes/data/CItemData.php:1308
 msgid "VMware hypervisor datastores list, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr ""
+msgstr "Liste de banques de données (datastores) de l’hyperviseur VMware <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1396
 msgid "VMware hypervisor health state rollup sensor, <url> - VMware service URL, <uuid> - VMware hypervisor host name. Returns 0 - gray; 1 - green; 2 - yellow; 3 - red"
-msgstr ""
+msgstr "Indicateur de l’état de santé de l’hyperviseur VMware <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware. Retourne : 0 — gris, 1 — vert, 2 — jaune, 3 — rouge"
 
 #: include/classes/data/CItemData.php:1356
 msgid "VMware hypervisor model, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Modèle de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "Modèle de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1332
 msgid "VMware hypervisor name, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Nom de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "Nom de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1380
 msgid "VMware hypervisor network input statistics, <url> - VMware service URL, <uuid> - VMware hypervisor host name, <mode> - bps"
-msgstr "Statistiques d'entrée réseau de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware, <mode> - bps"
+msgstr "Statistiques d’entrée réseau de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware, <mode> — bit/s"
 
 #: include/classes/data/CItemData.php:1384
 msgid "VMware hypervisor network output statistics, <url> - VMware service URL, <uuid> - VMware hypervisor host name, <mode> - bps"
-msgstr "Statistiques de sortie réseau de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware, <mode> - bps"
+msgstr "Statistiques de sortie réseau de l’hyperviseur VMware, <url> — URL du service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware, <mode> — bit/s"
 
 #: include/classes/data/CItemData.php:1388
 msgid "VMware hypervisor performance counter, <url> - VMware service URL, <uuid> - VMware hypervisor host name, <path> - performance counter path, <instance> - performance counter instance"
-msgstr "Compteur de performance de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware, <path> - chemin du compteur de performance, <instance> - instance du compteur de performance"
+msgstr "Compteur de performance de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware, <path> — chemin du compteur de performance, <instance> — instance du compteur de performance"
 
 #: include/classes/data/CItemData.php:1336
 msgid "VMware hypervisor processor frequency, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Fréquence du processeur de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "Fréquence du processeur de l’hyperviseur VMware, <url> — URL du service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1340
 msgid "VMware hypervisor processor model, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Modèle du processeur de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "Modèle du processeur de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1292
 msgid "VMware hypervisor processor usage in Hz, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Utilisation du processeur de l'hyperviseur VMware en Hz, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "Utilisation du processeur de l’hyperviseur VMware en Hz, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1404
 msgid "VMware hypervisor status, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "État de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "État de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1352
 msgid "VMware hypervisor total memory size, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Fréquence du processeur de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "Capacité totale de la mémoire de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1408
 msgid "VMware hypervisor uptime, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Uptime de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "Durée de fonctionnement de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1376
 msgid "VMware hypervisor used memory size, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Taille mémoire utilisée sur l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "Capacité mémoire utilisée de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1364
 msgid "VMware hypervisor vendor name, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "vendor name de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "Nom du fournisseur de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1412
 msgid "VMware hypervisor version, <url> - VMware service URL, <uuid> - VMware hypervisor host name"
-msgstr "Version de l'hyperviseur VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de l'hyperviseur VMware"
+msgstr "Version de l’hyperviseur VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware"
 
 #: include/classes/data/CItemData.php:1280
 msgid "VMware service full name, <url> - VMware service URL"
-msgstr "Nom complet du service VMware, <url> - URL du service VMware"
+msgstr "Nom complet du service VMware, <url> — URL de service VMware"
 
 #: include/classes/data/CItemData.php:1420
 msgid "VMware service version, <url> - VMware service URL"
-msgstr "Version du service VMware, <url> - URL du service VMware"
+msgstr "Version du service VMware, <url> — URL de service VMware"
 
 #: include/classes/data/CItemData.php:1476
 msgid "VMware virtual machine ballooned memory size, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Taille de la mémoire \"balloon\" d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Taille de la mémoire élastique « balloon » de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1540
 msgid "VMware virtual machine committed storage space, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Espace de stockage utilisé d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Espace de stockage utilisé de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1480
 msgid "VMware virtual machine compressed memory size, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Taille de la mémoire compressée d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Taille de la mémoire compressée de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1456
 msgid "VMware virtual machine datacenter name, <url> - VMware service URL, <uuid> - VMware virtual machine host name. Returns string"
-msgstr ""
+msgstr "Nom du centre de données hébergeant la machine virtuelle VMware <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware. Retourne une chaîne de caractères"
 
 #: include/classes/data/CItemData.php:1576
 msgid "VMware virtual machine disk device read statistics, <url> - VMware service URL, <uuid> - VMware virtual machine host name, <instance> - disk device instance, <mode> - bps/ops - bytes/operations per second"
-msgstr "Statistiques de lecture d'un disque d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware, <instance> - instance du périphérique disque, <mode> - bps/ops - octets/opérations par seconde"
+msgstr "Statistiques de lecture disque de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware, <instance> — instance du périphérique disque, <mode> — bps/ops — octets/opérations par seconde"
 
 #: include/classes/data/CItemData.php:1580
 msgid "VMware virtual machine disk device write statistics, <url> - VMware service URL, <uuid> - VMware virtual machine host name, <instance> - disk device instance, <mode> - bps/ops - bytes/operations per second"
-msgstr "Statistiques d'écriture d'un disque d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware, <instance> - instance du périphérique disque, <mode> - bps/ops - octets/opérations par seconde"
+msgstr "Statistiques d’écriture disque de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware, <instance> — instance du périphérique disque, <mode> — bps/ops — octets/opérations par seconde"
 
 #: include/classes/data/CItemData.php:1588
 msgid "VMware virtual machine file system statistics, <url> - VMware service URL, <uuid> - VMware virtual machine host name, <fsname> - file system name, <mode> - total/free/used/pfree/pused"
-msgstr "Statistiques d'un système de fichiers d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware, <fsname> - nom du système de fichiers, <mode> - total/free/used/pfree/pused"
+msgstr "Statistiques du système de fichiers de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware, <fsname> — nom du système de fichiers, <mode> — total/free/used/pfree/pused"
 
 #: include/classes/data/CItemData.php:1500
 msgid "VMware virtual machine guest memory usage, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Utilisation de la mémoire \"invité\" d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Utilisation de la mémoire « invité » de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1504
 msgid "VMware virtual machine host memory usage, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Utilisation de la mémoire \"hôte\" d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Utilisation mémoire de l’hôte par la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1472
 msgid "VMware virtual machine hypervisor name, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Nom de l'hyperviseur d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Nom de l’hyperviseur de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1424
 msgid "VMware virtual machine name, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Nom d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Nom de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1520
 msgid "VMware virtual machine network interface input statistics, <url> - VMware service URL, <uuid> - VMware virtual machine host name, <instance> - network interface instance, <mode> - bps/pps - bytes/packets per second"
-msgstr "Statistiques d'entrée d'une interface réseau d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware, <instance> - instance de l'interface réseau, <mode> - bps/ops - octets/operations par second"
+msgstr "Statistiques d’entrée de l’interface réseau de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware, <instance> — instance de l’interface réseau, <mode> — bps/ops — octets/opérations par seconde"
 
 #: include/classes/data/CItemData.php:1524
 msgid "VMware virtual machine network interface output statistics, <url> - VMware service URL, <uuid> - VMware virtual machine host name, <instance> - network interface instance, <mode> - bps/pps - bytes/packets per second"
-msgstr "Statistiques de sortie d'une interface réseau d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware, <instance> - instance de l'interface réseau, <mode> - bps/ops - octets/operations par second"
+msgstr "Statistiques de sortie de l’interface réseau de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware, <instance> — instance de l’interface réseau, <mode> — bps/ops — octets/opérations par seconde"
 
 #: include/classes/data/CItemData.php:1532
 msgid "VMware virtual machine performance counter, <url> - VMware service URL, <uuid> - VMware virtual machine host name, <path> - performance counter path, <instance> - performance counter instance"
-msgstr "Compteur de performance d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware, <path> - chemin du compteur de performance, <instance> - instance du compteur de performance"
+msgstr "Compteur de performance de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware, <path> — chemin du compteur de performance, <instance> — instance du compteur de performance"
 
 #: include/classes/data/CItemData.php:1536
 msgid "VMware virtual machine power state, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "État de fonctionnement (allumée/éteinte) d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "État de fonctionnement de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1488
 msgid "VMware virtual machine private memory size, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Taille de la mémoire privée d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Taille de la mémoire privée de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1440
 msgid "VMware virtual machine processor ready time ms, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Temps de disponibilité du processeur d'une machine virtuelle VMware en ms, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Temps de disponibilité du processeur de la machine virtuelle VMware en ms, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1452
 msgid "VMware virtual machine processor usage in Hz, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Utilisation du processeur d'une machine virtuelle VMware en Hz, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Utilisation du processeur de la machine virtuelle VMware en Hz, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1492
 msgid "VMware virtual machine shared memory size, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Taille de la mémoire partager d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Taille de la mémoire partagée de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1496
 msgid "VMware virtual machine swapped memory size, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Taille de la mémoire swappée d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Taille de la mémoire échangée (swapped) de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1508
 msgid "VMware virtual machine total memory size, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Taille totale de la mémoire d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Taille totale de la mémoire de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1556
 msgid "VMware virtual machine uncommitted storage space, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Espace de stockage inutilisé d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Espace de stockage inutilisé par la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1560
 msgid "VMware virtual machine unshared storage space, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Espace de stockage non partagé d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Espace de stockage non partagé de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1568
 msgid "VMware virtual machine uptime, <url> - VMware service URL, <uuid> - VMware virtual machine host name"
-msgstr "Uptime d'une machine virtuelle VMware, <url> - URL du service VMware, <uuid> - Nom d'hôte de la machine virtuelle VMware"
+msgstr "Durée de fonctionnement (uptime) de la machine virtuelle VMware, <url> — URL de service VMware, <uuid> — nom d’hôte de la machine virtuelle VMware"
 
 #: include/classes/data/CItemData.php:1368
 msgid "VVMware hypervisor maintenance status, <url> - VMware service URL, <uuid> - VMware hypervisor host name. Returns 0 - not in maintenance; 1 - in maintenance"
-msgstr ""
+msgstr "Statut de la maintenance de l’hyperviseur VMware <url> — URL de service VMware, <uuid> — nom d’hôte de l’hyperviseur VMware. Retourne : 0 — en production, 1 — en maintenance"
 
 #: app/views/administration.miscconfig.edit.php:104
 msgid "Valid URI schemes"
-msgstr ""
+msgstr "Schémas d’URI valides"
 
 #: app/views/administration.miscconfig.edit.php:99
 msgid "Validate URI schemes"
-msgstr ""
+msgstr "Valider les schémas d’URI"
 
 #: include/items.inc.php:1866 include/items.inc.php:1870
 #: include/items.inc.php:1874 include/items.inc.php:1878
@@ -18799,8 +18775,7 @@ msgstr "Validation"
 #: app/views/popup.condition.common.php:601 app/views/popup.httpstep.php:70
 #: app/views/popup.httpstep.php:96 app/views/popup.httpstep.php:120
 #: app/views/popup.httpstep.php:139 app/views/popup.itemtestedit.view.php:262
-#: app/views/popup.lldoperation.php:268
-#: app/views/popup.massupdate.host.php:203
+#: app/views/popup.lldoperation.php:268 app/views/popup.massupdate.host.php:203
 #: app/views/popup.massupdate.item.php:120
 #: app/views/popup.massupdate.item.php:486
 #: app/views/popup.massupdate.service.php:50
@@ -18834,36 +18809,36 @@ msgstr "Valeur"
 #: include/classes/api/services/CMap.php:1405
 #, c-format
 msgid "Value \"%1$s\" is invalid for parameter \"grid_align\". Choices are: \"%2$s\" and \"%3$s\""
-msgstr "La valeur \"%1$s\" est invalide pour le paramètre \"grid_align\". Les choix sont : \"%2$s\" et \"%3$s\""
+msgstr "La valeur « %1$s » est invalide pour le paramètre « grid_align ». Les choix sont : « %2$s » et « %3$s »"
 
 #: include/classes/api/services/CMap.php:941
 #: include/classes/api/services/CMap.php:1416
 #, c-format
 msgid "Value \"%1$s\" is invalid for parameter \"grid_show\". Choices are: \"%2$s\" and \"%3$s\"."
-msgstr "La valeur \"%1$s\" est invalide pour le paramètre \"grid_show\". Les choix sont : \"%2$s\" et \"%3$s\"."
+msgstr "La valeur « %1$s » est invalide pour le paramètre « grid_show ». Les choix sont : « %2$s » et « %3$s »."
 
 #: include/classes/api/services/CMap.php:920
 #: include/classes/api/services/CMap.php:1395
 #, c-format
 msgid "Value \"%1$s\" is invalid for parameter \"grid_show\". Choices are: \"%2$s\"."
-msgstr "La valeur \"%1$s\" est invalide pour le paramètre \"grid_show\". Les choix sont : \"%2$s\"."
+msgstr "La valeur « %1$s » est invalide pour le paramètre « grid_show ». Les choix sont : « %2$s »."
 
 #: include/classes/db/DB.php:390 include/classes/db/DB.php:423
 #, c-format
 msgid "Value \"%1$s\" is too long for field \"%2$s\" - %3$d characters. Allowed length is %4$d characters."
-msgstr "La valeur \"%1$s\" est trop longue pour le champ \"%2$s\" - %3$d caractères. La longueur autorisée est de %4$d caractères."
+msgstr "La valeur « %1$s » est trop longue pour le champ « %2$s » — %3$d caractères. La longueur autorisée est de %4$d caractères."
 
 #: include/classes/data/CItemData.php:1744
 msgid "Value cache effectiveness. Valid parameters are: requests, hits and misses."
-msgstr "Efficacité du cache de valeurs. Les paramètres valides sont : requests, hits et misses."
+msgstr "Efficacité du cache de valeurs. Les paramètres valides sont : requests, hits et misses."
 
 #: include/classes/data/CItemData.php:1740
 msgid "Value cache statistics. Valid modes are: total, free, pfree, used and pused."
-msgstr "Statistiques du cache de valeurs. Les modes valides sont : total, free, pfree, used et pused."
+msgstr "Statistiques du cache de valeurs. Les modes valides sont : total, free, pfree, used et pused."
 
 #: include/classes/helpers/CCookieHelper.php:75
 msgid "Value cannot be empty."
-msgstr ""
+msgstr "La valeur ne peut être vide."
 
 #: app/controllers/CControllerAuditLogList.php:246
 msgid "Value map"
@@ -18872,7 +18847,7 @@ msgstr "Table de correspondance"
 #: include/classes/api/services/CValueMap.php:335
 #, c-format
 msgid "Value map \"%1$s\" already exists."
-msgstr "La table de correspondance \"%1$s\" existe déjà."
+msgstr "La table de correspondance « %1$s » existe déjà."
 
 #: app/controllers/CControllerPopupGeneric.php:345
 #: app/controllers/CControllerPopupGeneric.php:357
@@ -18896,37 +18871,37 @@ msgstr "Tables de correspondance"
 
 #: include/classes/data/CItemData.php:928
 msgid "Value of MQTT topic. Format of returned data depends on the topic content. If wildcards are used, returns topic values in JSON"
-msgstr ""
+msgstr "Valeur du sujet MQTT. Le format des données renvoyées dépend du contenu du sujet. Si des caractères jokers sont utilisés, renvoie les valeurs des sujets en JSON"
 
 #: include/classes/data/CItemData.php:1004
 msgid "Value of any Windows performance counter in English. Returns integer, float, string or text (depending on the request)"
-msgstr ""
+msgstr "Valeur de n’importe quel compteur de performance de Windows en anglais. Retourne un entier, un flottant, une chaîne ou un texte (en fonction de la requête)"
 
 #: include/classes/data/CItemData.php:1000
 msgid "Value of any Windows performance counter. Returns integer, float, string or text (depending on the request)"
-msgstr "Valeur de n'importe quel compteur de performances Windows. Retourne un entier, un flottant une chaîne ou un texte (selon la requête)"
+msgstr "Valeur de n’importe quel compteur de performances Windows. Retourne un entier, un flottant une chaîne ou un texte (selon la requête)"
 
 #: include/classes/helpers/CCorrelationHelper.php:153
 msgid "Value of new event tag"
-msgstr ""
+msgstr "Valeur de la nouvelle étiquette d’événement"
 
 #: include/classes/helpers/CCorrelationHelper.php:138
 #: include/classes/helpers/CCorrelationHelper.php:146
 msgid "Value of old event tag"
-msgstr ""
+msgstr "Valeur de l’ancienne étiquette d’événement"
 
 #: include/actions.inc.php:352
 msgid "Value of tag"
-msgstr ""
+msgstr "Valeur de l’étiquette"
 
 #: include/classes/graphdraw/CPieGraphDraw.php:320
 msgid "Value: no data"
-msgstr "Valeur : pas de donnée"
+msgstr "Valeur : pas de donnée"
 
 #: include/classes/api/services/CItemGeneral.php:2848
 #, c-format
 msgid "Valuemap with ID \"%1$s\" is not available on \"%2$s\"."
-msgstr ""
+msgstr "La carte de correspondance (Valuemap) avec l’identifiant « %1$s » n’est pas disponible pour « %2$s »."
 
 #: app/controllers/CControllerPopupTriggerExpr.php:624
 #: app/views/monitoring.charts.view.php:56
@@ -18950,26 +18925,26 @@ msgstr "Diverses informations sur le(s) processus spécifique(s). Retourne un no
 #: include/classes/setup/CSetupWizard.php:502
 #: include/classes/setup/CSetupWizard.php:682
 msgid "Vault API endpoint"
-msgstr ""
+msgstr "Point de terminaison de l’API du coffre‑fort"
 
 #: include/classes/setup/CSetupWizard.php:515
 #: include/classes/setup/CSetupWizard.php:690
 msgid "Vault authentication token"
-msgstr ""
+msgstr "Jeton d’authentification au coffre‑fort"
 
 #: include/classes/core/ZBase.php:231
 #: include/classes/setup/CSetupWizard.php:191 include/config.inc.php:53
 msgid "Vault connection failed."
-msgstr ""
+msgstr "La connexion au coffre‑fort a échoué."
 
 #: include/classes/html/CMacroValue.php:158
 msgid "Vault secret"
-msgstr ""
+msgstr "Secret du coffre‑fort"
 
 #: include/classes/setup/CSetupWizard.php:508
 #: include/classes/setup/CSetupWizard.php:686
 msgid "Vault secret path"
-msgstr ""
+msgstr "Chemin d’accès au secret du coffre‑fort"
 
 #: include/hosts.inc.php:249
 msgid "Vendor"
@@ -18981,20 +18956,20 @@ msgstr "Verbeux"
 
 #: include/classes/setup/CSetupWizard.php:546
 msgid "Verify database certificate"
-msgstr ""
+msgstr "Vérifier le certificat de la base de données"
 
 #: app/views/administration.module.edit.php:39
 #: app/views/administration.module.list.php:75
 msgid "Version"
-msgstr ""
+msgstr "Version"
 
 #: include/classes/data/CItemData.php:848
 msgid "Version of Zabbix agent. Returns string"
-msgstr "Version de l'agent Zabbix. Retourne une chaîne"
+msgstr "Version de l’agent Zabbix. Retourne une chaîne"
 
 #: include/classes/data/CItemData.php:1748
 msgid "Version of Zabbix server or proxy"
-msgstr ""
+msgstr "Version du serveur ou du proxy Zabbix"
 
 #: include/classes/widgets/forms/CWidgetFormHostAvail.php:50
 #: include/classes/widgets/forms/CWidgetFormProblemsBySv.php:123
@@ -19014,7 +18989,7 @@ msgstr "Vietnamien (vi_VN)"
 #: app/views/monitoring.service.list.php:113
 #: include/views/js/configuration.host.discovery.edit.overr.js.php:106
 msgid "View"
-msgstr ""
+msgstr "Affichage"
 
 #: app/views/monitoring.charts.view.php:49
 #: include/views/monitoring.history.php:91
@@ -19023,7 +18998,7 @@ msgstr "Afficher comme"
 
 #: include/classes/data/CItemData.php:1236
 msgid "Virtual space size in bytes or in percentage from total. Returns integer for bytes; float for percentage"
-msgstr "Taille de l'espace virtuel en octets ou en pourcentage du toutal. Retourne un entier pour les octets; un flottant pour les pourcentages"
+msgstr "Taille de l’espace virtuel en octets ou en pourcentage du toutal. Retourne un entier pour les octets; un flottant pour les pourcentages"
 
 #: app/partials/configuration.host.edit.html.php:98
 #: app/views/configuration.discovery.edit.php:118
@@ -19035,12 +19010,12 @@ msgstr "Nom visible"
 
 #: include/classes/api/services/CHost.php:2241
 msgid "Visible name cannot be empty if host name is missing."
-msgstr "Le nom visible ne peut pas être vide si le nom d'hôte est manquant."
+msgstr "Le nom visible ne peut pas être vide si le nom d’hôte est manquant."
 
 #: include/classes/helpers/CServiceHelper.php:57
 #: include/classes/helpers/CServiceHelper.php:67
 msgid "W"
-msgstr ""
+msgstr "W"
 
 #: jsLoader.php:252
 msgctxt "Wednesday short"
@@ -19050,7 +19025,7 @@ msgstr "M"
 #: jsLoader.php:184
 msgctxt "abbreviation of severity level"
 msgid "W"
-msgstr ""
+msgstr "A"
 
 #: app/controllers/CControllerPopupMediatypeTestSend.php:172
 #: app/views/administration.trigdisplay.edit.php:118
@@ -19066,16 +19041,16 @@ msgstr "Avertissement"
 
 #: include/func.inc.php:1643 jsLoader.php:227
 msgid "Warning message"
-msgstr ""
+msgstr "Message d’alerte"
 
 #: app/partials/administration.system.info.php:167
 #, c-format
 msgid "Warning! Unsupported %1$s database server version. Should be at least (%2$s)"
-msgstr ""
+msgstr "Attention ! Version du serveur de base de données %1$s non prise en charge. La version devrait être au moins la %2$s"
 
 #: jsLoader.php:299
 msgid "We are sorry, the maximum possible number of elements to remember has been reached."
-msgstr "Nous sommes désolés, le nombre maximal d'éléments à mémoriser a été atteint."
+msgstr "Nous sommes désolés, le nombre maximal d’éléments à mémoriser a été atteint."
 
 #: app/partials/monitoring.host.view.html.php:39
 #: app/partials/monitoring.host.view.html.php:148
@@ -19103,56 +19078,56 @@ msgstr "Supervision Web"
 
 #: app/controllers/CControllerAuditLogList.php:235
 msgid "Web scenario"
-msgstr "Scénario web"
+msgstr "Scénario Web"
 
 #: include/classes/api/managers/CHttpTestManager.php:377
 #: include/classes/api/managers/CHttpTestManager.php:390
 #, c-format
 msgid "Web scenario \"%1$s\" already exists on host \"%2$s\"."
-msgstr "Le scénario web \"%1$s\" existe déjà sur l'hôte \"%2$s\"."
+msgstr "Le scénario Web « %1$s » existe déjà sur l’hôte « %2$s »."
 
 #: include/classes/api/services/CHttpTest.php:714
 #, c-format
 msgid "Web scenario \"%1$s\" already exists."
-msgstr "Le scénario web \"%1$s\" existe déjà."
+msgstr "Le scénario Web « %1$s » existe déjà."
 
 #: httpconf.php:197
 msgid "Web scenario added"
-msgstr "Scénario web ajouté"
+msgstr "Scénario Web ajouté"
 
 #: httpconf.php:177 httpconf.php:442
 msgid "Web scenario deleted"
-msgstr "Scénario web supprimé"
+msgstr "Scénario Web supprimé"
 
 #: httpconf.php:413
 msgid "Web scenario disabled"
 msgid_plural "Web scenarios disabled"
-msgstr[0] "Scénario web désactivé"
-msgstr[1] "Scénarios web désactivés"
+msgstr[0] "Scénario Web désactivé"
+msgstr[1] "Scénarios Web désactivés"
 
 #: httpconf.php:412
 msgid "Web scenario enabled"
 msgid_plural "Web scenarios enabled"
-msgstr[0] "Scénarion web activé"
-msgstr[1] "Scénarios web activés"
+msgstr[0] "Scénario Web activé"
+msgstr[1] "Scénarios Web activés"
 
 #: httpconf.php:193
 msgid "Web scenario updated"
-msgstr "Scénario web mis à jour"
+msgstr "Scénario Web mis à jour"
 
 #: app/controllers/CControllerPopupImportCompare.php:171
 #: app/views/popup.import.php:39 include/html.inc.php:400
 msgid "Web scenarios"
-msgstr "Scénarios web"
+msgstr "Scénarios Web"
 
 #: app/views/administration.script.edit.php:114
 #: app/views/administration.script.list.php:152 include/media.inc.php:27
 msgid "Webhook"
-msgstr ""
+msgstr "Webhook"
 
 #: app/views/popup.mediatypetest.edit.php:42
 msgid "Webhook does not have parameters."
-msgstr ""
+msgstr "Le Webhook n’a aucun paramètre."
 
 #: include/func.inc.php:199
 msgid "Wed"
@@ -19171,7 +19146,7 @@ msgstr "Hebdomadaire"
 
 #: app/views/popup.service.edit.php:211
 msgid "Weight"
-msgstr ""
+msgstr "Poids"
 
 #: include/classes/setup/CSetupWizard.php:54
 msgid "Welcome"
@@ -19188,11 +19163,11 @@ msgstr "Lorsque actif"
 #: include/classes/api/services/CDashboardGeneral.php:346
 #, c-format
 msgid "Widget at X:%3$d, Y:%4$d on page #%2$d of dashboard \"%1$s\" is out of bounds."
-msgstr ""
+msgstr "Le widget aux coordonnées x = %3$d, y = %4$d de la page nᵒ %2$d du tableau de bord « %1$s » est hors limites."
 
 #: jsLoader.php:194
 msgid "Widget is too small for the specified number of columns and rows."
-msgstr ""
+msgstr "Le widget est trop petit pour le nombre de lignes et de colonnes spécifiés."
 
 #: graphs.php:44 include/classes/widgets/CWidgetHelper.php:768
 #: include/classes/widgets/CWidgetHelper.php:801
@@ -19228,13 +19203,13 @@ msgstr "Avec dépendances"
 
 #: include/forms.inc.php:1367 include/views/js/item.preprocessing.js.php:215
 msgid "With header row"
-msgstr ""
+msgstr "Avec ligne d’en‑tête"
 
 #: app/partials/monitoring.problem.filter.php:244
 #: include/classes/widgets/forms/CWidgetFormProblemsBySv.php:142
 #: include/classes/widgets/forms/CWidgetFormProblems.php:162
 msgid "With problem name"
-msgstr ""
+msgstr "Avec nom du problème"
 
 #: app/views/monitoring.widget.problemhosts.view.php:33
 msgid "With problems"
@@ -19269,13 +19244,13 @@ msgstr "Écriture"
 #: include/classes/core/CModuleManager.php:203
 #, c-format
 msgid "Wrong Module.php class name for module located at %1$s."
-msgstr ""
+msgstr "Nom de classe Module.php incorrect pour le module situé dans %1$s."
 
 #: include/classes/api/services/CHost.php:1873
 #: include/classes/api/services/CHost.php:2110
 #, c-format
 msgid "Wrong fields for host \"%1$s\"."
-msgstr "Champs incorrects pour l'hôte \"%1$s\"."
+msgstr "Champs incorrects pour l’hôte « %1$s »."
 
 #: include/classes/api/services/CMapElement.php:310
 msgid "Wrong fields for map link."
@@ -19285,7 +19260,7 @@ msgstr "Champs incorrects pour un lien de carte."
 #: include/classes/api/services/CMap.php:977
 #: include/classes/api/services/CMap.php:1452
 msgid "Wrong value for \"url\" field."
-msgstr ""
+msgstr "Valeur du champ « url » incorrecte."
 
 #: include/views/js/monitoring.sysmaps.js.php:303
 #: include/views/js/monitoring.sysmaps.js.php:436
@@ -19298,7 +19273,7 @@ msgstr "Axe X"
 
 #: app/views/administration.miscconfig.edit.php:112
 msgid "X-Frame-Options HTTP header"
-msgstr ""
+msgstr "En‑tête HTTP X-Frame-Options"
 
 #: include/views/js/monitoring.sysmaps.js.php:437
 msgid "X1"
@@ -19310,7 +19285,7 @@ msgstr "X2"
 
 #: include/classes/html/CButtonExport.php:67
 msgid "XML"
-msgstr ""
+msgstr "XML"
 
 #: include/items.inc.php:1823
 msgid "XML XPath"
@@ -19329,11 +19304,11 @@ msgstr "Le XML est vide"
 
 #: include/classes/api/services/CItemGeneral.php:2602
 msgid "XML is expected"
-msgstr ""
+msgstr "Du XML est attendu"
 
 #: include/items.inc.php:1835
 msgid "XML to JSON"
-msgstr ""
+msgstr "XML vers JSON"
 
 #: include/forms.inc.php:1288 include/views/js/item.preprocessing.js.php:141
 msgid "XPath"
@@ -19351,12 +19326,12 @@ msgstr "Valeur MAX axe Y"
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:484
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:500
 msgid "Y axis MAX value must be greater than Y axis MIN value"
-msgstr "La valeur MAX de l'axe Y doit être supérieure à la valeur MIN de l'axe Y"
+msgstr "La valeur MAX de l’axe Y doit être supérieure à la valeur MIN de l’axe Y"
 
 #: include/classes/api/services/CGraphGeneral.php:349
 #: include/classes/graphdraw/CLineGraphDraw.php:1881
 msgid "Y axis MAX value must be greater than Y axis MIN value."
-msgstr "La valeur maximal de l'axe Y doit être supérieure à la valeur minimale de l'axe Y."
+msgstr "La valeur maximal de l’axe Y doit être supérieure à la valeur minimale de l’axe Y."
 
 #: include/views/configuration.graph.edit.php:249
 msgid "Y axis MIN value"
@@ -19364,7 +19339,7 @@ msgstr "Valeur minimale axe Y"
 
 #: include/views/configuration.graph.edit.php:375
 msgid "Y axis side"
-msgstr "Coté de l'axe Y"
+msgstr "Coté de l’axe Y"
 
 #: include/classes/widgets/CWidgetHelper.php:781
 #: include/classes/widgets/CWidgetHelper.php:857
@@ -19387,7 +19362,7 @@ msgstr "d/m/Y H:i:s"
 
 #: include/translateDefines.inc.php:37
 msgid "Y-n-d"
-msgstr ""
+msgstr "Y-m-d"
 
 #: include/views/js/monitoring.sysmaps.js.php:446
 msgid "Y1"
@@ -19399,12 +19374,12 @@ msgstr "Y2"
 
 #: include/classes/html/CButtonExport.php:59
 msgid "YAML"
-msgstr ""
+msgstr "YAML"
 
 #: app/partials/scheduledreport.formgrid.html.php:155
 #: app/partials/scheduledreport.formgrid.html.php:164
 msgid "YYYY-MM-DD"
-msgstr ""
+msgstr "YYYY-MM-DD"
 
 #: app/views/popup.maintenance.period.php:150
 #: app/views/popup.service.time.edit.php:136
@@ -19417,7 +19392,7 @@ msgstr "AAAA-MM-JJ hh:mm"
 #: app/views/administration.token.edit.php:84
 #: app/views/administration.user.token.edit.php:66
 msgid "YYYY-MM-DD hh:mm:ss"
-msgstr ""
+msgstr "YYYY-MM-DD hh:mm:ss"
 
 #: include/classes/import/validators/C20XmlValidator.php:801
 #: include/classes/import/validators/C30XmlValidator.php:864
@@ -19451,9 +19426,8 @@ msgstr "Annuel"
 #: app/views/hintbox.eventlist.php:178 app/views/hintbox.eventlist.php:182
 #: app/views/monitoring.widget.problems.view.php:264
 #: app/views/monitoring.widget.problems.view.php:268
-#: app/views/popup.condition.common.php:680
-#: app/views/popup.lldoperation.php:84 app/views/popup.lldoperation.php:96
-#: app/views/popup.massupdate.item.php:327
+#: app/views/popup.condition.common.php:680 app/views/popup.lldoperation.php:84
+#: app/views/popup.lldoperation.php:96 app/views/popup.massupdate.item.php:327
 #: app/views/popup.massupdate.item.php:336
 #: app/views/popup.massupdate.item.php:378
 #: app/views/popup.massupdate.trigger.php:65 include/actions.inc.php:32
@@ -19463,8 +19437,7 @@ msgstr "Annuel"
 #: include/classes/screens/CScreenProblem.php:1245 include/events.inc.php:198
 #: include/events.inc.php:202 include/events.inc.php:392
 #: include/events.inc.php:396 include/triggers.inc.php:995
-#: include/triggers.inc.php:1000
-#: include/views/configuration.graph.list.php:206
+#: include/triggers.inc.php:1000 include/views/configuration.graph.list.php:206
 #: include/views/configuration.host.prototype.list.php:142
 #: include/views/configuration.host.prototype.list.php:158
 #: include/views/configuration.httpconf.list.php:188
@@ -19486,21 +19459,21 @@ msgstr "Hier"
 #: include/func.inc.php:1513
 #, c-format
 msgid "You are logged in as \"%1$s\"."
-msgstr "Vous êtes connecté en tant que \"%1$s\"."
+msgstr "Vous êtes connecté en tant que « %1$s »."
 
 #: app/views/administration.gui.edit.php:66
 #: app/views/administration.user.edit.php:233
 #: include/classes/setup/CSetupWizard.php:391
 msgid "You are not able to choose some of the languages, because locales for them are not installed on the web server."
-msgstr "Certaines langues ne peuvent pas être choisi, car elles ne sont pas toutes installées sur le serveur web."
+msgstr "Certaines langues ne peuvent pas être choisi, car elles ne sont pas toutes installées sur le serveur Web."
 
 #: include/func.inc.php:1533 index_http.php:87 index_sso.php:262
 msgid "You are not logged in"
-msgstr "Vous n'êtes pas connecté"
+msgstr "Vous n’êtes pas connecté"
 
 #: app/views/popup.generic.php:79
 msgid "You cannot switch hosts for current selection."
-msgstr ""
+msgstr "Vous ne pouvez pas intervertir les hôtes de la sélection actuelle."
 
 #: include/classes/api/services/CAuditLog.php:73
 #: include/classes/api/services/CHaNode.php:45
@@ -19522,11 +19495,11 @@ msgstr ""
 #: include/classes/api/services/CToken.php:414
 #: include/classes/api/services/CToken.php:448
 msgid "You do not have permission to perform this operation."
-msgstr "Vous n'avez pas la permission d'effectuer cette opération."
+msgstr "Vous n’avez pas la permission d’effectuer cette opération."
 
 #: include/func.inc.php:1514
 msgid "You have no permissions to access this page."
-msgstr "Vous n'avez pas la permission d'accéder à cette page."
+msgstr "Vous n’avez pas la permission d’accéder à cette page."
 
 #: include/func.inc.php:1535
 msgid "You must login to view this page."
@@ -19534,7 +19507,7 @@ msgstr "Vous devez vous identifier pour accéder à cette page."
 
 #: include/classes/db/DB.php:135
 msgid "Your database is not working properly. Please wait a few minutes and try to repeat this action. If the problem still persists, please contact system administrator. The problem might be caused by long running transaction or row level lock accomplished by your database management system."
-msgstr "Votre base de données ne fonctionne pas correctement. Veuillez patienter quelques minutes et essayez de répéter cette action. Si le problème persiste, contactez l'administrateur système. Le problème peut être causé par une transaction de longue durée ou un verrouillage de niveau de ligne effectué par votre système de gestion de base de données."
+msgstr "Votre base de données ne fonctionne pas correctement. Veuillez patienter quelques minutes et essayez de répéter cette action. Si le problème persiste, contactez l’administrateur système. Le problème peut être causé par une transaction de longue durée ou un verrouillage de niveau de ligne effectué par votre système de gestion de base de données."
 
 #: index.php:27
 msgid "ZABBIX"
@@ -19546,7 +19519,7 @@ msgstr "Zabbix"
 
 #: include/classes/helpers/CMenuHelper.php:340
 msgid "Zabbix Integrations"
-msgstr ""
+msgstr "Intégrations Zabbix"
 
 #: include/classes/helpers/CMenuHelper.php:333
 msgid "Zabbix Technical Support"
@@ -19557,11 +19530,11 @@ msgstr "Support Technique Zabbix"
 #: include/classes/widgets/views/widget.hostavail.form.view.php:46
 #: include/discovery.inc.php:56 include/items.inc.php:86
 msgid "Zabbix agent"
-msgstr "agent Zabbix"
+msgstr "Agent Zabbix"
 
 #: include/items.inc.php:87
 msgid "Zabbix agent (active)"
-msgstr "agent Zabbix (actif)"
+msgstr "Agent Zabbix (actif)"
 
 #: include/validate.inc.php:361
 msgid "Zabbix has received an incorrect request."
@@ -19590,6 +19563,9 @@ msgid ""
 "1. Incorrect server IP/DNS in the \"zabbix.conf.php\";\n"
 "2. Incorrect network configuration.\n"
 msgstr ""
+"Le serveur Zabbix « %1$s » ne peut être atteint. Les raisons possibles sont :\n"
+"1. un nom ou une adresse IP incorrects dans le fichier « zabbix.conf.php » ;\n"
+"2. une configuration du réseau incorrecte.\n"
 
 #: app/views/administration.script.edit.php:124
 msgid "Zabbix server (proxy)"
@@ -19597,11 +19573,11 @@ msgstr "Serveur Zabbix (proxy)"
 
 #: jsrpc.php:91
 msgid "Zabbix server is not running: the information displayed may not be current."
-msgstr "Le serveur Zabbix ne fonctionne pas : les informations affichées peuvent ne pas être actuelles."
+msgstr "Le serveur Zabbix ne fonctionne pas : les informations affichées peuvent être obsolètes."
 
 #: app/partials/administration.system.info.php:34
 msgid "Zabbix server is running"
-msgstr "Le serveur Zabbix est en cours d'exécution"
+msgstr "Le serveur Zabbix est en cours d’exécution"
 
 #: include/classes/setup/CSetupWizard.php:602
 #: include/classes/setup/CSetupWizard.php:733
@@ -19612,24 +19588,23 @@ msgstr "Nom du serveur Zabbix"
 msgid "Zabbix trapper"
 msgstr "Zabbix trapper"
 
-#: include/classes/html/CFilter.php:251
-#: include/classes/html/CTabFilter.php:309
+#: include/classes/html/CFilter.php:251 include/classes/html/CTabFilter.php:309
 msgid "Zoom out"
 msgstr "Dézoomer"
 
 #: include/func.inc.php:129
 #, c-format
 msgid "[Wrong value for day: \"%1$s\" ]"
-msgstr ""
+msgstr "[valeur de jour incorrecte : « %1$s » ]"
 
 #: include/func.inc.php:114
 #, c-format
 msgid "[Wrong value for month: \"%1$s\" ]"
-msgstr ""
+msgstr "[valeur de mois incorrecte : « %1$s » ]"
 
 #: include/classes/validators/CApiInputValidator.php:2307
 msgid "a DNS name is expected"
-msgstr ""
+msgstr "un nom pleinement qualifié est attendu"
 
 #: include/classes/validators/CApiInputValidator.php:1111
 msgid "a boolean is expected"
@@ -19637,7 +19612,7 @@ msgstr "un booléen est nécessaire"
 
 #: include/classes/validators/CNewValidator.php:300
 msgid "a boolean value is expected"
-msgstr ""
+msgstr "une valeur booléenne est attendue"
 
 #: include/classes/api/services/CUser.php:908
 #: include/classes/import/validators/CXmlValidatorGeneral.php:269
@@ -19650,21 +19625,21 @@ msgstr "une chaîne de caractères est attendue"
 
 #: include/classes/validators/CApiInputValidator.php:2521
 msgid "a date in YYYY-MM-DD format is expected"
-msgstr ""
+msgstr "une date au format AAAA-MM-JJ est attendue"
 
 #: app/views/administration.authentication.edit.php:79
 msgid "a digit"
-msgstr ""
+msgstr "un chiffre"
 
 #: app/controllers/CControllerPopupValueMapUpdate.php:125
 #: include/classes/validators/CApiInputValidator.php:811
 msgid "a floating point value is expected"
-msgstr ""
+msgstr "une nombre en virgule flottante est attendue"
 
 #: include/classes/validators/CApiInputValidator.php:437
 #: include/classes/validators/CNewValidator.php:279
 msgid "a hexadecimal color code (6 symbols) is expected"
-msgstr ""
+msgstr "une valeur de couleur hexadécimale (à 6 chiffres) est attendue"
 
 #: include/classes/validators/CApiInputValidator.php:1748
 msgid "a low-level discovery macro is expected"
@@ -19673,7 +19648,7 @@ msgstr "une macro de découverte de bas niveau est attendue"
 #: include/classes/validators/CApiInputValidator.php:1627
 #: include/validate.inc.php:194
 msgid "a number has too many fractional digits"
-msgstr ""
+msgstr "un nombre a trop de décimales"
 
 #: include/classes/validators/CApiInputValidator.php:1065
 #: include/classes/validators/CApiInputValidator.php:1606
@@ -19706,11 +19681,11 @@ msgstr "une durée relative est attendue"
 
 #: app/views/administration.authentication.edit.php:86
 msgid "a special character"
-msgstr ""
+msgstr "un caractère spécial"
 
 #: include/classes/validators/CApiInputValidator.php:2491
 msgid "a string, number or null value is expected"
-msgstr ""
+msgstr "une valeur de type chaîne de caractères, nombre ou nulle est attendue"
 
 #: include/classes/validators/CNewValidator.php:238
 msgid "a time is expected"
@@ -19737,11 +19712,11 @@ msgstr "une unité de temps est nécessaire"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:302
 msgid "abs() - Absolute value"
-msgstr ""
+msgstr "abs() — value absolue"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:308
 msgid "acos() - The arccosine of a value as an angle, expressed in radians"
-msgstr ""
+msgstr "acos() — l’arc cosinus d’une valeur (réelle comprise entre -1 et 1), donnant un angle en radians"
 
 #: include/forms.inc.php:157
 msgid "affects only filtered data"
@@ -19780,7 +19755,7 @@ msgstr "tous les médias"
 
 #: include/classes/validators/CApiInputValidator.php:2220
 msgid "an IP address is expected"
-msgstr ""
+msgstr "une adresse IP est attendue"
 
 #: include/classes/api/services/CDRule.php:474
 #: include/classes/api/services/CDRule.php:481
@@ -19818,12 +19793,12 @@ msgstr "un tableau ou une chaîne de caractères est attendu"
 
 #: include/classes/validators/CApiInputValidator.php:2471
 msgid "an array or object is expected"
-msgstr ""
+msgstr "un tableau ou un objet est attendu"
 
 #: include/classes/import/validators/C10XmlValidator.php:360
 #: include/classes/import/validators/C10XmlValidator.php:382
 msgid "an empty string is expected"
-msgstr "une chaîne vie est attendue"
+msgstr "une chaîne vide est attendue"
 
 #: include/classes/api/services/CHost.php:1798
 #: include/classes/validators/CApiInputValidator.php:1315
@@ -19837,35 +19812,35 @@ msgstr "un temps explicite est attendu"
 #: include/classes/api/services/CAction.php:2712
 #: include/classes/api/services/CCorrelation.php:730
 msgid "an identifier is not defined in the formula"
-msgstr ""
+msgstr "un identifiant n’est pas défini dans la formule"
 
 #: include/classes/validators/CApiInputValidator.php:666
 msgid "an integer is expected"
-msgstr ""
+msgstr "un entier relatif est attendu"
 
 #: include/classes/validators/CApiInputValidator.php:705
 msgid "an unsigned integer is expected"
-msgstr ""
+msgstr "un entier naturel est attendu"
 
 #: app/views/administration.authentication.edit.php:72
 msgid "an uppercase and a lowercase Latin letter"
-msgstr ""
+msgstr "une lettre latine majuscule et une minuscule"
 
 #: app/views/administration.geomaps.edit.php:47
 msgid "and"
-msgstr ""
+msgstr "et"
 
 #: include/views/monitoring.history.php:186
 msgid "as Blue"
-msgstr "en Bleu"
+msgstr "en bleu"
 
 #: include/views/monitoring.history.php:185
 msgid "as Green"
-msgstr "en Vert"
+msgstr "en vert"
 
 #: include/views/monitoring.history.php:184
 msgid "as Red"
-msgstr "en Rouge"
+msgstr "en rouge"
 
 #: include/classes/widgets/forms/CWidgetFormActionLog.php:32
 #: include/classes/widgets/forms/CWidgetFormActionLog.php:34
@@ -19880,17 +19855,17 @@ msgstr "croissant"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:315
 msgid "ascii() - Returns the ASCII code of the leftmost character of the value"
-msgstr ""
+msgstr "ascii() — retourne la code ASCII du caractère le plus à gauche de la valeur"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:322
 msgid "asin() - The arcsine of a value as an angle, expressed in radians"
-msgstr ""
+msgstr "asin() — l’arc sinus d’une valeur (réelle comprise entre -1 et 1), donnant un angle en radians"
 
 #: app/controllers/CControllerPopupScheduledReportCreate.php:71
 #: app/controllers/CControllerScheduledReportCreate.php:83
 #: app/controllers/CControllerScheduledReportUpdate.php:87
 msgid "at least one day of the week must be selected"
-msgstr ""
+msgstr "au moins un jour de la semaine doit être sélectionné"
 
 #: include/classes/widgets/fields/CWidgetFieldGraphOverride.php:131
 msgid "at least one override option must be specified"
@@ -19898,19 +19873,19 @@ msgstr "au moins une option de substitution doit être spécifiée"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:329
 msgid "atan() - The arctangent of a value as an angle, expressed in radians"
-msgstr ""
+msgstr "atan() — l’arc tangente d’une valeur, le résultat est un angle en radians"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:336
 msgid "atan2() - The arctangent of the ordinate (exprue) and abscissa coordinates specified as an angle, expressed in radians"
-msgstr ""
+msgstr "atan2() — variante de l’arc tangente des coordonnées (x,y) donnant un l’angle en radians"
 
 #: include/events.inc.php:63
 msgid "autoregistered host"
-msgstr ""
+msgstr "hôte auto‐enregistré"
 
 #: include/events.inc.php:36
 msgid "autoregistration"
-msgstr ""
+msgstr "enregistrement automatique"
 
 #: include/classes/graphdraw/CLineGraphDraw.php:1379
 #: include/classes/graphdraw/CLineGraphDraw.php:1401
@@ -19924,39 +19899,39 @@ msgstr "moy"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:349
 msgid "avg() - Average value of a period T"
-msgstr "avg() - Valeur moyenne d'une période T"
+msgstr "avg() — valeur moyenne d’une période T"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:356
 msgid "between() - Checks if a value belongs to the given range (1 - in range, 0 - otherwise)"
-msgstr ""
+msgstr "between() — vérifie qu’une valeur est comprise dans une plage donnée (renvoie 1 si positif, 0 sinon)"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:374
 msgid "bitand() - Bitwise AND"
-msgstr ""
+msgstr "bitand() — ET binaire"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:387
 msgid "bitlength() - Returns the length in bits"
-msgstr ""
+msgstr "bitlength() — retourne le nombre de bits"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:394
 msgid "bitlshift() - Bitwise shift left"
-msgstr ""
+msgstr "bitlshift() — décalage binaire à gauche"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:407
 msgid "bitnot() - Bitwise NOT"
-msgstr ""
+msgstr "bitnot() — NON binaire"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:414
 msgid "bitor() - Bitwise OR"
-msgstr ""
+msgstr "bitor() — OU binaire"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:427
 msgid "bitrshift() - Bitwise shift right"
-msgstr ""
+msgstr "bitrshift() — décalage binaire à droite"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:440
 msgid "bitxor() - Bitwise exclusive OR"
-msgstr ""
+msgstr "bitxor() — OU exclusif binaire"
 
 #: app/views/administration.trigdisplay.edit.php:48
 #: app/views/administration.trigdisplay.edit.php:60
@@ -19967,11 +19942,11 @@ msgstr "clignotant"
 
 #: include/classes/api/services/CItemGeneral.php:488
 msgid "both username and password should be either present or empty"
-msgstr "le nom d'utilisateur et le mot de passe doivent être présents ou vides"
+msgstr "le nom d’utilisateur et le mot de passe doivent être présents ou vides"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:453
 msgid "bytelength() - Returns the length in bytes"
-msgstr ""
+msgstr "bytelength() — retourne la longueur en octets"
 
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:120
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:135
@@ -19982,11 +19957,11 @@ msgstr "calculé"
 
 #: app/views/administration.geomaps.edit.php:52
 msgid "can be used to add \"@2x\" to the URL to load retina tiles."
-msgstr ""
+msgstr "peut être utilisé pour ajouter « @2x » à l’URL afin de charger les tuiles haute résolution."
 
 #: include/classes/api/services/CItemGeneral.php:229
 msgid "cannot be changed"
-msgstr "ne peut pas être changé"
+msgstr "ne peut être modifié"
 
 #: app/controllers/CControllerAuthenticationUpdate.php:143
 #: app/controllers/CControllerAuthenticationUpdate.php:215
@@ -20101,41 +20076,41 @@ msgstr "impossible de mettre à jour la propriété pour la règle de découvert
 
 #: app/controllers/CControllerPopupTriggerExpr.php:460
 msgid "cbrt() - Cube root"
-msgstr ""
+msgstr "cbrt() — racine cubique"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:467
 msgid "ceil() - Rounds up to the nearest greater integer"
-msgstr ""
+msgstr "ceil() — arrondit la valeur au nombre entier supérieur"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:474
 msgid "change() - Difference between last and previous value"
-msgstr "change () - Différence entre valeur précédente et précédente"
+msgstr "change () — Différence entre la dernière valeur et la précédente"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:480
 msgid "changecount() - Number of changes between adjacent values, Mode (all - all changes, inc - only increases, dec - only decreases)"
-msgstr ""
+msgstr "changecount() — nombre de changements entre les valeurs adjacentes, mode (all — tous les changements, inc — croissants uniquement, dec — décroissants uniquement)"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:487
 msgid "char() - Returns the character which represents the given ASCII code"
-msgstr ""
+msgstr "char() — retourne le caractère correspondant au code ASCII donné"
 
 #: include/classes/parsers/CConditionFormula.php:219
 #, c-format
 msgid "check expression starting from \"%1$s\""
-msgstr "vérifiez l'expression à partir de \"%1$s\""
+msgstr "vérifiez l’expression à partir de « %1$s »"
 
 #: include/classes/widgets/fields/CWidgetFieldNavTree.php:125
 msgid "circular dependency is not allowed"
-msgstr ""
+msgstr "les dépendances circulaires ne sont pas autorisées"
 
 #: include/classes/api/services/CItemGeneral.php:2270
 #: include/classes/import/CConfigurationImport.php:2843
 msgid "circular item dependency is not allowed"
-msgstr "la dépendance d'élément circulaire n'est pas autorisée"
+msgstr "la dépendance d’élément circulaire n’est pas autorisée"
 
 #: jsLoader.php:302
 msgid "color"
-msgstr ""
+msgstr "couleur"
 
 #: app/partials/monitoring.problem.filter.php:236
 #: include/classes/widgets/views/widget.problems.form.view.php:94
@@ -20144,7 +20119,7 @@ msgstr "liste séparée par des virgules"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:494
 msgid "concat() - Returns a string that is the result of concatenating value to string"
-msgstr ""
+msgstr "concat(chaine1, chaine2) — retourne une chaîne de caractères résultant de la concaténation des chaînes chaine1 et chaine2"
 
 #: app/partials/hostmacros.inherited.list.html.php:39
 msgid "configure"
@@ -20159,27 +20134,27 @@ msgstr "contient"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:507
 msgid "cos() - The cosine of a value, where the value is an angle expressed in radians"
-msgstr ""
+msgstr "cos() — le cosinus d’un angle exprimé en radians"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:514
 msgid "cosh() - The hyperbolic cosine of a value"
-msgstr ""
+msgstr "cosh() — le cosinus hyperbolique d’une valeur"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:521
 msgid "cot() - The cotangent of a value, where the value is an angle expressed in radians"
-msgstr ""
+msgstr "cot() — la cotangente d’une valeur"
 
 #: include/graphs.inc.php:82
 msgid "count"
-msgstr ""
+msgstr "total"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:528
 msgid "count() - Number of successfully retrieved values V (which fulfill operator O) for period T"
-msgstr "count () - Nombre de valeurs récupérées avec succès V (qui remplissent l'opérateur O) pour la période T"
+msgstr "count () — nombre de valeurs récupérées avec succès V (qui remplissent l’opérateur O) pour la période T"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:535
 msgid "countunique() - The number of unique values"
-msgstr ""
+msgstr "countunique() — le nombre de valeurs uniques"
 
 #: include/func.inc.php:579 jsLoader.php:221
 msgctxt "day short"
@@ -20192,15 +20167,15 @@ msgstr "d M"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:542
 msgid "date() - Current date"
-msgstr "date () - Date actuelle"
+msgstr "date () — Date actuelle"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:548
 msgid "dayofmonth() - Day of month"
-msgstr "dayofmonth () - Jour du mois"
+msgstr "dayofmonth () — Jour du mois"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:554
 msgid "dayofweek() - Day of week"
-msgstr "dayofweek () - Jour de la semaine"
+msgstr "dayofweek () — Jour de la semaine"
 
 #: app/partials/monitoring.problem.filter.php:124
 #: app/views/administration.token.list.php:71
@@ -20218,7 +20193,7 @@ msgstr "défaut"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:560
 msgid "degrees() - Converts a value from radians to degrees"
-msgstr ""
+msgstr "degrees() — Convertit en degrés une valeur exprimée en radians"
 
 #: include/classes/widgets/forms/CWidgetFormActionLog.php:31
 #: include/classes/widgets/forms/CWidgetFormActionLog.php:33
@@ -20242,11 +20217,11 @@ msgstr "décroissant"
 #: include/views/js/common.template.edit.js.php:66
 #: include/views/js/common.template.edit.js.php:88
 msgid "description"
-msgstr ""
+msgstr "description"
 
 #: include/classes/validators/CApiInputValidator.php:1686
 msgid "directory cannot be empty"
-msgstr ""
+msgstr "le répertoire ne peut être vide"
 
 #: include/events.inc.php:61
 msgid "discovered host"
@@ -20263,7 +20238,7 @@ msgstr "découverte"
 #: include/classes/api/services/CTask.php:452
 #, c-format
 msgid "discovery rule \"%1$s\" on host \"%2$s\" is not monitored"
-msgstr ""
+msgstr "la règle de découverte « %1$s » sur l’hôte « %2$s » n’est pas supervisée"
 
 #: app/views/popup.lldoperation.php:67 include/actions.inc.php:27
 #: include/classes/helpers/CCorrelationHelper.php:37
@@ -20275,14 +20250,14 @@ msgstr "ne contient pas"
 #: include/classes/helpers/CCorrelationHelper.php:35
 #: include/views/js/configuration.host.discovery.edit.overr.js.php:170
 msgid "does not equal"
-msgstr "n'est pas égal"
+msgstr "n’est pas égal"
 
 #: app/views/popup.lldoverride.php:120
 #: include/views/configuration.host.discovery.edit.php:762
 #: include/views/js/configuration.host.discovery.edit.js.php:58
 #: include/views/js/configuration.host.discovery.edit.overr.js.php:83
 msgid "does not exist"
-msgstr ""
+msgstr "n’existe pas"
 
 #: app/views/popup.lldoperation.php:69 app/views/popup.lldoverride.php:118
 #: include/actions.inc.php:35
@@ -20295,11 +20270,10 @@ msgstr "ne correspond pas"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:567
 msgid "e() - Returns Euler's number"
-msgstr ""
+msgstr "e() — retourne le nombre d’Euler"
 
 #: app/views/popup.lldoperation.php:64 app/views/popup.valuemap.edit.php:78
-#: include/actions.inc.php:24
-#: include/classes/helpers/CCorrelationHelper.php:34
+#: include/actions.inc.php:24 include/classes/helpers/CCorrelationHelper.php:34
 #: include/views/inventory.host.list.php:70
 #: include/views/js/configuration.host.discovery.edit.overr.js.php:169
 msgid "equals"
@@ -20307,26 +20281,26 @@ msgstr "égal"
 
 #: include/views/js/item.preprocessing.js.php:426
 msgid "error message"
-msgstr "message d'erreur"
+msgstr "message d’erreur"
 
 #: app/views/popup.lldoverride.php:119
 #: include/views/configuration.host.discovery.edit.php:761
 #: include/views/js/configuration.host.discovery.edit.js.php:57
 #: include/views/js/configuration.host.discovery.edit.overr.js.php:82
 msgid "exists"
-msgstr ""
+msgstr "existe"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:572
 msgid "exp() - Euler's number at a power of a value"
-msgstr ""
+msgstr "exp() — retourne l’exponentielle d’un nombre"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:579
 msgid "expm1() - Euler's number at a power of a value minus 1"
-msgstr ""
+msgstr "expm1() — retourne l’exponentielle d’un nombre moins 1"
 
 #: include/classes/parsers/CConditionFormula.php:214
 msgid "expression is empty"
-msgstr "l'expression est vide"
+msgstr "l’expression est vide"
 
 #: include/classes/helpers/CElasticsearchHelper.php:185
 msgid "failed to parse JSON"
@@ -20334,11 +20308,11 @@ msgstr "impossible de parcourir le JSON"
 
 #: include/classes/validators/CApiInputValidator.php:2741
 msgid "file format is unsupported"
-msgstr ""
+msgstr "le format de fichier n’est pas pris en charge"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:586
 msgid "find() - Check occurrence of pattern V (which fulfill operator O) for period T (1 - match, 0 - no match)"
-msgstr ""
+msgstr "find (/hôte/clef,<(sec|#nb)<:décalage temporel>>,<opérateur>,<motif>) — vérifie l’occurrence du motif (satisfaisant l’opérateur) pour la période donnée (1 — positif, 0 — négatif)"
 
 #: app/views/popup.maintenance.period.php:124 include/graphs.inc.php:86
 #: include/maintenances.inc.php:105
@@ -20352,27 +20326,27 @@ msgstr "le premier paramètre est nécessaire"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:593
 msgid "first() - The oldest value in the specified time interval"
-msgstr ""
+msgstr "first() — valeur la plus ancienne de l’intervalle de temps spécifié"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:600
 msgid "floor() - Rounds down to the nearest smaller integer"
-msgstr ""
+msgstr "floor() — arrondit la valeur au nombre entier inférieur"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:607
 msgid "forecast() - Forecast for next t seconds based on period T"
-msgstr "forecast () - Prévisions pour les prochaines t secondes sur la base de la période T"
+msgstr "forecast () — Prévisions pour les prochaines t secondes sur la base de la période T"
 
 #: app/views/popup.maintenance.period.php:127 include/maintenances.inc.php:108
 msgid "fourth"
-msgstr "Quatrième"
+msgstr "quatrième"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:614
 msgid "fuzzytime() - Difference between item value (as timestamp) and Zabbix server timestamp is less than or equal to T seconds (1 - true, 0 - false)"
-msgstr "fuzzytime() - La différence entre la valeur de l'horodatage de l'élément et l'horodatage du serveur Zabbix est inférieure ou égale à T secondes (1 - vrai, 0 - faux)"
+msgstr "fuzzytime() — La différence entre la valeur de l’horodatage de l’élément et l’horodatage du serveur Zabbix est inférieure ou égale à T secondes (1 — vrai, 0 — faux)"
 
 #: include/classes/validators/CApiInputValidator.php:2807
 msgid "geographical coordinates (values of comma separated latitude and longitude) are expected"
-msgstr ""
+msgstr "des coordonnées géographiques (valeurs de latitude et longitude séparées par une virgule) sont attendues"
 
 #: include/views/configuration.item.edit.php:803
 #: include/views/configuration.item.edit.php:808
@@ -20384,7 +20358,7 @@ msgstr "paramètres de nettoyage globaux"
 
 #: app/views/monitoring.charts.view.php:140
 msgid "graph pattern"
-msgstr ""
+msgstr "motif graphique"
 
 #: include/func.inc.php:580 jsLoader.php:222
 msgctxt "hour short"
@@ -20409,13 +20383,13 @@ msgstr "hôte"
 #: include/classes/api/services/CMap.php:849
 #: include/classes/api/services/CMap.php:1317
 msgid "host group"
-msgstr "groupe d'hôte"
+msgstr "groupe de l’hôte"
 
 #: include/classes/widgets/CWidgetHelper.php:643
 #: include/classes/widgets/CWidgetHelper.php:1003
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:332
 msgid "host pattern"
-msgstr "modèle d'hôte"
+msgstr "modèle d’hôte"
 
 #: include/classes/api/services/CMap.php:844
 #: include/classes/api/services/CMap.php:1311
@@ -20430,7 +20404,7 @@ msgstr "image"
 #: include/classes/validators/CApiInputValidator.php:2735
 #, c-format
 msgid "image size must be less than %1$s"
-msgstr ""
+msgstr "la taille de l’image doit être inférieure à %1$s"
 
 #: include/actions.inc.php:28
 msgid "in"
@@ -20438,49 +20412,49 @@ msgstr "dans"
 
 #: app/views/popup.valuemap.edit.php:81
 msgid "in range"
-msgstr ""
+msgstr "dans l’intervalle"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:621
 msgid "in() - Checks if a value equals to one of the listed values (1 - equals, 0 - otherwise)"
-msgstr ""
+msgstr "in() — vérifie la présence d’une valeur parmi une liste (1 — positif, 0 — négatif)"
 
 #: app/partials/administration.usergroup.grouprights.html.php:61
 #: app/views/administration.user.edit.php:436
 msgid "including subgroups"
-msgstr "sous-groupes inclus"
+msgstr "sous‐groupes inclus"
 
 #: include/classes/parsers/C10TriggerExpression.php:525
 msgid "incorrect calculated item formula"
-msgstr ""
+msgstr "formule d’élément calculé incorrecte"
 
 #: include/classes/parsers/C10TriggerExpression.php:541
 #, c-format
 msgid "incorrect calculated item formula starting from \"%1$s\""
-msgstr ""
+msgstr "formule d’élément calculé incorrecte à partie de « %1$s »"
 
 #: include/classes/validators/CEventCorrCondValidator.php:47
 msgid "incorrect condition type"
-msgstr ""
+msgstr "type de condition incorrect"
 
 #: include/classes/api/services/CMapElement.php:169
 msgid "incorrect element count"
-msgstr "compte d'éléments incorrect"
+msgstr "compte d’éléments incorrect"
 
 #: include/classes/parsers/CExpressionParser.php:132
 #: include/classes/parsers/CExpressionParser.php:140
 #, c-format
 msgid "incorrect expression starting from \"%1$s\""
-msgstr ""
+msgstr "expression incorrecte à partir de « %1$s »"
 
 #: include/classes/api/services/CAction.php:2705
 #: include/classes/api/services/CCorrelation.php:723
 msgid "incorrect number of conditions"
-msgstr ""
+msgstr "nombre de conditions incorrect"
 
 #: include/classes/parsers/CParser.php:118
 #, c-format
 msgid "incorrect syntax near \"%1$s\""
-msgstr "syntaxe incorrecte à proximité de \"%1$s\""
+msgstr "syntaxe incorrecte à proximité de « %1$s »"
 
 #: include/classes/validators/CExpressionValidator.php:140
 #: include/classes/validators/CExpressionValidator.php:156
@@ -20488,11 +20462,11 @@ msgstr "syntaxe incorrecte à proximité de \"%1$s\""
 #: include/classes/validators/CExpressionValidator.php:197
 #, c-format
 msgid "incorrect usage of function \"%1$s\""
-msgstr ""
+msgstr "utilisation incorrecte de la fonction « %1$s »"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:634
 msgid "insert() - Inserts specified characters or spaces into a character string, beginning at a specified position in the string"
-msgstr ""
+msgstr "insert(chaine1, p, n, insert) — insère les n premiers caractères de la chaîne insert dans la chaîne chaine1, à partir de la position p"
 
 #: include/events.inc.php:37
 msgctxt "event source"
@@ -20511,11 +20485,11 @@ msgstr "motif Prometheus invalide"
 #: include/classes/parsers/CIPRangeParser.php:135
 #, c-format
 msgid "invalid address range \"%1$s\""
-msgstr "plage d'adresses \"%1$s\" invalide"
+msgstr "plage d’adresses « %1$s » invalide"
 
 #: include/classes/validators/CApiInputValidator.php:350
 msgid "invalid byte sequence in UTF-8"
-msgstr "séquence d'octets invalide en UTF-8"
+msgstr "séquence d’octets invalide en UTF-8"
 
 #: include/classes/graphdraw/CLineGraphDraw.php:115 include/items.inc.php:2078
 msgid "invalid delay"
@@ -20524,68 +20498,68 @@ msgstr "délai invalide"
 #: include/classes/validators/CHistFunctionValidator.php:67
 #, c-format
 msgid "invalid fifth parameter in function \"%1$s\""
-msgstr ""
+msgstr "cinquième paramètre incorrect dans la fonction « %1$s »"
 
 #: include/classes/validators/CHistFunctionValidator.php:63
 #, c-format
 msgid "invalid first parameter in function \"%1$s\""
-msgstr ""
+msgstr "premier paramètre incorrect dans la fonction « %1$s »"
 
 #: include/classes/validators/CHistFunctionValidator.php:66
 #, c-format
 msgid "invalid fourth parameter in function \"%1$s\""
-msgstr ""
+msgstr "quatrième paramètre incorrect dans la fonction « %1$s »"
 
 #: include/classes/graphdraw/CLineGraphDraw.php:241
 #: include/classes/graphdraw/CPieGraphDraw.php:168
 #: include/classes/helpers/CSvgGraphHelper.php:373
 msgid "invalid history storage period"
-msgstr "période de stockage de l'historique invalide"
+msgstr "période de stockage de l’historique invalide"
 
 #: include/classes/validators/CApiInputValidator.php:1506
 msgid "invalid host group name"
-msgstr "nom de groupe d'hôte non valide"
+msgstr "nom de groupe d’hôte non valide"
 
 #: include/classes/validators/CApiInputValidator.php:1550
 msgid "invalid host name"
-msgstr "nom d'hôte invalide"
+msgstr "nom d’hôte invalide"
 
 #: include/classes/validators/CHistFunctionValidator.php:82
 #: include/classes/validators/CMathFunctionValidator.php:86
 #, c-format
 msgid "invalid number of parameters in function \"%1$s\""
-msgstr ""
+msgstr "nombre de paramètres incorrect dans la fonction « %1$s »"
 
 #: app/controllers/CControllerPopupValueMapUpdate.php:117
 #: include/classes/validators/CApiInputValidator.php:1031
 #: include/classes/validators/CApiInputValidator.php:2569
 msgid "invalid range expression"
-msgstr ""
+msgstr "expression de plage incorrecte"
 
 #: app/controllers/CControllerPopupValueMapUpdate.php:105
 #: include/classes/validators/CApiInputValidator.php:1851
 msgid "invalid regular expression"
-msgstr "expression régulière invalide"
+msgstr "expression rationnelle invalide"
 
 #: include/classes/validators/CHistFunctionValidator.php:64
 #, c-format
 msgid "invalid second parameter in function \"%1$s\""
-msgstr ""
+msgstr "deuxième paramètre incorrect dans la fonction « %1$s »"
 
 #: include/classes/validators/CHistFunctionValidator.php:69
 #, c-format
 msgid "invalid seventh parameter in function \"%1$s\""
-msgstr ""
+msgstr "septième paramètre incorrect dans la fonction « %1$s »"
 
 #: include/classes/validators/CHistFunctionValidator.php:68
 #, c-format
 msgid "invalid sixth parameter in function \"%1$s\""
-msgstr ""
+msgstr "sixième paramètre incorrect dans la fonction « %1$s »"
 
 #: include/classes/validators/CHistFunctionValidator.php:65
 #, c-format
 msgid "invalid third parameter in function \"%1$s\""
-msgstr ""
+msgstr "troisième paramètre incorrect dans la fonction « %1$s »"
 
 #: include/classes/graphdraw/CLineGraphDraw.php:251
 #: include/classes/graphdraw/CPieGraphDraw.php:178
@@ -20603,7 +20577,7 @@ msgstr "est inférieur ou égal à"
 
 #: include/classes/validators/CApiInputValidator.php:2139
 msgid "is not enclosed in {} or is malformed"
-msgstr "n'est pas entouré de {} ou est malformé"
+msgstr "n’est pas entouré de {} ou est malformé"
 
 #: include/events.inc.php:64
 msgid "item"
@@ -20612,20 +20586,20 @@ msgstr "élément"
 #: include/classes/api/services/CTask.php:453
 #, c-format
 msgid "item \"%1$s\" on host \"%2$s\" is not monitored"
-msgstr ""
+msgstr "l’élément « %1$s » sur l’hôte « %2$s » n’est pas supervisé"
 
 #: include/classes/widgets/CWidgetHelper.php:663
 #: include/classes/widgets/CWidgetHelper.php:1020
 msgid "item pattern"
-msgstr "modèle d'article"
+msgstr "modèle d’article"
 
 #: include/classes/parsers/CItemKey.php:54
 msgid "key is empty"
-msgstr "la clé est vide"
+msgstr "la clef est vide"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:657
 msgid "kurtosis() - Measures the \"tailedness\" of the probability distribution"
-msgstr ""
+msgstr "kurtosis() — coefficient d’aplatissement « kurtosis »"
 
 #: include/classes/graphdraw/CLineGraphDraw.php:1377
 #: include/classes/graphdraw/CPieGraphDraw.php:296 include/graphs.inc.php:88
@@ -20641,7 +20615,7 @@ msgstr "dernier"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:664
 msgid "last() - Last (most recent) T value"
-msgstr "last () - Dernière valeur T la plus récente"
+msgstr "last () — Dernière valeur T la plus récente"
 
 #: include/classes/graphdraw/CLineGraphDraw.php:1516
 msgid "left"
@@ -20649,11 +20623,11 @@ msgstr "gauche"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:671
 msgid "left() - Returns the leftmost count characters"
-msgstr ""
+msgstr "left(chaine, n) — retourne les n caractères les plus à gauche de la chaîne"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:684
 msgid "length() - Length of last (most recent) T value in characters"
-msgstr ""
+msgstr "length() — longueur de la dernière valeur T (la plus récente) en caractères"
 
 #: include/forms.inc.php:1282 include/views/js/item.preprocessing.js.php:134
 msgid "list of characters"
@@ -20661,23 +20635,23 @@ msgstr "liste de caractères"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:690
 msgid "log() - Natural logarithm"
-msgstr ""
+msgstr "log() — logarithme népérien"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:697
 msgid "log10() - Decimal logarithm"
-msgstr ""
+msgstr "log10() — logarithme décimal"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:704
 msgid "logeventid() - Event ID of last log entry matching regular expression V for period T (1 - match, 0 - no match)"
-msgstr ""
+msgstr "logeventid(/host/key,<période<:décalage de temps>>,<regexp>) — vérifie qu’un identifiant d’événement du journal correspond à une expression rationnelle durant la période donnée (1 — positif, 0 — négatif)"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:711
 msgid "logseverity() - Log severity of the last log entry for period T"
-msgstr ""
+msgstr "logseverity() — gravité de la dernière entrée du journal pour la période considérée"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:718
 msgid "logsource() - Log source of the last log entry matching parameter V for period T (1 - match, 0 - no match)"
-msgstr ""
+msgstr "logsource() — vérifie si la source de la dernière entrée de journal correspond à l’expression rationnelle pour la période considérée (1 — positif, 0 — aucune correspondance)"
 
 #: include/events.inc.php:65
 msgid "low-level discovery rule"
@@ -20685,7 +20659,7 @@ msgstr "règle de découverte bas niveau"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:725
 msgid "ltrim() - Remove specified characters from the beginning of a string"
-msgstr ""
+msgstr "ltrim(chaine, <caracteres>) — supprime les caractères spécifiés (ou sinon les espaces) au début de la chaîne chaine"
 
 #: include/func.inc.php:581 jsLoader.php:124 jsLoader.php:223 jsLoader.php:399
 msgctxt "minute short"
@@ -20717,12 +20691,12 @@ msgstr "macro(s)"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:738
 msgid "mad() - Median absolute deviation"
-msgstr ""
+msgstr "mad() — écart absolu médian"
 
 #: include/classes/validators/CHistFunctionValidator.php:93
 #, c-format
 msgid "mandatory parameter is missing in function \"%1$s\""
-msgstr ""
+msgstr "il manque un paramètre obligatoire à la fonction « %1$s »"
 
 #: include/classes/api/services/CMap.php:861
 #: include/classes/api/services/CMap.php:1329
@@ -20753,15 +20727,15 @@ msgstr "max"
 
 #: include/classes/api/services/CSettings.php:288
 msgid "max period is less than time filter default period"
-msgstr ""
+msgstr "la période maximale est inférieure à la période par défaut du filtre"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:745
 msgid "max() - Maximum value for period T"
-msgstr "max () - Valeur maximale pour la période T"
+msgstr "max () — Valeur maximale pour la période T"
 
 #: include/classes/api/services/CItemGeneral.php:2364
 msgid "maximum dependent items count reached"
-msgstr "nombre maximal d'éléments dépendants atteint"
+msgstr "nombre maximal d’éléments dépendants atteint"
 
 #: include/classes/api/services/CItemGeneral.php:2350
 #: include/classes/import/CConfigurationImport.php:2791
@@ -20771,7 +20745,7 @@ msgstr "nombre maximal de niveaux de dépendance atteint"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:752
 msgid "mid() - Returns a substring beginning at the character position specified by start for N characters"
-msgstr ""
+msgstr "mid(chaine, p, l) — retourne une sous‐chaîne de l caractères à partir de la position p"
 
 #: include/classes/api/services/CItemGeneral.php:1399
 #: include/classes/graphdraw/CLineGraphDraw.php:1378
@@ -20788,7 +20762,7 @@ msgstr "min"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:770
 msgid "min() - Minimum value for period T"
-msgstr "min () - Valeur minimale pour la période T"
+msgstr "min () — Valeur minimale pour la période T"
 
 #: include/classes/api/services/CHost.php:1804
 #: include/classes/validators/CApiInputValidator.php:1309
@@ -20803,15 +20777,15 @@ msgstr "mm"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:777
 msgid "mod() - Division remainder"
-msgstr ""
+msgstr "mod(dividende, diviseur) — reste de la division entière de dividende par diviseur"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:790
 msgid "monodec() - Check for continuous item value decrease (1 - data is monotonic, 0 - otherwise), Mode (strict - require strict monotonicity)"
-msgstr ""
+msgstr "monodec() — vérifie la décroissance continue des valeurs (1 — la décroissance est monotone, 0 — non monotone), mode (strict — requiert une monotonie stricte)"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:797
 msgid "monoinc() - Check for continuous item value increase (1 - data is monotonic, 0 - otherwise), Mode (strict - require strict monotonicity)"
-msgstr ""
+msgstr "monoinc() — vérifie la croissance continue des valeurs (1 — la croissance est monotone, 0 — non monotone), mode (strict — requiert une monotonie stricte)"
 
 #: include/func.inc.php:583
 msgctxt "millisecond short"
@@ -20822,7 +20796,7 @@ msgstr "ms"
 #: include/classes/validators/CApiInputValidator.php:2672
 #, c-format
 msgid "must be %1$s characters long"
-msgstr ""
+msgstr "doit être composé de %1$s caractères"
 
 #: app/views/administration.authentication.edit.php:199
 msgid "must be a valid LDAP user"
@@ -20832,13 +20806,13 @@ msgstr "doit être un utilisateur LDAP correct"
 #: include/classes/validators/CPasswordComplexityValidator.php:74
 #, c-format
 msgid "must be at least %1$d characters long"
-msgstr ""
+msgstr "doit être composé d’au moins %1$d caractères"
 
 #: app/views/administration.authentication.edit.php:55
 #: app/views/administration.user.edit.php:132
 #: include/classes/validators/CPasswordComplexityValidator.php:88
 msgid "must contain at least one digit"
-msgstr ""
+msgstr "doit être composé d’au moins un chiffre"
 
 #: include/classes/validators/CApiInputValidator.php:1513
 #: include/classes/validators/CApiInputValidator.php:1557
@@ -20849,33 +20823,33 @@ msgstr "doit contenir au moins une macro de découverte de bas niveau"
 #: app/views/administration.user.edit.php:124
 #: include/classes/validators/CPasswordComplexityValidator.php:81
 msgid "must contain at least one lowercase and one uppercase Latin letter"
-msgstr ""
+msgstr "doit être composé d’au moins un caractère latin en minuscule et un en majuscule"
 
 #: app/views/administration.authentication.edit.php:59
 #: app/views/administration.user.edit.php:139
 #: include/classes/validators/CPasswordComplexityValidator.php:95
 msgid "must contain at least one special character"
-msgstr ""
+msgstr "doit être composé d’au moins un caractère non alphanumérique"
 
 #: app/views/administration.authentication.edit.php:98
 #: app/views/administration.user.edit.php:146
 #: include/classes/validators/CPasswordComplexityValidator.php:108
 msgid "must not be one of common or context-specific passwords"
-msgstr ""
+msgstr "ne doit être un nom commun ou spécifique au contexte"
 
 #: app/views/administration.authentication.edit.php:97
 #: app/views/administration.user.edit.php:145
 #: include/classes/validators/CPasswordComplexityValidator.php:102
 msgid "must not contain user's name, surname or username"
-msgstr ""
+msgstr "ne doit pas être contenir le nom, le prénom ou le nom d’utilisateur"
 
 #: include/translateDefines.inc.php:38
 msgid "n-d"
-msgstr ""
+msgstr "d/m"
 
 #: include/translateDefines.inc.php:36
 msgid "n-d H:i"
-msgstr ""
+msgstr "d/m H:i"
 
 #: include/views/configuration.host.discovery.edit.php:190
 #: include/views/configuration.host.discovery.edit.php:334
@@ -20903,31 +20877,31 @@ msgstr "pas de donnée"
 
 #: include/classes/api/services/CEvent.php:773
 msgid "no permissions to acknowledge problems"
-msgstr ""
+msgstr "aucune permission d’accuser réception des problèmes"
 
 #: include/classes/api/services/CEvent.php:762
 msgid "no permissions to add problem comments"
-msgstr ""
+msgstr "aucune permission d’ajouter des commentaires aux problèmes"
 
 #: include/classes/api/services/CEvent.php:767
 msgid "no permissions to change problem severity"
-msgstr ""
+msgstr "aucune permission de changer la gravité des problèmes"
 
 #: include/classes/api/services/CEvent.php:757
 msgid "no permissions to close problems"
-msgstr ""
+msgstr "aucune permission de clore les problèmes"
 
 #: include/classes/api/services/CConfiguration.php:168
 msgid "no permissions to create and edit maps"
-msgstr ""
+msgstr "aucune permission de créer et modifier des cartes"
 
 #: include/classes/api/services/CEvent.php:774
 msgid "no permissions to unacknowledge problems"
-msgstr ""
+msgstr "aucune permission d’ignorer des problèmes"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:804
 msgid "nodata() - No data received during period of time T (1 - true, 0 - false), Mode (strict - ignore proxy time delay in sending data)"
-msgstr ""
+msgstr "nodata() — détermine si aucune donnée n’a été reçue durant la période de temps considérée (1 — vrai, 0 — faux), mode (strict — ignore le délai d’envoi des données par le proxy)"
 
 #: include/classes/widgets/CWidgetHelper.php:1131 include/graphs.inc.php:74
 msgid "none"
@@ -20936,7 +20910,7 @@ msgstr "aucun"
 #: include/classes/api/services/CItemGeneral.php:2549
 #: include/classes/api/services/CItemGeneral.php:2571
 msgid "nonempty key and value pair expected"
-msgstr "clé et paire de valeurs non vide attendues"
+msgstr "clef et paire de valeurs non vide attendues"
 
 #: include/actions.inc.php:31
 msgid "not in"
@@ -20948,7 +20922,7 @@ msgstr "non sélectionné"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:811
 msgid "now() - Number of seconds since the Epoch"
-msgstr "now () - Nombre de secondes écoulées depuis le temps Epoch"
+msgstr "now () — Nombre de secondes écoulées depuis le temps Epoch"
 
 #: include/forms.inc.php:1274 include/views/js/item.preprocessing.js.php:126
 msgid "number"
@@ -21008,7 +20982,7 @@ msgstr "une seule unité de temps est autorisée"
 
 #: include/views/general.login.php:41
 msgid "or"
-msgstr ""
+msgstr "ou"
 
 #: include/views/configuration.httpconf.edit.php:88
 msgid "other"
@@ -21020,11 +20994,11 @@ msgstr "sortie"
 
 #: include/classes/setup/CSetupWizard.php:510
 msgid "path/to/secret"
-msgstr ""
+msgstr "chemin/vers/secret"
 
 #: include/classes/html/CMacroValue.php:139 jsLoader.php:410
 msgid "path/to/secret:key"
-msgstr ""
+msgstr "chemin/vers/secret:clef"
 
 #: app/views/popup.httpstep.php:173 app/views/popup.lldoperation.php:76
 #: include/forms.inc.php:1299 include/forms.inc.php:1313
@@ -21035,15 +21009,15 @@ msgstr "motif"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:817
 msgid "percentile() - Percentile P of a period T"
-msgstr "percentile () - Pourcentage P d'une période T"
+msgstr "percentile () — Pourcentage P d’une période T"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:824
 msgid "pi() - Returns the Pi constant"
-msgstr ""
+msgstr "pi() — retourne la valeur de π"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:829
 msgid "power() - The power of a base value to a power value"
-msgstr ""
+msgstr "power() — la valeur d’un nombre élevé à une puissance donnée"
 
 #: include/classes/widgets/forms/CWidgetFormSvgGraph.php:357
 msgid "problem pattern"
@@ -21051,40 +21025,40 @@ msgstr "modèle de problème"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:842
 msgid "radians() - Converts a value from degrees to radians"
-msgstr ""
+msgstr "radians() — convertit un angle de degrés en radians"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:849
 msgid "rand() - A random integer value"
-msgstr ""
+msgstr "rand() — retourne un entier au hasard"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:854
 msgid "rate() - Returns per-second average rate for monotonically increasing counters"
-msgstr ""
+msgstr "rate() — renvoie le taux moyen par seconde des compteurs à augmentation monotone"
 
 #: include/classes/api/services/CService.php:2565
 #, c-format
 msgid "read-write access to the child service \"%1$s\" is required"
-msgstr ""
+msgstr "l’accès en lecture‐écriture au service fils « %1$s » est nécessaire"
 
 #: include/classes/api/services/CService.php:489
 #, c-format
 msgid "read-write access to the child service \"%1$s\" must be retained"
-msgstr ""
+msgstr "l’accès en lecture‐écriture au service fils « %1$s » doit être conservé"
 
 #: include/classes/api/services/CService.php:476
 #: include/classes/api/services/CService.php:2482
 #: include/classes/api/services/CService.php:2542
 msgid "read-write access to the service is required"
-msgstr ""
+msgstr "l’accès en lecture‐écriture au service est nécessaire"
 
 #: include/classes/api/services/CService.php:2541
 #: include/classes/api/services/CService.php:2602
 msgid "read-write access to the service must be retained"
-msgstr ""
+msgstr "l’accès en lecture‐écriture au service doit être conservé"
 
 #: include/classes/widgets/fields/CWidgetFieldNavTree.php:110
 msgid "reference to a non-existent tree element"
-msgstr ""
+msgstr "référence à un élément d’arborescence inexistant"
 
 #: app/controllers/CControllerQueueDetails.php:112
 #: app/controllers/CControllerQueueOverview.php:82
@@ -21097,38 +21071,38 @@ msgstr "rafraîchi toutes les %1$s sec."
 #: app/views/js/popup.valuemap.edit.js.php:33
 #: app/views/popup.valuemap.edit.php:82
 msgid "regexp"
-msgstr ""
+msgstr "expression rationnelle"
 
 #: app/views/popup.lldoverride.php:150
 #: include/views/configuration.host.discovery.edit.php:790
 #: include/views/js/configuration.host.discovery.edit.js.php:64
 #: include/views/js/configuration.host.discovery.edit.overr.js.php:90
 msgid "regular expression"
-msgstr "expression régulière"
+msgstr "expression rationnelle"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:861
 msgid "repeat() - Returns a string composed of value repeated count times"
-msgstr ""
+msgstr "repeat(chaine, n) — retourne une chaîne de caractères composée de la chaîne « chaine » répétée n fois"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:874
 msgid "replace() - Search value for occurrences of pattern, and replace with replacement"
-msgstr ""
+msgstr "replace(chaine, motif, remplacement) — recherche les occurrences de la chaîne motif dans la première chaîne, et les remplace par la dernière"
 
 #: include/forms.inc.php:1376 include/views/js/item.preprocessing.js.php:224
 msgid "replacement"
-msgstr ""
+msgstr "remplacement"
 
 #: app/views/administration.geomaps.edit.php:48
 msgid "represent tile coordinates;"
-msgstr ""
+msgstr "représentent les coordonnées de la tuile ;"
 
 #: app/views/administration.geomaps.edit.php:40
 msgid "represents one of the available subdomains;"
-msgstr ""
+msgstr "représente un des sous‐domaines disponibles ;"
 
 #: app/views/administration.geomaps.edit.php:44
 msgid "represents zoom level parameter in the URL;"
-msgstr ""
+msgstr "représente le paramètre d’agrandissement dans l’URL ;"
 
 #: include/classes/graphdraw/CLineGraphDraw.php:1516
 msgid "right"
@@ -21136,15 +21110,15 @@ msgstr "droite"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:892
 msgid "right() - Returns the rightmost count characters"
-msgstr ""
+msgstr "right(chaine, n) — retourne les n caractères les plus à droite de la chaîne"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:905
 msgid "round() - Rounds a value to decimal places"
-msgstr ""
+msgstr "round(nombre, decimales) — arrondit un nombre à un certain nombre de décimales"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:918
 msgid "rtrim() - Removes specified characters from the end of a string"
-msgstr ""
+msgstr "rtrim(chaine, <caracteres>) — supprime les caractères spécifiés (ou sinon les espaces) à la fin de la chaîne chaine"
 
 #: include/func.inc.php:582
 msgctxt "second short"
@@ -21162,7 +21136,7 @@ msgstr "script"
 
 #: include/forms.inc.php:1375 include/views/js/item.preprocessing.js.php:223
 msgid "search string"
-msgstr ""
+msgstr "chaîne à rechercher"
 
 #: app/views/popup.maintenance.period.php:125 include/maintenances.inc.php:106
 msgctxt "adjective"
@@ -21184,7 +21158,7 @@ msgstr "sélectionné"
 
 #: include/events.inc.php:38 include/events.inc.php:66
 msgid "service"
-msgstr ""
+msgstr "service"
 
 #: app/views/popup.service.time.edit.php:127
 msgid "short description"
@@ -21223,63 +21197,63 @@ msgstr "doit être vide"
 
 #: app/controllers/CControllerPopupItemTestSend.php:197
 msgid "should be less than current time"
-msgstr "devrait être inférieur à l'heure actuelle"
+msgstr "devrait être inférieur à l’heure actuelle"
 
 #: include/views/monitoring.sysmap.edit.php:133
 msgid "show icon mappings"
-msgstr "afficher les correspondances d'icônes"
+msgstr "afficher les correspondances d’icônes"
 
 #: include/views/general.login.php:41
 msgid "sign in as guest"
-msgstr ""
+msgstr "s’identifier comme invité"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:931
 msgid "signum() - Returns -1 if a value is negative, 0 if a value is zero, 1 if a value is positive"
-msgstr ""
+msgstr "signum() — retourne -1 si la valeur est négative, 0 si elle est nulle et 1 si elle est positive"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:938
 msgid "sin() - The sine of a value, where the value is an angle expressed in radians"
-msgstr ""
+msgstr "sin() — le sinus d’un angle exprimé en radians"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:945
 msgid "sinh() - The hyperbolic sine of a value"
-msgstr ""
+msgstr "sinh() — le sinus hyperbolique d’une valeur"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:952
 msgid "skewness() - Measures the asymmetry of the probability distribution"
-msgstr ""
+msgstr "skewness() — mesure le coefficient d’asymétrie"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:959
 msgid "sqrt() - Square root of a value"
-msgstr ""
+msgstr "cbrt() — racine carré d’une valeur"
 
 #: app/partials/administration.ha.nodes.php:63
 msgid "standalone server"
-msgstr ""
+msgstr "serveur autonome"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:966
 msgid "stddevpop() - Population standard deviation"
-msgstr ""
+msgstr "stddevpop() — écart type de la population"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:973
 msgid "stddevsamp() - Sample standard deviation"
-msgstr ""
+msgstr "stddevsamp() — écart type de l’échantillon"
 
 #: include/graphs.inc.php:84
 msgid "sum"
-msgstr ""
+msgstr "somme"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:980
 msgid "sum() - Sum of values of a period T"
-msgstr "sum () - Somme des valeurs d'une période T"
+msgstr "sum () — Somme des valeurs d’une période T"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:987
 msgid "sumofsquares() - The sum of squares"
-msgstr ""
+msgstr "sumofsquares(/hôte/clef,(sec|#nb)<:durée>) — la somme des carrés des valeurs collectées durant la période considérée"
 
 #: include/classes/api/services/CUser.php:2047
 msgid "supplied credentials are not unique"
-msgstr "les informations d'identification fournies ne sont pas uniques"
+msgstr "les informations d’identification fournies ne sont pas uniques"
 
 #: app/partials/configuration.tags.tab.php:57
 #: app/partials/monitoring.host.filter.php:41
@@ -21303,16 +21277,16 @@ msgstr "tag"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:994
 msgid "tan() - The tangent of a value"
-msgstr ""
+msgstr "tan() — la tangente d’une valeur"
 
 #: include/classes/api/services/CHostBase.php:64
 #, c-format
 msgid "template ID \"%1$s\" is passed %2$s times"
-msgstr "ID du modèle \"%1$s\" passé %2$s fois"
+msgstr "l’identifiant du modèle « %1$s » est passé %2$s fois"
 
 #: include/classes/validators/CApiInputValidator.php:2774
 msgid "the last new line feed is missing"
-msgstr ""
+msgstr "le dernier saut de ligne est absent"
 
 #: app/controllers/CControllerDashboardUpdate.php:192
 #: app/controllers/CControllerDashboardUpdate.php:201
@@ -21345,14 +21319,14 @@ msgstr ""
 #: include/classes/validators/CApiInputValidator.php:1237
 #, c-format
 msgid "the parameter \"%1$s\" is missing"
-msgstr "le paramètre \"%1$s\" est manquant"
+msgstr "le paramètre « %1$s » est manquant"
 
 #: include/classes/db/MysqlDbBackend.php:36
 #: include/classes/db/OracleDbBackend.php:37
 #: include/classes/db/PostgresqlDbBackend.php:62
 #, c-format
 msgid "the table \"%1$s\" was not found"
-msgstr ""
+msgstr "la table « %1$s » est introuvable"
 
 #: include/classes/export/CConfigurationExportBuilder.php:87
 #: include/classes/import/validators/C44XmlValidator.php:1983
@@ -21364,7 +21338,7 @@ msgstr ""
 #: include/classes/import/validators/CXmlValidatorGeneral.php:202
 #, c-format
 msgid "the tag \"%1$s\" is missing"
-msgstr "le tag \"%1$s\" est manquante"
+msgstr "l’étiquette « %1$s » est manquante"
 
 #: app/views/popup.maintenance.period.php:126 include/maintenances.inc.php:107
 msgid "third"
@@ -21372,11 +21346,11 @@ msgstr "troisième"
 
 #: include/classes/api/services/CItemGeneral.php:1552
 msgid "third parameter is expected"
-msgstr ""
+msgstr "un troisième paramètre est attendu"
 
 #: include/classes/api/services/CSettings.php:284
 msgid "time filter default period exceeds the max period"
-msgstr ""
+msgstr "la période par défaut du filtre temporel dépasse la période maximale"
 
 #: jsLoader.php:303
 msgid "time shift"
@@ -21384,35 +21358,35 @@ msgstr "décalage horaire"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1001
 msgid "time() - Current time"
-msgstr "time () - Heure actuelle"
+msgstr "time () — Heure actuelle"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1007
 msgid "timeleft() - Time to reach threshold estimated based on period T"
-msgstr "timeleft () - Temps nécessaire pour atteindre le seuil estimé en fonction de la période T"
+msgstr "timeleft () — Temps nécessaire pour atteindre le seuil estimé en fonction de la période T"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1014
 msgid "trendavg() - Average value of a period T with exact period shift"
-msgstr ""
+msgstr "trendavg() — moyenne des valeurs de tendance sur la période considérée"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1021
 msgid "trendcount() - Number of successfully retrieved values for period T"
-msgstr ""
+msgstr "trendcount() — nombre de valeurs de tendance récupérées sur la période considérée"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1028
 msgid "trendmax() - Maximum value for period T with exact period shift"
-msgstr ""
+msgstr "trendmax() — valeur maximale des tendances sur la période considérée"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1035
 msgid "trendmin() - Minimum value for period T with exact period shift"
-msgstr ""
+msgstr "trendmin() — valeur minimale des tendances sur la période considérée"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1042
 msgid "trendstl() - Anomaly detection for period T"
-msgstr ""
+msgstr "trendstl() — détection d’anomalies durant la période donnée"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1085
 msgid "trendsum() - Sum of values of a period T with exact period shift"
-msgstr ""
+msgstr "trendsum() — somme des valeurs de tendance sur la période considérée"
 
 #: include/classes/api/services/CMap.php:857
 #: include/classes/api/services/CMap.php:1325 include/events.inc.php:34
@@ -21426,7 +21400,7 @@ msgstr "le déclencheur ne permet pas une fermeture manuelle"
 
 #: include/classes/validators/CExpressionValidator.php:116
 msgid "trigger expression must contain at least one /host/key reference"
-msgstr ""
+msgstr "l’expression de déclencheur doit contenir au moins une référence /hôte/clef"
 
 #: include/classes/api/services/CTriggerGeneral.php:1722
 msgid "trigger prototype cannot be moved to another template or host"
@@ -21438,11 +21412,11 @@ msgstr "un déclencheur avec liens ne peut pas être déplacé vers un autre mod
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1092
 msgid "trim() - Remove specified characters from the beginning and the end of a string"
-msgstr ""
+msgstr "trim(chaine, <caracteres>) — supprime les caractères spécifiés (ou sinon les espaces) au début et à la fin de la chaîne chaine"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1105
 msgid "truncate() - Truncates a value to decimal places"
-msgstr ""
+msgstr "truncate(valeur, n) — tronque la valeur à n décimales"
 
 #: app/partials/layout.htmlpage.aside.php:74
 #: include/classes/html/CMultiSelect.php:84 jsLoader.php:335
@@ -21451,7 +21425,7 @@ msgstr "taper ici pour rechercher"
 
 #: include/classes/validators/CApiInputValidator.php:2176
 msgid "unacceptable URL"
-msgstr ""
+msgstr "URL inacceptable"
 
 #: include/classes/import/validators/C44XmlValidator.php:2182
 #: include/classes/import/validators/C50XmlValidator.php:2332
@@ -21459,7 +21433,7 @@ msgstr ""
 #: include/classes/import/validators/CXmlValidatorGeneral.php:298
 #, c-format
 msgid "unexpected constant \"%1$s\""
-msgstr ""
+msgstr "valeur de constante « %1$s » inattendue"
 
 #: include/classes/export/CConfigurationExportBuilder.php:119
 #: include/classes/import/converters/CConstantImportConverter.php:60
@@ -21470,15 +21444,15 @@ msgstr ""
 #: include/classes/import/validators/C60XmlValidator.php:2511
 #, c-format
 msgid "unexpected constant value \"%1$s\""
-msgstr ""
+msgstr "constante « %1$s » inattendue"
 
 #: include/classes/parsers/CExpressionMacroParser.php:108
 msgid "unexpected end of expression macro"
-msgstr ""
+msgstr "fin d’expression de macro inattendue"
 
 #: include/classes/parsers/CItemKey.php:55
 msgid "unexpected end of key"
-msgstr "fin de clé inattendue"
+msgstr "fin de clef inattendue"
 
 #: include/classes/parsers/CUserMacroParser.php:38
 msgid "unexpected end of macro"
@@ -21505,20 +21479,20 @@ msgstr "fin de macro inattendue"
 #: include/classes/validators/CApiInputValidator.php:1196
 #, c-format
 msgid "unexpected parameter \"%1$s\""
-msgstr "paramètre inattendu \"%1$s\""
+msgstr "paramètre inattendu « %1$s »"
 
 #: include/classes/import/validators/CXmlValidatorGeneral.php:164
 #: include/classes/import/validators/CXmlValidatorGeneral.php:230
 #, c-format
 msgid "unexpected tag \"%1$s\""
-msgstr "tag \"%1$s\" inattendue"
+msgstr "étiquette « %1$s » inattendue"
 
 #: include/classes/import/readers/CXmlImportReader.php:78
 #: include/classes/import/readers/CXmlImportReader.php:117
 #: include/classes/import/readers/CXmlImportReader.php:135
 #, c-format
 msgid "unexpected text \"%1$s\""
-msgstr "texte \"%1$s\" inattendu"
+msgstr "texte « %1$s » inattendu"
 
 #: include/classes/api/services/CEvent.php:744
 #: include/classes/api/services/CEvent.php:878
@@ -21533,7 +21507,7 @@ msgstr "texte \"%1$s\" inattendu"
 #: include/classes/api/services/CTriggerGeneral.php:821
 #, c-format
 msgid "unexpected value \"%1$s\""
-msgstr "valeur \"%1$s\" inattendue"
+msgstr "valeur « %1$s » inattendue"
 
 #: include/classes/setup/CFrontendSetup.php:365
 #: include/classes/setup/CFrontendSetup.php:474
@@ -21544,19 +21518,19 @@ msgstr "inconnu"
 #: include/classes/validators/CMathFunctionValidator.php:55
 #, c-format
 msgid "unknown function \"%1$s\""
-msgstr ""
+msgstr "fonction « %1$s » inconnue"
 
 #: app/controllers/CControllerPopupItemTestSend.php:192
 msgid "unsupported time suffix"
-msgstr "suffixe de temps non supporté"
+msgstr "suffixe de temps non pris en charge"
 
 #: include/classes/import/validators/CXmlValidator.php:64
 msgid "unsupported version number"
-msgstr "numéro de version non supporté"
+msgstr "numéro de version non pris en charge"
 
 #: include/classes/validators/CApiInputValidator.php:498
 msgid "uppercase identifier expected"
-msgstr ""
+msgstr "identifiant attendu en majuscules"
 
 #: app/partials/configuration.tags.tab.php:67
 #: app/partials/monitoring.host.filter.php:57
@@ -21572,8 +21546,7 @@ msgstr ""
 #: app/views/js/popup.valuemap.edit.js.php:30
 #: app/views/js/popup.valuemap.edit.js.php:31
 #: app/views/js/popup.valuemap.edit.js.php:32
-#: app/views/popup.itemtestedit.view.php:83
-#: app/views/popup.service.edit.php:96
+#: app/views/popup.itemtestedit.view.php:83 app/views/popup.service.edit.php:96
 #: include/classes/helpers/CTagFilterFieldHelper.php:78
 #: include/classes/helpers/CTagFilterFieldHelper.php:131
 #: include/classes/html/CMacroValue.php:131
@@ -21600,7 +21573,7 @@ msgstr "valeur"
 #: include/classes/api/services/CDiscoveryRule.php:1886
 #, c-format
 msgid "value \"%1$s\" already exists"
-msgstr "la valeur \"%1$s\" existe déjà"
+msgstr "la valeur « %1$s » existe déjà"
 
 #: include/classes/import/CConfigurationImport.php:839
 #: include/classes/import/CConfigurationImport.php:876
@@ -21609,7 +21582,7 @@ msgstr "la valeur \"%1$s\" existe déjà"
 #: include/classes/import/CConfigurationImport.php:2852
 #, c-format
 msgid "value \"%1$s\" not found"
-msgstr "valeur \"%1$s\" non trouvée"
+msgstr "valeur « %1$s » non trouvée"
 
 #: app/controllers/CControllerPopupValueMapUpdate.php:71
 #: app/controllers/CControllerPopupValueMapUpdate.php:137
@@ -21662,35 +21635,35 @@ msgstr "la valeur est trop longue"
 #, c-format
 msgid "value must be %1$s"
 msgid_plural "value must be one of %1$s"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "la valeur doit être %1$s"
+msgstr[1] "la valeur doit être parmi %1$s"
 
 #: include/classes/validators/CActionCondValidator.php:171
 #: include/classes/validators/CApiInputValidator.php:2527
 #, c-format
 msgid "value must be between \"%1$s\" and \"%2$s\""
-msgstr ""
+msgstr "la valeur doit être comprise entre « %1$s » et « %2$s »"
 
 #: include/classes/validators/CApiInputValidator.php:578
 msgid "value must be empty"
-msgstr ""
+msgstr "la valeur doit être vide"
 
 #: include/classes/validators/CApiInputValidator.php:573
 #, c-format
 msgid "value must be empty or %1$s"
 msgid_plural "value must be empty or one of %1$s"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "la valeur doit être vide ou égale à %1$s"
+msgstr[1] "la valeur doit être vide ou parmi %1$s"
 
 #: include/classes/validators/CNewValidator.php:208
 #, c-format
 msgid "value must be no greater than \"%1$s\""
-msgstr ""
+msgstr "la valeur doit être inférieure ou égale à « %1$s »"
 
 #: include/classes/validators/CNewValidator.php:196
 #, c-format
 msgid "value must be no less than \"%1$s\""
-msgstr ""
+msgstr "la valeur doit être supérieure ou égale à « %1$s »"
 
 #: app/controllers/CControllerPopupHttpStep.php:101
 #: include/classes/api/services/CDiscoveryRule.php:1679
@@ -21715,37 +21688,37 @@ msgstr ""
 #: include/validate.inc.php:587
 #, c-format
 msgid "value must be one of %1$s"
-msgstr "la valeur doit être l'un de %1$s"
+msgstr "la valeur doit être l’un de %1$s"
 
 #: include/classes/validators/CApiInputValidator.php:936
 #, c-format
 msgid "value must be within the range of %1$s"
-msgstr ""
+msgstr "la valeur doit être comprise dans l’intervalle de %1$s"
 
 #: include/classes/api/services/CItemGeneral.php:1560
 msgid "value of first parameter is too long"
-msgstr ""
+msgstr "la valeur du premier paramètre est trop longue"
 
 #: include/classes/helpers/CCorrelationHelper.php:141
 msgid "value of new event tag"
-msgstr ""
+msgstr "valeur de la nouvelle étiquette d’événement"
 
 #: include/classes/api/services/CItemGeneral.php:1566
 msgid "value of second parameter is too long"
-msgstr ""
+msgstr "la valeur du deuxième paramètre est trop longue"
 
 #: include/classes/api/services/CItemGeneral.php:1577
 #, c-format
 msgid "value of third parameter must be one of %1$s"
-msgstr ""
+msgstr "la valeur du troisième paramètre doit être parmi %1$s"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1118
 msgid "varpop() - Population variance"
-msgstr ""
+msgstr "varpop() — variance de la population"
 
 #: app/controllers/CControllerPopupTriggerExpr.php:1125
 msgid "varsamp() - Sample variance"
-msgstr ""
+msgstr "varsamp() — variance de l’échantillon"
 
 #: include/actions.inc.php:605 include/actions.inc.php:623
 #: include/actions.inc.php:783 include/actions.inc.php:801
@@ -21758,7 +21731,7 @@ msgstr "mauvais type de règle de découverte"
 
 #: include/classes/api/services/CTask.php:444
 msgid "wrong item type"
-msgstr "mauvais type d'élément"
+msgstr "mauvais type d’élément"
 
 #: include/func.inc.php:577 jsLoader.php:219
 msgctxt "year short"
@@ -21768,4 +21741,4 @@ msgstr "a"
 #: include/classes/validators/CApiInputValidator.php:2815
 #, c-format
 msgid "zoom level must be between \"%1$s\" and \"%2$s\""
-msgstr ""
+msgstr "le niveau d’agrandissement doit être compris entre « %1$s » et « %2$s »"


### PR DESCRIPTION
This is a complete update of the French translation of Zabbix UI.
It contains fixes to fit the French orthotypographic rules:
- use French guillemets « and »;
- use a non-breaking space before a colon and a closing guillemet, and after a opening guillemet;
- use a thin space before semi-colon, question and exclamation marks.