### PR TITLE
Update CControllerWidgetTrigOverView.php

### DIFF
--- a/ui/app/controllers/CControllerWidgetTrigOverView.php
+++ b/ui/app/controllers/CControllerWidgetTrigOverView.php
@@ -47,6 +47,7 @@ class CControllerWidgetTrigOverView extends CControllerWidget {
 		$trigger_options = [
 			'skipDependent' => ($fields['show'] == TRIGGERS_OPTION_ALL) ? null : true,
 			'only_true' => ($fields['show'] == TRIGGERS_OPTION_RECENT_PROBLEM) ? true : null,
+			'tags' => (array_key_exists('tags', $fields) && $fields['tags']) ? $fields['tags'] : null,
 			'filter' => [
 				'value' => ($fields['show'] == TRIGGERS_OPTION_IN_PROBLEM) ? TRIGGER_VALUE_TRUE : null
 			]


### PR DESCRIPTION
Restore original behavior of the trigger overview screen.
With this change it is possible to filter out triggers that are not needed on the dashboard. Otherwise it brings all triggers for each host regardless of tag filter settings. 