### PR TITLE
Fixed crash in Zabbix agentd

### DIFF
--- a/src/libs/zbxsysinfo/common/diskdevices.c
+++ b/src/libs/zbxsysinfo/common/diskdevices.c
@@ -114,6 +114,11 @@ static void	process_diskstat(zbx_single_diskdevice_data *device)
 
 void	collect_stats_diskdevices(zbx_diskdevices_data *diskdevices)
 {
+	if (diskdevices == NULL)
+	{
+		return;
+	}
+
 	stats_lock_diskstats();
 	diskstat_shm_reattach();
 
@@ -196,7 +201,10 @@ zbx_single_diskdevice_data	*collector_diskdevice_add(const char *devname)
 	}
 
 	if (diskdevices->count == diskdevices->max_diskdev)
+	{
 		diskstat_shm_extend();
+		diskdevices = get_diskdevices();
+	}
 
 	device = &(diskdevices->device[diskdevices->count]);
 	memset(device, 0, sizeof(zbx_single_diskdevice_data));

--- a/src/libs/zbxsysinfo/common/stats.c
+++ b/src/libs/zbxsysinfo/common/stats.c
@@ -51,7 +51,7 @@ int	diskdevice_collector_started(void)
 	return ((NULL != collector) && (ZBX_NONEXISTENT_SHMID != collector->diskstat_shmid));
 }
 
-static int			shm_id;
+static int			shm_id = ZBX_NONEXISTENT_SHMID;
 static int			my_diskstat_shmid = ZBX_NONEXISTENT_SHMID;
 static zbx_diskdevices_data	*diskdevices = NULL;
 zbx_diskdevices_data	*get_diskdevices(void)


### PR DESCRIPTION
Since version 7.0.0 the Zabbix agentd is crashing on all my Debian bookmark servers after a few seconds:

[trace.txt](https://github.com/user-attachments/files/15587609/trace.txt)

I do not understand much of the code and the (side) effects of my changes, but there seems to be some missing NULL pointer checks. Also the pointer to `diskdevices` after a `diskstat_shm_extend()` points to released memory.

I (think) I do not use the disk discovery feature and don't know why not all users experience this crash (and tests are failing).