### PR TITLE
initialize msghdr portably

### DIFF
--- a/src/libs/zbxsysinfo/linux/net.c
+++ b/src/libs/zbxsysinfo/linux/net.c
@@ -114,13 +114,21 @@ static int	find_tcp_port_by_state_nl(unsigned short port, int state, int *found)
 
 	struct sockaddr_nl	s_sa = { AF_NETLINK, 0, 0, 0 };
 	struct iovec		s_io[1] = { { &request, sizeof(request) } };
-	struct msghdr		s_msg = { (void *)&s_sa, sizeof(struct sockaddr_nl), s_io, 1, NULL, 0, 0};
+	struct msghdr		s_msg = { 0 };
+	s_msg.msg_name 		= (void *)&s_sa;
+	s_msg.msg_namelen 	= sizeof(struct sockaddr_nl);
+	s_msg.msg_iov 		= s_io;
+	s_msg.msg_iovlen 	= 1;
 
 	char			buffer[BUFSIZ] = { 0 };
 
 	struct sockaddr_nl	r_sa = { AF_NETLINK, 0, 0, 0 };
 	struct iovec		r_io[1] = { { buffer, BUFSIZ } };
-	struct msghdr		r_msg = { (void *)&r_sa, sizeof(struct sockaddr_nl), r_io, 1, NULL, 0, 0};
+	struct msghdr		r_msg = { 0 };
+	r_msg.msg_name 		= (void *)&r_sa;
+	r_msg.msg_namelen 	= sizeof(struct sockaddr_nl);
+	r_msg.msg_iov 		= r_io;
+	r_msg.msg_iovlen 	= 1;
 
 	struct nlmsghdr		*r_hdr;
 


### PR DESCRIPTION
on linux we have musl as an option for system C library and current
initialization assumes the structure to be same as glibc, therefore
initialize the elements of structure instead, so it can work on both
glibc and musl.

Fixes
net.c:115:79: error: incompatible pointer to integer conversion initializing 'int' with an expression of type 'void *' [-Wint-conversion]
        struct msghdr           s_msg = { (void *)&s_sa, sizeof(struct sockaddr_nl), s_io, 1, NULL, 0, 0};
                                                                                              ^~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>