### PR TITLE
Allow Housekeeper to select in chunks

### DIFF
--- a/conf/zabbix_server.conf
+++ b/conf/zabbix_server.conf
@@ -425,6 +425,19 @@ DBUser=zabbix
 # Default:
 # MaxHousekeeperDelete=5000
 
+### Option: HousekeeperMaxChunkSize
+#	Limit query size and fetch data in chunks, the size actual not means you are going to fetch 
+#	that amount of records at one go as some of the items in range might be missing.
+#	The purpose of this option is to not overload database server if you are selecting from large tables. 
+#	It allows housekeeper works if you just enabled it as you not get timeout and disconnect form database
+#	If set to 0 then no limit is used at all. In this case you must know what you are doing!
+#
+# Mandatory: no
+# Range: 0-50000000
+# Default:
+# HousekeeperMaxChunkSize=1000000
+
+
 ### Option: CacheSize
 #	Size of configuration cache, in bytes.
 #	Shared memory size for storing host, item and trigger data.

--- a/src/zabbix_server/housekeeper/housekeeper.h
+++ b/src/zabbix_server/housekeeper/housekeeper.h
@@ -24,6 +24,7 @@
 
 extern int	CONFIG_HOUSEKEEPING_FREQUENCY;
 extern int	CONFIG_MAX_HOUSEKEEPER_DELETE;
+extern int      CONFIG_HOUSEKEEPING_MAX_CHUNK_SIZE;
 
 typedef struct
 {

--- a/src/zabbix_server/server.c
+++ b/src/zabbix_server/server.c
@@ -327,6 +327,7 @@ char	*CONFIG_SERVER			= NULL;		/* not used in zabbix_server, required for linkin
 
 int	CONFIG_HOUSEKEEPING_FREQUENCY	= 1;
 int	CONFIG_MAX_HOUSEKEEPER_DELETE	= 5000;		/* applies for every separate field value */
+int     CONFIG_HOUSEKEEPING_MAX_CHUNK_SIZE = 0;
 int	CONFIG_HISTSYNCER_FREQUENCY	= 1;
 int	CONFIG_CONFSYNCER_FREQUENCY	= 10;
 
@@ -873,6 +874,8 @@ static void	zbx_load_config(ZBX_TASK_EX *task)
 			PARM_OPT,	0,			24},
 		{"MaxHousekeeperDelete",	&CONFIG_MAX_HOUSEKEEPER_DELETE,		TYPE_INT,
 			PARM_OPT,	0,			1000000},
+                {"HousekeeperMaxChunkSize",	&CONFIG_HOUSEKEEPING_MAX_CHUNK_SIZE,	TYPE_INT,
+                        PARM_OPT,	0,			50000000},
 		{"TmpDir",			&CONFIG_TMPDIR,				TYPE_STRING,
 			PARM_OPT,	0,			0},
 		{"FpingLocation",		&CONFIG_FPING_LOCATION,			TYPE_STRING,


### PR DESCRIPTION
This is untested code as I cannot reproduce this in my lab. 

Basically it limit query size used by housekeeper and fetching items in chunks. Current version of zabbix can overload mysql database due to fetching all data as it using single query. If the tables are too big, the query gets timeout, so zabbix_server lost connection to db. The current behaviour not allows to use housekeeper with large tables.