### PR TITLE
Add OpenSSL 3.0 compatibility for peer certificate retrieval

### DIFF
--- a/src/go/pkg/tls/tls.go
+++ b/src/go/pkg/tls/tls.go
@@ -63,6 +63,13 @@ const char	*tls_crypto_init_msg;
 #define TLS_EX_DATA_IDENTITY	1
 #define TLS_EX_DATA_KEY		2
 
+/* OpenSSL 3.0 renamed SSL_get_peer_certificate() to SSL_get1_peer_certificate(). */
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+#	define zbx_ssl_get_peer_cert(ssl)	SSL_get1_peer_certificate(ssl)
+#else
+#	define zbx_ssl_get_peer_cert(ssl)	SSL_get_peer_certificate(ssl)
+#endif
+
 typedef SSL_CTX * SSL_CTX_LP;
 
 typedef struct {
@@ -680,7 +687,7 @@ static int tls_validate_issuer_and_subject(tls_t *tls, const char *issuer, const
 	char *peer_issuer = NULL, *peer_subject = NULL;
 	int ret = -1;
 
-	if (NULL == (cert = SSL_get_peer_certificate(tls->ssl)))
+	if (NULL == (cert = zbx_ssl_get_peer_cert(tls->ssl)))
 	{
 		BIO_printf(tls->err, "cannot obtain peer certificate");
 		goto out;
@@ -724,7 +731,7 @@ static void tls_description(tls_t *tls, char **desc)
 
 	ptr += snprintf(ptr, sizeof(buf), "%s %s", SSL_get_version(tls->ssl), SSL_get_cipher(tls->ssl));
 
-	if ((sizeof(buf) - 1 > (size_t)(ptr - buf)) && NULL != (cert = SSL_get_peer_certificate(tls->ssl)))
+	if ((sizeof(buf) - 1 > (size_t)(ptr - buf)) && NULL != (cert = zbx_ssl_get_peer_cert(tls->ssl)))
 	{
 		char	*peer_issuer = NULL, *peer_subject = NULL;
 
@@ -801,7 +808,7 @@ static int	tls_has_peer_certificate(tls_t *tls)
 {
 	X509	*cert;
 
-	if (NULL == (cert = SSL_get_peer_certificate(tls->ssl)))
+	if (NULL == (cert = zbx_ssl_get_peer_cert(tls->ssl)))
 		return 0;
 
 	X509_free(cert);

--- a/src/libs/zbxcomms/tls_openssl.c
+++ b/src/libs/zbxcomms/tls_openssl.c
@@ -2318,7 +2318,7 @@ int	zbx_tls_get_attr_cert(const zbx_socket_t *s, zbx_tls_conn_attr_t *attr)
 
 	if (NULL == (peer_cert = zbx_ssl_get_peer_cert(s->tls_ctx->ctx)))
 	{
-		zabbix_log(LOG_LEVEL_WARNING, "no peer certificate, SSL_get_peer_certificate() returned NULL");
+		zabbix_log(LOG_LEVEL_WARNING, "no peer certificate, zbx_ssl_get_peer_cert() returned NULL");
 		return FAIL;
 	}
 

--- a/src/libs/zbxcomms/tls_openssl.c
+++ b/src/libs/zbxcomms/tls_openssl.c
@@ -177,6 +177,14 @@ static int	zbx_openssl_init_ssl(zbx_uint64_t opts, void *settings)
 }
 #endif /* OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER) */
 
+/* OpenSSL 3.0 renamed SSL_get_peer_certificate() to SSL_get1_peer_certificate().
+ * Both functions increment the refcount and require X509_free(). */
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+#	define zbx_ssl_get_peer_cert(ssl)	SSL_get1_peer_certificate(ssl)
+#else
+#	define zbx_ssl_get_peer_cert(ssl)	SSL_get_peer_certificate(ssl)
+#endif
+
 static zbx_get_program_type_f		zbx_get_program_type_cb = NULL;
 
 static ZBX_THREAD_LOCAL const char	*my_psk_identity	= NULL;
@@ -643,7 +651,7 @@ static void	zbx_log_peer_cert(const char *function_name, const zbx_tls_context_t
 	if (SUCCEED != ZBX_CHECK_LOG_LEVEL(LOG_LEVEL_DEBUG))
 		return;
 
-	if (NULL == (cert = SSL_get_peer_certificate(tls_ctx->ctx)))
+	if (NULL == (cert = zbx_ssl_get_peer_cert(tls_ctx->ctx)))
 	{
 		zabbix_log(LOG_LEVEL_DEBUG, "%s() cannot obtain peer certificate", function_name);
 	}
@@ -696,7 +704,7 @@ static int	zbx_verify_issuer_subject(const zbx_tls_context_t *tls_ctx, const cha
 	tls_issuer[0] = '\0';
 	tls_subject[0] = '\0';
 
-	if (NULL == (cert = SSL_get_peer_certificate(tls_ctx->ctx)))
+	if (NULL == (cert = zbx_ssl_get_peer_cert(tls_ctx->ctx)))
 	{
 		*error = zbx_strdup(*error, "cannot obtain peer certificate");
 		return FAIL;
@@ -2308,7 +2316,7 @@ int	zbx_tls_get_attr_cert(const zbx_socket_t *s, zbx_tls_conn_attr_t *attr)
 	char	*error = NULL;
 	X509	*peer_cert;
 
-	if (NULL == (peer_cert = SSL_get_peer_certificate(s->tls_ctx->ctx)))
+	if (NULL == (peer_cert = zbx_ssl_get_peer_cert(s->tls_ctx->ctx)))
 	{
 		zabbix_log(LOG_LEVEL_WARNING, "no peer certificate, SSL_get_peer_certificate() returned NULL");
 		return FAIL;


### PR DESCRIPTION
Introduces a compatibility macro zbx_ssl_get_peer_cert() to handle the API rename in OpenSSL 3.0, where SSL_get_peer_certificate() was renamed to SSL_get1_peer_certificate(). Replaces all direct calls to SSL_get_peer_certificate() in src/go/pkg/tls/tls.go and src/libs/zbxcomms/tls_openssl.c with the new macro, ensuring the code compiles and runs correctly on both OpenSSL 2.x and 3.x.