### PR TITLE
Enable SonarCloud analysis caching

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,4 +4,3 @@ sonar.java.binaries=target
 sonar.sources=src/, ui/
 sonar.java.binaries=**/*.java
 sonar.exclusions=**/*.java, **/*.sql, src/zabbix_agent/zabbix_agentd.c, src/zabbix_server/server.c, src/zabbix_proxy/proxy.c, ui/tests/**/*, ui/tests/*, **/test*, **/*test, **/*test*
-sonar.cfamily.cache.enabled=false


### PR DESCRIPTION
SonarCloud now has an automatic analysis caching which gets saved on the server. See https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#analysis-cache.