### PR TITLE
Filtering trigger overview widget with tags on all-shown mode

### DIFF
--- a/ui/widgets/trigover/actions/WidgetView.php
+++ b/ui/widgets/trigover/actions/WidgetView.php
@@ -53,7 +53,7 @@ class WidgetView extends CControllerDashboardWidgetView {
 				'skipDependent' => ($this->fields_values['show'] == TRIGGERS_OPTION_ALL) ? null : true,
 				'only_true' => $this->fields_values['show'] == TRIGGERS_OPTION_RECENT_PROBLEM ? true : null,
 				'filter' => [
-				    'value' => $this->fields_values['show'] == TRIGGERS_OPTION_IN_PROBLEM ? TRIGGER_VALUE_TRUE : null
+				    	'value' => $this->fields_values['show'] == TRIGGERS_OPTION_IN_PROBLEM ? TRIGGER_VALUE_TRUE : null
 				]
 			];
 


### PR DESCRIPTION
I ran into a problem when using Zabbix - if I have a node with a **large number** of triggers/templates and I need to add **only some of them** to the widget - this is only available in **recent problems/problems** mode, but I needed to filter out the triggers in **all shown** mode as well.
This modification of the Trigger Overview widget allows you to filter by tags in the **all shown** mode.