### PR TITLE
Remove Placeholder for MYSQL.DNS from MySQL for Zabbix Agent 2 Template

### DIFF
--- a/templates/db/mysql_agent2/template_db_mysql_agent2.yaml
+++ b/templates/db/mysql_agent2/template_db_mysql_agent2.yaml
@@ -1248,7 +1248,6 @@ zabbix_export:
           value: information_schema
           description: 'Filter to exclude discovered databases.'
         - macro: '{$MYSQL.DSN}'
-          value: '<Put your DSN>'
           description: 'System data source name such as <tcp://host:port or unix:/path/to/socket)/>.'
         - macro: '{$MYSQL.INNODB_LOG_FILES}'
           value: '2'


### PR DESCRIPTION
in general i want to use the default value or the one specified in the agent configuration. Right now, i have to specify the macro for every host to be empty (i.e. MYSQL.DNS = '') so it uses these defaults because the template puts the placeholder "<Put your DNS>" there which does not really help(!?)