### PR TITLE
Add proxy support for TimescalDB to drop partitions

### DIFF
--- a/create/bin/gen_schema.pl
+++ b/create/bin/gen_schema.pl
@@ -732,6 +732,14 @@ EOF
 	;
 	}
 
+	for ("proxy_history")
+	{
+		print<<EOF
+	PERFORM create_hypertable('$_', 'id', chunk_time_interval => 1000000, $flags);
+EOF
+	;
+	}
+
 	print<<EOF
 
 	IF (current_db_extension = 'timescaledb') THEN


### PR DESCRIPTION
For high (N)VPS deployments where a proxy is deployed and responsible for lots of data, housekeeping on the proxy can become a bottleneck requiring lots of cpu/memory resources.  As such, we're looking to add TimescaleDB (partitioning) support to the `proxy_history` table, along with modifications to the housekeeping process, similar to what the zabbix server supports.