### PR TITLE
fix api service.get with problems

### DIFF
--- a/ui/include/classes/api/services/CService.php
+++ b/ui/include/classes/api/services/CService.php
@@ -885,7 +885,7 @@ class CService extends CApiService {
 			$output = ['serviceid', 'eventid', 'severity', 'name'];
 		}
 		else {
-			$output = array_unique(array_merge(['serviceid', 'eventid'], $options['selectProblemEvents']));
+			$output = array_unique(array_merge(['serviceid', 'eventid', 'severity'], $options['selectProblemEvents']));
 		}
 
 		$do_output_name = in_array('name', $output);


### PR DESCRIPTION
For request service with "selectProblemEvents":["eventid"] getProblemEvents is failed in case min_status != NULL