### PR TITLE
Allow to use system.sw.packages on gentoo linux

### DIFF
--- a/src/go/plugins/system/sw/sw.go
+++ b/src/go/plugins/system/sw/sw.go
@@ -165,6 +165,7 @@ func getManagers() []manager {
 		{"pkgtools", "[ -d /var/log/packages ] && echo true", "ls /var/log/packages", parseRegex},
 		{"rpm", "rpm --version 2> /dev/null", "rpm -qa", parseRegex},
 		{"pacman", "pacman --version 2> /dev/null", "pacman -Q", parseRegex},
+		{"portage", "emerge --version 2> /dev/null", "qlist -IRCv", parseRegex},
 	}
 }
 

--- a/src/libs/zbxsysinfo/linux/software.c
+++ b/src/libs/zbxsysinfo/linux/software.c
@@ -177,6 +177,7 @@ static ZBX_PACKAGE_MANAGER	package_managers[] =
 	{"pkgtools",	"[ -d /var/log/packages ] && echo true",	"ls /var/log/packages",		NULL},
 	{"rpm",		"rpm --version 2> /dev/null",			"rpm -qa",			NULL},
 	{"pacman",	"pacman --version 2> /dev/null",		"pacman -Q",			NULL},
+	{"portage",     "emerge --version 2> /dev/null",                "qlist -IRCv",                  NULL},
 	{NULL}
 };
 


### PR DESCRIPTION
This change allow to use system.sw.packages on gentoo linux using portage and portage-utils

Signed-off-by: Alexey Shvetsov <alexxy@gentoo.org>