### PR TITLE
Correct trigger expression for swap

### DIFF
--- a/templates/app/proxmox/template_app_proxmox.yaml
+++ b/templates/app/proxmox/template_app_proxmox.yaml
@@ -1338,8 +1338,8 @@ zabbix_export:
             -
               uuid: f38ccc2e0e40430e801bf98b488e12e4
               expression: 'min(/Proxmox VE by HTTP/proxmox.node.swapused[{#NODE.NAME}],5m) / last(/Proxmox VE by HTTP/proxmox.node.swaptotal[{#NODE.NAME}]) * 100 > {$PVE.SWAP.PUSE.MAX.WARN:"{#NODE.NAME}"} and last(/Proxmox VE by HTTP/proxmox.node.swaptotal[{#NODE.NAME}]) > 0'
-              name: 'Proxmox: Node [{#NODE.NAME}] high root filesystem space usage'
-              event_name: 'Proxmox: Node [{#NODE.NAME}] high root filesystem space usage (over {$PVE.SWAP.PUSE.MAX.WARN:"{#NODE.NAME}"}% use)'
+              name: 'Proxmox: Node [{#NODE.NAME}] high swap filesystem space usage'
+              event_name: 'Proxmox: Node [{#NODE.NAME}] high swap filesystem space usage (over {$PVE.SWAP.PUSE.MAX.WARN:"{#NODE.NAME}"}% use)'
               opdata: 'Current use: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
               priority: WARNING
               description: 'This trigger is ignored, if there is no swap configured.'


### PR DESCRIPTION
Lines 1341 and 1342, change "root" to "swap" to reflect this trigger being used to check and report on the swap filesystem space usage, not the root file system space usage.