### PR TITLE
Grey icon on ZBX passive icon, when Active checks are enabled

### DIFF
--- a/ui/include/items.inc.php
+++ b/ui/include/items.inc.php
@@ -2440,7 +2440,7 @@ function getEnabledItemsCountByInterfaceIds(array $interfaceids): array {
 		'countOutput' => true,
 		'groupCount' => true,
 		'interfaceids' => $interfaceids,
-		'filter' => ['status' => ITEM_STATUS_ACTIVE]
+		'filter' => ['type' => [ITEM_TYPE_ZABBIX,ITEM_TYPE_ZABBIX_ACTIVE], 'status' => ITEM_STATUS_ACTIVE]
 	]);
 
 	return $items_count ? array_column($items_count, 'rowscount', 'interfaceid') : [];


### PR DESCRIPTION
Patch for https://support.zabbix.com/browse/ZBX-21080
I think I may have missed some test cases.