### PR TITLE
add admin status to netapp template adjust trigger

### DIFF
--- a/templates/san/netapp_aff_a700_http/template_san_netapp_aff_a700_http.yaml
+++ b/templates/san/netapp_aff_a700_http/template_san_netapp_aff_a700_http.yaml
@@ -1243,6 +1243,31 @@ zabbix_export:
           username: '{$USERNAME}'
           password: '{$PASSWORD}'
           item_prototypes:
+            - uuid: 9866032fbf964dcbb59fb19a9911ba57
+              name: '{#ETHPORTNAME}: Enabled'
+              type: DEPENDENT
+              key: 'netapp.port.eth.enabled[{#NODENAME},{#ETHPORTNAME}]'
+              delay: '0'
+              history: 7d
+              trends: '0'
+              value_type: CHAR
+              description: 'The admin state of the port. Possible values: true, false.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.records[?(@.name==''{#ETHPORTNAME}'')].enabled.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: netapp.ports.eth.get
+              tags:
+                - tag: component
+                  value: interfaces
+                - tag: interfaces
+                  value: '{#ETHPORTNAME}'
+                - tag: node
+                  value: '{#NODENAME}'
             - uuid: dda2086a96f844c7b5a8002549fe6bf5
               name: '{#ETHPORTNAME}: State'
               type: DEPENDENT
@@ -1270,9 +1295,9 @@ zabbix_export:
                   value: '{#NODENAME}'
               trigger_prototypes:
                 - uuid: 0fa3a54b559349d58b616720ee33cdf5
-                  expression: '(last(/NetApp AFF A700 by HTTP/netapp.port.eth.state[{#NODENAME},{#ETHPORTNAME}],#1)<>last(/NetApp AFF A700 by HTTP/netapp.port.eth.state[{#NODENAME},{#ETHPORTNAME}],#2) and last(/NetApp AFF A700 by HTTP/netapp.port.eth.state[{#NODENAME},{#ETHPORTNAME}])="down")'
+                  expression: 'last(/NetApp by HTTP/netapp.port.eth.state[{#NODENAME},{#ETHPORTNAME}])="down" and last(/NetApp by HTTP/netapp.port.eth.enabled[{#NODENAME},{#ETHPORTNAME}])="false"'
                   recovery_mode: RECOVERY_EXPRESSION
-                  recovery_expression: '(last(/NetApp AFF A700 by HTTP/netapp.port.eth.state[{#NODENAME},{#ETHPORTNAME}],#1)<>last(/NetApp AFF A700 by HTTP/netapp.port.eth.state[{#NODENAME},{#ETHPORTNAME}],#2) and last(/NetApp AFF A700 by HTTP/netapp.port.eth.state[{#NODENAME},{#ETHPORTNAME}])="up")'
+                  recovery_expression: 'last(/NetApp by HTTP/netapp.port.eth.state[{#NODENAME},{#ETHPORTNAME}])="up"'
                   name: '{#ETHPORTNAME}: Ethernet port of the Node "{#NODENAME}" is down'
                   priority: AVERAGE
                   description: 'Something is wrong with the ethernet port.'


### PR DESCRIPTION
Add the admin status of ethernet ports to the discovery rule and adjsut the trigger.
This way no alarm is generated if a port is disconnected and the port is administrative down.