### PR TITLE
Add {#IFALIAS} to the SNMP Walk Network Interfaces for template_net_tplink_snmp.yaml

### DIFF
--- a/templates/net/tplink_snmp/template_net_tplink_snmp.yaml
+++ b/templates/net/tplink_snmp/template_net_tplink_snmp.yaml
@@ -112,7 +112,7 @@ zabbix_export:
         - uuid: 0cf11e0dfd3b47f1a0a5d8f011e6517b
           name: 'TP-LINK: SNMP walk network interfaces'
           type: SNMP_AGENT
-          snmp_oid: 'walk[1.3.6.1.2.1.2.2.1.8,1.3.6.1.2.1.2.2.1.7,1.3.6.1.2.1.2.2.1.2,1.3.6.1.2.1.2.2.1.3,1.3.6.1.2.1.2.2.1.10,1.3.6.1.2.1.2.2.1.16,1.3.6.1.2.1.2.2.1.14,1.3.6.1.2.1.2.2.1.20,1.3.6.1.2.1.2.2.1.19,1.3.6.1.2.1.2.2.1.13,1.3.6.1.2.1.2.2.1.5]'
+          snmp_oid: 'walk[1.3.6.1.2.1.2.2.1.8,1.3.6.1.2.1.2.2.1.7,1.3.6.1.2.1.2.2.1.2,1.3.6.1.2.1.2.2.1.3,1.3.6.1.2.1.2.2.1.10,1.3.6.1.2.1.2.2.1.16,1.3.6.1.2.1.2.2.1.14,1.3.6.1.2.1.2.2.1.20,1.3.6.1.2.1.2.2.1.19,1.3.6.1.2.1.2.2.1.13,1.3.6.1.2.1.2.2.1.5,1.3.6.1.2.1.31.1.1.1.18]'
           key: net.if.walk
           history: '0'
           trends: '0'
@@ -588,34 +588,41 @@ zabbix_export:
                 value: '{$NET.IF.IFADMINSTATUS.NOT_MATCHES}'
                 operator: NOT_MATCHES_REGEX
                 formulaid: B
+              - macro: '{#IFALIAS}'
+                value: '{$NET.IF.IFALIAS.MATCHES}'
+                formulaid: C
+              - macro: '{#IFALIAS}'
+                value: '{$NET.IF.IFALIAS.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: D
               - macro: '{#IFOPERSTATUS}'
                 value: '{$NET.IF.IFOPERSTATUS.MATCHES}'
-                formulaid: G
+                formulaid: I
               - macro: '{#IFOPERSTATUS}'
                 value: '{$NET.IF.IFOPERSTATUS.NOT_MATCHES}'
                 operator: NOT_MATCHES_REGEX
-                formulaid: H
+                formulaid: J
               - macro: '{#IFNAME}'
                 value: '{$NET.IF.IFNAME.MATCHES}'
-                formulaid: E
+                formulaid: G
               - macro: '{#IFNAME}'
                 value: '{$NET.IF.IFNAME.NOT_MATCHES}'
                 operator: NOT_MATCHES_REGEX
-                formulaid: F
+                formulaid: H
               - macro: '{#IFDESCR}'
                 value: '{$NET.IF.IFDESCR.MATCHES}'
-                formulaid: C
+                formulaid: E
               - macro: '{#IFDESCR}'
                 value: '{$NET.IF.IFDESCR.NOT_MATCHES}'
                 operator: NOT_MATCHES_REGEX
-                formulaid: D
+                formulaid: F
               - macro: '{#IFTYPE}'
                 value: '{$NET.IF.IFTYPE.MATCHES}'
-                formulaid: I
+                formulaid: K
               - macro: '{#IFTYPE}'
                 value: '{$NET.IF.IFTYPE.NOT_MATCHES}'
                 operator: NOT_MATCHES_REGEX
-                formulaid: J
+                formulaid: L
           description: 'Discovering interfaces from IF-MIB.'
           item_prototypes:
             - uuid: 27f1c9ccfc744b5eb215d032fbbe2ff8
@@ -1049,6 +1056,9 @@ zabbix_export:
                 - '{#IFTYPE}'
                 - 1.3.6.1.2.1.2.2.1.3
                 - '0'
+                - '{#IFALIAS}'
+                - 1.3.6.1.2.1.31.1.1.1.18
+                - '0'
               error_handler: DISCARD_VALUE
             - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
@@ -1099,6 +1109,10 @@ zabbix_export:
           value: CHANGE_IF_NEEDED
         - macro: '{$SNMP.TIMEOUT}'
           value: 5m
+        - macro: '{$NET.IF.IFALIAS.MATCHES}'
+          value: '.*'
+        - macro: '{$NET.IF.IFALIAS.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
       dashboards:
         - uuid: badebb168da14b07856c04774bf07102
           name: 'Network interfaces'


### PR DESCRIPTION
Added `{#IFALIAS}` to the SNMP walk network interfaces for the TP-LINK by SNMP template.
With these changes, the description tag for the network interfaces discovered items will resolve correctly to the value of `{#IFALIAS}`.