### PR TITLE
[ZBXNEXT-8804] added tcp-socket-proxy support for docker plugin in agent2

### DIFF
--- a/src/go/conf/zabbix_agent2.d/plugins.d/docker.conf
+++ b/src/go/conf/zabbix_agent2.d/plugins.d/docker.conf
@@ -3,6 +3,7 @@
 #
 # Mandatory: no
 # Default: unix:///var/run/docker.sock
+# Using a Docker socket TCP proxy: tcp://docker-socket-proxy:2375
 # Plugins.Docker.Endpoint=unix:///var/run/docker.sock
 
 ### Option: Plugins.Docker.Timeout

--- a/src/go/plugins/docker/README.md
+++ b/src/go/plugins/docker/README.md
@@ -24,7 +24,8 @@ Open Zabbix agent 2 docker configuration file `zabbix_agent2.d/plugins.d/docker.
 set the required parameters.
 
 **Plugins.Docker.Endpoint** — the Docker API endpoint.
-*Default value:* `unix:///var/run/docker.sock`    
+*Default value:* `unix:///var/run/docker.sock`
+*Using a Docker socket TCP proxy:* `tcp://docker-socket-proxy:2375`
  
 **Plugins.Docker.Timeout** — the maximum time (in seconds) for 
 waiting when a request has to be done.


### PR DESCRIPTION
Added tcp-socket-proxy support for docker plugin in agent2.
This allows the use of Docker socket proxies like.. :
- https://github.com/Tecnativa/docker-socket-proxy
- https://github.com/hectorm/cetusguard

.. and so to increase security.

https://support.zabbix.com/browse/ZBXNEXT-8804
https://www.zabbix.com/forum/zabbix-help/473139-monitoring-docker-containers-using-a-socket-proxy