### PR TITLE
Correction in {$VFS.FS.FSNAME.NOT_MATCHES}

### DIFF
--- a/templates/os/linux/template_os_linux.yaml
+++ b/templates/os/linux/template_os_linux.yaml
@@ -1752,7 +1752,7 @@ zabbix_export:
           description: 'This macro is used in filesystems discovery. Can be overridden on the host or linked template level'
         -
           macro: '{$VFS.FS.FSNAME.NOT_MATCHES}'
-          value: ^(/dev|/sys|/run|/proc|.+/shm$)
+          value: ^(/dev|/sys|/run|/proc|.+/shm)$
           description: 'This macro is used in filesystems discovery. Can be overridden on the host or linked template level'
         -
           macro: '{$VFS.FS.FSTYPE.MATCHES}'


### PR DESCRIPTION
Previously, the default regxp for {$VFS.FS.FSNAME.NOT_MATCHES} matched *any mount point beginning with* /dev, /sys, /run or /proc. It must be an error, the proposed update matches exactly these paths.