### PR TITLE
updated libssh.m4

### DIFF
--- a/m4/libssh.m4
+++ b/m4/libssh.m4
@@ -32,7 +32,7 @@ AC_DEFUN([LIBSSH_ACCEPT_VERSION],
 [
 	# Zabbix minimal major supported version of libssh:
 	minimal_libssh_major_version=0
-	minimal_libssh_minor_version=6
+	minimal_libssh_minor_version=9
 
 	# get the major version
 	found_ssh_version_major=`cat $1 | $EGREP \#define.*'LIBSSH_VERSION_MAJOR ' | $AWK '{print @S|@3;}'`


### PR DESCRIPTION
the minimal libssh version should be 0.9.0,because the variable SSH_OPTIONS_PROCESS_CONFIG used in run_ssh.c exists in libssh.h after version 0.9.0