### PR TITLE
Added if for Ticketupdate via trigger-based actions

### DIFF
--- a/templates/media/zammad/media_zammad.yaml
+++ b/templates/media/zammad/media_zammad.yaml
@@ -302,6 +302,12 @@ zabbix_export:
         
             Zammad.setParams(params_zammad);
             Zammad.HTTPProxy = params.HTTPProxy;
+            
+            // Update ticket for trigger-based events from actions.
+            if (params.event_source == '0'
+                && params.event_value == '1' && Number.isInteger(parseInt(Zammad.params.ticket_id))) {
+                params.event_value = '0';
+            }
         
             // Create ticket for non trigger-based events.
             if (params.event_source !== '0'


### PR DESCRIPTION
In case you want to use trigger-based actions and update tickets through configured steps, every send message from a step will create a new ticket. Therefore we created this if statement, so we can update an existing ticket.

Added if statement to set ` params.event_value = '0';` to update tickets in zammad via trigger-based action-steps.