### PR TITLE
Fix Nextcloud Template serverinfo url

### DIFF
--- a/templates/app/nextcloud/template_nextcloud_http.yaml
+++ b/templates/app/nextcloud/template_nextcloud_http.yaml
@@ -369,7 +369,7 @@ zabbix_export:
               parameters:
                 - ''
           timeout: 10s
-          url: '{$NEXTCLOUD.SCHEMA}://{$NEXTCLOUD.ADDRESS}/ocs/v2.php/apps/serverinfo/api/v1/info'
+          url: '{$NEXTCLOUD.SCHEMA}://{$NEXTCLOUD.ADDRESS}/ocs/v2.php/apps/serverinfo/api/v1/info?skipApps=false'
           status_codes: '200,401'
           http_proxy: '{$NEXTCLOUD.PROXY}'
           headers:


### PR DESCRIPTION
add `?skipApps=false` parameter, otherwise the template items `Apps installed` and `Apps update available` get no data from it's parent item.

> cannot extract value from json by path "$.ocs.data.nextcloud.system.apps.num_installed": no data matches the specified path