### PR TITLE
Fixed Replication LLD macro for MySQL by Zabbix agent template

### DIFF
--- a/templates/db/mysql_agent/template_db_mysql_agent.yaml
+++ b/templates/db/mysql_agent/template_db_mysql_agent.yaml
@@ -1345,9 +1345,9 @@ zabbix_export:
                     - tag: scope
                       value: notice
             - uuid: 27e807d840d4474484c2e1f896726b6b
-              name: 'MySQL: Replication Slave SQL Running State {#MASTER_HOST}'
+              name: 'MySQL: Replication Slave SQL Running State {#MASTERHOST}'
               type: DEPENDENT
-              key: 'mysql.slave_sql_running_state["{#MASTER_HOST}"]'
+              key: 'mysql.slave_sql_running_state["{#MASTERHOST}"]'
               delay: '0'
               history: 7d
               trends: '0'


### PR DESCRIPTION
The JavaScript preprocessing step for the Replication discovery rule returns `[{"{#MASTERHOST}": matches[1]}]`. Also, all other macros in this template use `MASTERHOST` in their keys and names, not `MASTER_HOST`.