### PR TITLE
Corrected empty S3 Buckets to return empty array

### DIFF
--- a/templates/cloud/AWS/aws_http/template_cloud_aws_http.yaml
+++ b/templates/cloud/AWS/aws_http/template_cloud_aws_http.yaml
@@ -1316,12 +1316,21 @@ zabbix_export:
             	params: {},
             	metadata: 'http://169.254.169.254/latest/meta-data/iam/security-credentials',
             
+            	isObjectEmpty: function (obj) {
+            		for (var prop in obj) {
+            			if (obj.hasOwnProperty(prop)) {
+            				return false;
+            			}
+            		}
+            		return true;
+            	},
+
             	getField: function (data, path) {
             		var steps = path.split('.');
             		for (var i = 0; i < steps.length; i++) {
             			var step = steps[i];
-            			if (typeof data !== 'object' || typeof data[step] === 'undefined') {
-            				throw 'Required field was not found: ' + path;
+            			if (typeof data !== 'object' || AWS.isObjectEmpty(data) || typeof data[step] === 'undefined') {
+            				return null;
             			}
             
             			data = data[step];


### PR DESCRIPTION
Corrected a bug when an account does not have any S3 Buckets and the Bucket object returns as a empty Object.