### PR TITLE
ZBX-24418: Ensure type casting for `iStat` variables

### DIFF
--- a/src/go/Makefile.am
+++ b/src/go/Makefile.am
@@ -4,8 +4,6 @@ EXTRA_DIST = .
 
 BUILD_TIME=`date +%H:%M:%S`
 BUILD_DATE=`date +"%b %_d %Y"`
-GOOS=`go env GOOS`
-GOARCH=`go env GOARCH`
 PKG=golang.zabbix.com/agent2/pkg/version
 NEW_FROM_REV=""
 


### PR DESCRIPTION
Some architectures such as `mips64` use `uint32` instead of the `uint64` that seems to be adopted in newer standards.

In order to support these architectures Zabbix must cast the type to a `uint64` to deal with these platforms.