### PR TITLE
template_app_systemd: change "service not running" prototype to "serv…

### DIFF
--- a/templates/app/systemd/template_app_systemd.yaml
+++ b/templates/app/systemd/template_app_systemd.yaml
@@ -73,10 +73,10 @@ zabbix_export:
                 - tag: component
                   value: service
               trigger_prototypes:
-                - uuid: 5237bd423307449b8a58f692082d2a0a
-                  expression: 'last(/Systemd by Zabbix agent 2/systemd.service.active_state["{#UNIT.NAME}"])<>1'
-                  name: '{#UNIT.NAME}: Service is not running'
-                  priority: WARNING
+                - uuid: d149192e3d4b48ba9fd5e800ce1538f0
+                  expression: 'last(/Systemd by Zabbix agent 2/systemd.service.active_state["{#UNIT.NAME}"])=4'
+                  name: '{#UNIT.NAME}: Service failed'
+                  priority: AVERAGE
                   manual_close: 'YES'
                   tags:
                     - tag: scope


### PR DESCRIPTION
…ice failed"

It is absolutely common that systemd service are not running. The prime example are timer activated services that enter the not running state after they ran, waiting for the next timer activation.

The existing "Service not running" trigger prototype causes a lot of noise due to false positives. Therefore, we replace this trigger prototoype with one that explicitly warns about failed services, because those need immediate attention.

Fixes ZBXNEXT-8767