### PR TITLE
Fixed memory leak when using TLS with zabbix-agent2

### DIFF
--- a/src/go/pkg/tls/tls.go
+++ b/src/go/pkg/tls/tls.go
@@ -727,6 +727,7 @@ static void tls_description(tls_t *tls, char **desc)
 	*desc = strdup(buf);
 	free(peer_issuer);
 	free(peer_subject);
+	X509_free(cert);
 }
 
 //*****************************************************************************


### PR DESCRIPTION
Probably an issue related to some issues.

I don't think it is a sufficient test, I have run zabbix_get command 5000 times and verified that memory usage is constant.

https://support.zabbix.com/browse/ZBX-23076
https://support.zabbix.com/browse/ZBX-23053
https://support.zabbix.com/browse/ZBX-23047