### PR TITLE
Ignore ZFS snapshot mounts in mounted filesystem discovery

### DIFF
--- a/templates/os/linux_active/template_os_linux_active.yaml
+++ b/templates/os/linux_active/template_os_linux_active.yaml
@@ -1833,7 +1833,7 @@ zabbix_export:
           description: 'This macro is used in filesystems discovery. Can be overridden on the host or linked template level'
         -
           macro: '{$VFS.FS.FSNAME.NOT_MATCHES}'
-          value: ^(/dev|/sys|/run|/proc|.+/shm$)
+          value: ^(/dev|/sys|/run|/proc|.+/shm$|.+/\.zfs/snapshot)
           description: 'This macro is used in filesystems discovery. Can be overridden on the host or linked template level'
         -
           macro: '{$VFS.FS.FSTYPE.MATCHES}'


### PR DESCRIPTION
When ZFS snaphots are accessed they get mounted. To prevent discovery as new mounted filesystem they need to be ignored.