### PR TITLE
Fix Cisco Meraki devices/statuses deprecation

### DIFF
--- a/templates/net/meraki_http/template_net_meraki_http.yaml
+++ b/templates/net/meraki_http/template_net_meraki_http.yaml
@@ -102,7 +102,7 @@ zabbix_export:
             		for (i in organizations) {
             			if ('id' in organizations[i] && 'name' in organizations[i]) {
             				try {
-            					organization_devices = getHttpData(params.url + 'organizations/' + encodeURIComponent(organizations[i].id) + '/devices/statuses');
+            					organization_devices = getHttpData(params.url + 'organizations/' + encodeURIComponent(organizations[i].id) + '/devices/availabilities');
             
             					if (Array.isArray(organization_devices) && organization_devices.length > 0) {
             						for (j in organization_devices) {
@@ -344,7 +344,7 @@ zabbix_export:
               parameters:
                 - '$[0]'
           timeout: '{$MERAKI.DATA.TIMEOUT}'
-          url: 'https://{$MERAKI.API.URL}/organizations/{$ORGANIZATION_ID}/devices/statuses?serials[]={$SERIAL}'
+          url: 'https://{$MERAKI.API.URL}/organizations/{$ORGANIZATION_ID}/devices/availabilities?serials[]={$SERIAL}'
           http_proxy: '{$MERAKI.HTTP_PROXY}'
           headers:
             - name: X-Cisco-Meraki-API-Key
@@ -968,7 +968,7 @@ zabbix_export:
             
             	licenses = getHttpData(params.url + 'organizations/' + encodeURIComponent(params.organizationId) + '/licenses');
             
-            	organization_devices = getHttpData(params.url + 'organizations/' + encodeURIComponent(params.organizationId) + '/devices/statuses');
+            	organization_devices = getHttpData(params.url + 'organizations/' + encodeURIComponent(params.organizationId) + '/devices/availabilities');
             
             	licenses.forEach(function (license) {
             


### PR DESCRIPTION
As per documentation (https://developer.cisco.com/meraki/api-v1/get-organization-devices-statuses/) devices/statuses api call is deprecated. I have replaced it with devices/availabilities which provides same information.