### PR TITLE
Template Oracle ODBC: Fix tablespace USED_BYTES and USED_FILE_PCT calculation

### DIFF
--- a/templates/db/oracle_odbc/template_db_oracle_odbc.yaml
+++ b/templates/db/oracle_odbc/template_db_oracle_odbc.yaml
@@ -254,9 +254,9 @@ zabbix_export:
               NVL(SUM(Y.BYTES), 0) AS FILE_BYTES, 
               NVL(SUM(Y.MAX_BYTES), 0) AS MAX_BYTES, 
               NVL(MAX(NVL(Y.FREE_BYTES, 0)), 0) AS FREE,
-              SUM(Y.BYTES)-SUM(Y.FREE_BYTES) AS USED_BYTES,
+              SUM(Y.BYTES)-NVL(MAX(NVL(Y.FREE_BYTES, 0)), 0) AS USED_BYTES,
               ROUND(DECODE(SUM(Y.MAX_BYTES), 0, 0, (SUM(Y.BYTES) / SUM(Y.MAX_BYTES) * 100)), 2) AS USED_PCT_MAX, 
-              ROUND(DECODE(SUM(Y.BYTES), 0, 0,(SUM(Y.BYTES)-SUM(Y.FREE_BYTES))/ SUM(Y.BYTES)* 100), 2) AS USED_FILE_PCT,
+              ROUND(DECODE(SUM(Y.BYTES), 0, 0,(SUM(Y.BYTES)-NVL(MAX(NVL(Y.FREE_BYTES, 0)), 0))/ SUM(Y.BYTES)* 100), 2) AS USED_FILE_PCT,
               DECODE(Y.TBS_STATUS, 'ONLINE', 1, 'OFFLINE', 2, 'READ ONLY', 3, 0) AS STATUS 
                FROM ( SELECT
                  dtf.tablespace_name AS name,


### PR DESCRIPTION
FREE_BYTES is calculated using MAX function, but related USED_BYTES and USED_FILE_PCT is using SUM !
This is causing negative number to appear in percentage.
This PR fix the issue using MAX function to calculate the stats and have good value