### PR TITLE
Refactor token extraction from headers

### DIFF
--- a/templates/cloud/openstack/template_cloud_openstack_http.yaml
+++ b/templates/cloud/openstack/template_cloud_openstack_http.yaml
@@ -94,7 +94,8 @@ zabbix_export:
             			try {
             				token = headers["X-Subject-Token"][0];
             			} catch (error) {
-            				throw 'Failed to parse response received from OpenStack Identity API. Check debug log for more information.';
+            				token = headers["x-subject-token"][0];
+            				// throw 'Failed to parse response received from OpenStack Identity API. Check debug log for more information.';
             			}
             		} else {
             			throw 'Response object is empty. Check debug log for more information.';


### PR DESCRIPTION
Fix for a bug in the template that appears with latest OpenStack projects (see, for example, https://support.zabbix.com/si/jira.issueviews:issue-html/ZBX-24204/ZBX-24204.html).

> HTTP/2 (RFC 7540) mandates that all header field names be converted to lowercase before transmission, making it mandatory rather than optional. While HTTP header names are technically case-insensitive in earlier versions, HTTP/2 treats uppercase letters in header names as malformed, enforcing a standard lowercase format for improved efficiency and compatibility.