### PR TITLE
Ticketupdate fix for Issue [ZBXNEXT-8531]

### DIFF
--- a/templates/media/zammad/media_zammad.yaml
+++ b/templates/media/zammad/media_zammad.yaml
@@ -302,6 +302,12 @@ zabbix_export:
         
             Zammad.setParams(params_zammad);
             Zammad.HTTPProxy = params.HTTPProxy;
+            
+            // Update ticket for trigger-based events from actions.
+            if (params.event_source == '0'
+                && params.event_value == '1' && Number.isInteger(parseInt(Zammad.params.ticket_id))) {
+                params.event_value = '0';
+            }
         
             // Create ticket for non trigger-based events.
             if (params.event_source !== '0'


### PR DESCRIPTION
This fix would change the behavior how zammad interact with zabbix.
Currently every message (trigger-based events) will create new tickets, after implementing the new lines, zammad will update an existing ticket and create new tickets - if there is no fitting ticket available a new ticket will be created.