### PR TITLE
Uncomment Include directive in zabbix_proxy.conf

### DIFF
--- a/conf/zabbix_proxy.conf
+++ b/conf/zabbix_proxy.conf
@@ -668,7 +668,7 @@ LogSlowQueries=3000
 
 # Include=/usr/local/etc/zabbix_proxy.general.conf
 # Include=/usr/local/etc/zabbix_proxy.conf.d/
-# Include=/usr/local/etc/zabbix_proxy.conf.d/*.conf
+Include=/usr/local/etc/zabbix_proxy.conf.d/*.conf
 
 ### Option: SSLCertLocation
 #	Location of SSL client certificates.


### PR DESCRIPTION
uncommented line 671:
# Include=/usr/local/etc/zabbix_proxy.conf.d/*.conf