### PR TITLE
Let "has been restartet" depend on "is running"

### DIFF
--- a/templates/app/proxmox/template_app_proxmox.yaml
+++ b/templates/app/proxmox/template_app_proxmox.yaml
@@ -1,6 +1,6 @@
 zabbix_export:
   version: '6.0'
-  date: '2022-04-21T13:07:34Z'
+  date: '2022-05-11T18:19:26Z'
   groups:
     -
       uuid: a571c0d144b14fd4a87a9d9b2aa9fcd6
@@ -529,6 +529,10 @@ zabbix_export:
                   priority: INFO
                   description: 'Uptime is less than 10 minutes'
                   manual_close: 'YES'
+                  dependencies:
+                    -
+                      name: 'Proxmox: LXC [{#NODE.NAME}/{#LXC.NAME} ({#LXC.ID})]: Not running'
+                      expression: 'last(/Proxmox VE by HTTP/proxmox.lxc.vmstatus[{#LXC.ID}])<>"running"'
                   tags:
                     -
                       tag: scope
@@ -1782,6 +1786,10 @@ zabbix_export:
                   priority: INFO
                   description: 'Uptime is less than 10 minutes'
                   manual_close: 'YES'
+                  dependencies:
+                    -
+                      name: 'Proxmox: VM [{#NODE.NAME}/{#QEMU.NAME} ({#QEMU.ID})]: Not running'
+                      expression: 'last(/Proxmox VE by HTTP/proxmox.qemu.vmstatus[{#QEMU.ID}])<>"running"'
                   tags:
                     -
                       tag: scope


### PR DESCRIPTION
Before this change, VMs and containers would trigger "has been restarted" while actually not running.