### PR TITLE
Add Flowtriq webhook media type

### DIFF
--- a/templates/media/flowtriq/README.md
+++ b/templates/media/flowtriq/README.md
@@ -1,0 +1,123 @@
+# Flowtriq webhook
+
+## Overview
+
+This guide describes how to integrate your Zabbix installation with [Flowtriq](https://flowtriq.com) using the Zabbix webhook feature, providing instructions on setting up a media type, user, and action in Zabbix.
+
+Flowtriq is a DDoS detection and traffic analytics platform. This integration forwards Zabbix alerts to a Flowtriq webhook endpoint, allowing you to correlate infrastructure alerts with network traffic data.
+
+## Requirements
+
+Zabbix version: 8.0 and higher.
+
+## Parameters
+
+After importing the webhook, you can configure it using webhook parameters.
+
+### Configurable parameters
+
+The configurable parameters are intended to be changed according to the webhook setup as well as the user's preferences and environment.
+
+|Name|Value|Description|
+|----|-----|-----------|
+|flowtriq\_url|\<PLACE WEBHOOK URL\>|The URL of your Flowtriq webhook endpoint.|
+|flowtriq\_api\_key|\<PLACE API KEY\>|Your Flowtriq API key for authentication.|
+|zabbix\_url|\{$ZABBIX\.URL\}|The URL of the Zabbix frontend.|
+
+### Internal parameters
+
+Internal parameters are reserved for predefined macros that are not meant to be changed.
+
+|Name|Value|Description|
+|----|-----|-----------|
+|event\_source|\{EVENT\.SOURCE\}|Numeric value of the event source. Possible values: 0 - Trigger, 1 - Discovery, 2 - Autoregistration, 3 - Internal, 4 - Service.|
+|event\_value|\{EVENT\.VALUE\}|Numeric value of the event that triggered an action (1 for problem, 0 for recovering).|
+|event\_nseverity|\{EVENT\.NSEVERITY\}|Numeric value of the event severity. Possible values: 0 - Not classified, 1 - Information, 2 - Warning, 3 - Average, 4 - High, 5 - Disaster.|
+|event\_severity|\{EVENT\.SEVERITY\}|Name of the event severity.|
+|event\_update\_nseverity|\{EVENT\.UPDATE\.NSEVERITY\}|Numeric value of the event update severity. Possible values: 0 - Not classified, 1 - Information, 2 - Warning, 3 - Average, 4 - High, 5 - Disaster.|
+|event\_update\_severity|\{EVENT\.UPDATE\.SEVERITY\}|Name of the event update severity.|
+|event\_update\_status|\{EVENT\.UPDATE\.STATUS\}|Numeric value of the problem update status. Possible values: 0 - Webhook was called because of problem/recovery event, 1 - Update operation.|
+|alert\_subject|\{ALERT\.SUBJECT\}|'Default subject' value from action configuration.|
+|alert\_message|\{ALERT\.MESSAGE\}|'Default message' value from action configuration.|
+|event\_id|\{EVENT\.ID\}|Numeric ID of the event that triggered an action.|
+|trigger\_id|\{TRIGGER\.ID\}|Numeric ID of the trigger of this action.|
+|trigger\_name|\{TRIGGER\.NAME\}|Name of the trigger.|
+|trigger\_description|\{TRIGGER\.DESCRIPTION\}|Description of the trigger.|
+|host\_name|\{HOST\.NAME\}|Name of the host.|
+|host\_ip|\{HOST\.IP\}|IP address of the host.|
+
+> Please be aware that each webhook supports an HTTP proxy. To use this feature, add a new media type parameter with the name `http_proxy` and set its value to the proxy URL.
+
+## Webhook payload
+
+The webhook sends a JSON payload to your Flowtriq endpoint with the following structure:
+
+```json
+{
+  "source": "zabbix",
+  "subject": "Problem: High CPU usage",
+  "message": "Problem started at 14:30:00 on 2024-01-15...",
+  "severity": "high",
+  "severity_name": "High",
+  "event_type": "problem",
+  "host": {
+    "name": "web-server-01",
+    "ip": "10.0.0.5"
+  },
+  "trigger": {
+    "name": "CPU usage is too high",
+    "description": "CPU usage has exceeded 90% for 5 minutes"
+  },
+  "event_id": "12345",
+  "event_url": "https://zabbix.example.com/tr_events.php?triggerid=100&eventid=12345",
+  "zabbix_url": "https://zabbix.example.com"
+}
+```
+
+The `event_type` field will be one of: `problem`, `resolve`, `update`, `discovery`, or `autoregistration`.
+
+## Flowtriq configuration
+
+1. Log in to your Flowtriq dashboard at [https://flowtriq.com](https://flowtriq.com).
+
+2. Navigate to your webhook settings and create a new webhook endpoint (or use an existing one). Copy the webhook URL.
+
+3. Copy your API key from the Flowtriq dashboard.
+
+## Zabbix configuration
+
+1. Before you can start using the Flowtriq webhook, you need to set up the global macro `{$ZABBIX.URL}`:
+  - In the Zabbix web interface, go to *Administration* > *Macros* in the top-left dropdown menu.
+  - Set up the global macro `{$ZABBIX.URL}` which will contain the URL to the Zabbix frontend. The URL should be either an IP address, a fully qualified domain name, or a localhost.
+  - Specifying a protocol is mandatory, whereas the port is optional. Good examples:
+    - `http://zabbix.com`
+    - `https://zabbix.lan/zabbix`
+    - `http://server.zabbix.lan/`
+    - `http://localhost`
+    - `http://127.0.0.1:8080`
+  - Bad examples:
+    - `zabbix.com`
+    - `http://zabbix/`
+
+2. Import the media type:
+  - In the *Alerts* > *Media types* section, import the [`media_flowtriq.yaml`](media_flowtriq.yaml) file.
+
+3. Configure the media type parameters:
+  - Open the imported **Flowtriq** media type.
+  - Set the `flowtriq_url` parameter to your Flowtriq webhook endpoint URL.
+  - Set the `flowtriq_api_key` parameter to your Flowtriq API key.
+
+4. Create a Zabbix user and add media:
+  - If you want to create a new user, go to the *Users* > *Users* section and click the *Create user* button in the top-right corner. In the *User* tab, fill in all the required fields (marked with red asterisks).
+  - In the *Media* tab, add a new media and select **Flowtriq** from the *Type* drop-down list.
+  - Make sure this user has access to all the hosts for which you would like problem notifications to be sent to Flowtriq.
+
+5. Done! You can now start using this media type in actions and receive alerts in Flowtriq.
+
+For more information, please see [Zabbix](https://www.zabbix.com/documentation/8.0/manual/config/notifications) and [Flowtriq](https://flowtriq.com) documentation.
+
+## Feedback
+
+Please report any issues with the media type at [`https://support.zabbix.com`](https://support.zabbix.com).
+
+You can also provide feedback, discuss the media type, or ask for help at [`ZABBIX forums`](https://www.zabbix.com/forum/zabbix-suggestions-and-feedback).

--- a/templates/media/flowtriq/media_flowtriq.yaml
+++ b/templates/media/flowtriq/media_flowtriq.yaml
@@ -1,0 +1,674 @@
+zabbix_export:
+  version: '8.0'
+  media_types:
+    - name: Flowtriq
+      type: WEBHOOK
+      parameters:
+        - name: alert_message
+          value: '{ALERT.MESSAGE}'
+        - name: alert_subject
+          value: '{ALERT.SUBJECT}'
+        - name: event_id
+          value: '{EVENT.ID}'
+        - name: event_nseverity
+          value: '{EVENT.NSEVERITY}'
+        - name: event_severity
+          value: '{EVENT.SEVERITY}'
+        - name: event_source
+          value: '{EVENT.SOURCE}'
+        - name: event_update_nseverity
+          value: '{EVENT.UPDATE.NSEVERITY}'
+        - name: event_update_severity
+          value: '{EVENT.UPDATE.SEVERITY}'
+        - name: event_update_status
+          value: '{EVENT.UPDATE.STATUS}'
+        - name: event_value
+          value: '{EVENT.VALUE}'
+        - name: flowtriq_api_key
+          value: '<PLACE API KEY>'
+        - name: flowtriq_url
+          value: '<PLACE WEBHOOK URL>'
+        - name: host_ip
+          value: '{HOST.IP}'
+        - name: host_name
+          value: '{HOST.NAME}'
+        - name: trigger_description
+          value: '{TRIGGER.DESCRIPTION}'
+        - name: trigger_id
+          value: '{TRIGGER.ID}'
+        - name: trigger_name
+          value: '{TRIGGER.NAME}'
+        - name: zabbix_url
+          value: '{$ZABBIX.URL}'
+      status: DISABLED
+      script: |
+        const CLogger = function(serviceName) {
+        	this.serviceName = serviceName;
+        	this.INFO = 4
+        	this.WARN = 3
+        	this.ERROR = 2
+        	this.log = function(level, msg) {
+        		Zabbix.log(level, '[' + this.serviceName + '] ' + msg);
+        	}
+        }
+
+        const CWebhook = function(value) {
+        	try {
+        		params = JSON.parse(value);
+
+        		if (['0', '1', '2', '3', '4'].indexOf(params.event_source) === -1) {
+        			throw 'Incorrect "event_source" parameter given: ' + params.event_source + '.\nMust be 0-4.';
+        		}
+
+        		if (['0', '3', '4'].indexOf(params.event_source) !== -1 && ['0', '1'].indexOf(params.event_value) === -1) {
+        			throw 'Incorrect "event_value" parameter given: ' + params.event_value + '.\nMust be 0 or 1.';
+        		}
+
+        		if (['0', '3', '4'].indexOf(params.event_source) !== -1) {
+        			if (params.event_source === '1' && ['0', '1', '2', '3'].indexOf(params.event_value) === -1) {
+        				throw 'Incorrect "event_value" parameter given: ' + params.event_value + '.\nMust be 0-3.';
+        			}
+
+        			if (params.event_source === '0' && ['0', '1'].indexOf(params.event_update_status) === -1) {
+        				throw 'Incorrect "event_update_status" parameter given: ' + params.event_update_status + '.\nMust be 0 or 1.';
+        			}
+
+        			if (params.event_source === '4') {
+        				if (['0', '1', '2', '3', '4', '5'].indexOf(params.event_update_nseverity) !== -1 && params.event_update_nseverity != params.event_nseverity) {
+        					params.event_nseverity = params.event_update_nseverity;
+        					params.event_severity = params.event_update_severity;
+        					params.event_update_status = '1';
+        				}
+        			}
+        		}
+
+        		this.runCallback = function(name, params) {
+        			if (typeof this[name] === 'function') {
+        				return this[name].apply(this, [params]);
+        			}
+        		}
+
+        		this.handleEvent = function(source, event) {
+        			const alert = { source: source, event: event };
+        			return [
+        				this.runCallback('on' + source + event, alert),
+        				this.runCallback('on' + event, alert),
+        				this.runCallback('onEvent', alert)
+        			];
+        		}
+
+        		this.handleEventless = function(source) {
+        			const alert = { source: source, event: null };
+        			return [
+        				this.runCallback('on' + source, alert),
+        				this.runCallback('onEvent', alert)
+        			];
+        		}
+
+        		this.run = function() {
+        			var results = [];
+        			if (typeof this.httpProxy === 'string' && this.httpProxy.trim() !== '') {
+        				this.request.setProxy(this.httpProxy);
+        			}
+        			const types = { '0': 'Trigger', '1': 'Discovery', '2': 'Autoreg', '3': 'Internal', '4': 'Service' };
+
+        			if (['0', '3', '4'].indexOf(this.params.event_source) !== -1) {
+        				var event = (this.params.event_update_status === '1')
+        					? 'Update'
+        					: ((this.params.event_value === '1') ? 'Problem' : 'Resolve');
+
+        				results = this.handleEvent(types[this.params.event_source], event);
+        			}
+        			else if (typeof types[this.params.event_source] !== 'undefined') {
+        				results = this.handleEventless(types[this.params.event_source]);
+        			}
+        			else {
+        				throw 'Unexpected "event_source": ' + this.params.event_source;
+        			}
+
+        			for (idx in results) {
+        				if (typeof results[idx] !== 'undefined') {
+        					return JSON.stringify(results[idx]);
+        				}
+        			}
+        		}
+        		this.httpProxy = params.http_proxy;
+        		this.params = params;
+        		this.runCallback('onCheckParams', {});
+        	} catch (error) {
+        		throw 'Webhook processing failed: ' + error;
+        	}
+        }
+
+        const CParamValidator = {
+
+        	isType: function(value, type) {
+        		if (type === 'array') {
+        			return Array.isArray(value);
+        		}
+        		if (type === 'integer') {
+        			return CParamValidator.isInteger(value);
+        		}
+        		if (type === 'float') {
+        			return CParamValidator.isFloat(value);
+        		}
+
+        		return (typeof value === type);
+        	},
+
+        	isInteger: function(value) {
+        		if (!CParamValidator.ifMatch(value, /^-?\d+$/)) {
+        			return false;
+        		}
+
+        		return !isNaN(parseInt(value));
+        	},
+
+        	isFloat: function(value) {
+        		if (!CParamValidator.ifMatch(value, /^-?\d+\.\d+$/)) {
+        			return false;
+        		}
+
+        		return !isNaN(parseFloat(value));
+        	},
+
+        	isDefined: function(value) {
+        		return !CParamValidator.isType(value, 'undefined');
+        	},
+
+        	isEmpty: function(value) {
+        		if (!CParamValidator.isType(value, 'string')) {
+        			throw 'Value "' + value + '" must be a string to be checked for emptiness.';
+        		}
+
+        		return (value.trim() === '');
+        	},
+
+        	isMacroSet: function(value, macro) {
+        		if (CParamValidator.isDefined(macro)) {
+        			return !(CParamValidator.ifMatch(value, '^\{' + macro + '\}$'))
+        		}
+
+        		return !(CParamValidator.ifMatch(value, '^\{[$#]{0,1}[A-Z_\.]+[\:]{0,1}["]{0,1}.*["]{0,1}\}$') || value === '*UNKNOWN*')
+        	},
+
+        	withinRange: function(value, min, max) {
+        		if (!CParamValidator.isType(value, 'number')) {
+        			throw 'Value "' + value + '" must be a number to be checked for range.';
+        		}
+        		if (value < ((CParamValidator.isDefined(min)) ? min : value)
+        			|| value > ((CParamValidator.isDefined(max)) ? max : value)) {
+        			return false;
+        		}
+
+        		return true;
+        	},
+
+        	inArray: function(value, array) {
+        		if (!CParamValidator.isType(array, 'array')) {
+        			throw 'The array must be an array to check the value for existing in it.';
+        		}
+
+        		return (array.indexOf((typeof value === 'string') ? value.toLowerCase() : value) !== -1);
+        	},
+
+        	ifMatch: function(value, regex) {
+        		return (new RegExp(regex)).test(value);
+        	},
+
+        	match: function(value, regex) {
+        		if (!CParamValidator.isType(value, 'string')) {
+        			throw 'Value "' + value + '" must be a string to be matched with the regular expression.';
+        		}
+
+        		return value.match(new RegExp(regex));
+        	},
+
+        	checkURL: function(value) {
+        		if (CParamValidator.isEmpty(value)) {
+        			throw 'URL value "' + value + '" must be a non-empty string.';
+        		}
+        		if (!CParamValidator.ifMatch(value, '^(http|https):\/\/.+')) {
+        			throw 'URL value "' + value + '" must contain a schema.';
+        		}
+
+        		return value.endsWith('/') ? value.slice(0, -1) : value;
+        	},
+
+        	check: function(key, rule, params) {
+        		if (!CParamValidator.isDefined(rule.type)) {
+        			throw 'Mandatory attribute "type" has not been defined for parameter "' + key + '".';
+        		}
+        		if (!CParamValidator.isDefined(params[key])) {
+        			throw 'Checked parameter "' + key + '" was not found in the list of input parameters.';
+        		}
+        		var value = params[key],
+        			error_message = null;
+        		switch (rule.type) {
+        			case 'string':
+        				if (!CParamValidator.isType(value, 'string')) {
+        					throw 'Value "' + key + '" must be a string.';
+        				}
+        				if (CParamValidator.isEmpty(value)) {
+        					error_message = 'Value "' + key + '" must be a non-empty string';
+        					break;
+        				}
+        				if (CParamValidator.isDefined(rule.len) && value.length < rule.len) {
+        					error_message = 'Value "' + key + '" must be a string with a length > ' + rule.len;
+        				}
+        				if (CParamValidator.isDefined(rule.regex) && !CParamValidator.ifMatch(value, rule.regex)) {
+        					error_message = 'Value "' + key + '" must match the regular expression "' + rule.regex + '"';
+        				}
+        				if (CParamValidator.isDefined(rule.url) && rule.url === true) {
+        					value = CParamValidator.checkURL(value);
+        				}
+        				break;
+        			case 'integer':
+        				if (!CParamValidator.isInteger(value)) {
+        					error_message = 'Value "' + key + '" must be an integer';
+        					break;
+        				}
+        				value = parseInt(value);
+        				break;
+        			case 'float':
+        				if (!CParamValidator.isFloat(value)) {
+        					error_message = 'Value "' + key + '" must be a floating-point number';
+        					break;
+        				}
+        				value = parseFloat(value);
+        				break;
+        			case 'boolean':
+        				if (CParamValidator.inArray(value, ['1', 'true', 'yes', 'on'])) {
+        					value = true;
+        				}
+        				else if (CParamValidator.inArray(value, ['0', 'false', 'no', 'off'])) {
+        					value = false;
+        				}
+        				else {
+        					error_message = 'Value "' + key + '" must be a boolean-like.';
+        				}
+        				break;
+        			case 'array':
+        				try {
+        					value = JSON.parse(value);
+        				} catch (error) {
+        					throw 'Value "' + key + '" contains invalid JSON.';
+        				}
+        				if (!CParamValidator.isType(value, 'array')) {
+        					error_message = 'Value "' + key + '" must be an array.';
+        				}
+        				if (CParamValidator.isDefined(rule.tags) && rule.tags === true) {
+        					value = value.reduce(function(acc, obj) {
+        						acc[obj.tag] = obj.value || null;
+        						return acc;
+        					}, {});
+        				}
+        				break;
+        			case 'object':
+        				value = JSON.parse(value);
+        				if (!CParamValidator.isType(value, 'object')) {
+        					error_message = 'Value "' + key + '" must be an object.';
+        				}
+        				break;
+        			default:
+        				throw 'Unexpected attribute type "' + rule.type + '" for value "' + key + '". Available: ' +
+        				['integer', 'float', 'string', 'boolean', 'array', 'object'].join(', ');
+        		}
+        		params[key] = value;
+        		if (CParamValidator.inArray(rule.type, ['integer', 'float']) && error_message === null && (CParamValidator.isDefined(rule.min)
+        			|| CParamValidator.isDefined(rule.max)) && !CParamValidator.withinRange(value, rule.min, rule.max)) {
+        			error_message = 'Value "' + key + '" must be a number ' + ((CParamValidator.isDefined(rule.min) && CParamValidator.isDefined(rule.max))
+        				? (rule.min + '..' + rule.max) : ((CParamValidator.isDefined(rule.min)) ? '>' + rule.min : '<' + rule.max));
+        		}
+        		else if (CParamValidator.isDefined(rule.array) && !CParamValidator.inArray(value, rule.array)) {
+        			error_message = 'Value "' + key + '" must be in the array ' + JSON.stringify(rule.array);
+        		}
+        		else if (CParamValidator.isDefined(rule.macro) && !CParamValidator.isMacroSet(value.toString(), rule.macro)) {
+        			error_message = 'The macro ' + ((CParamValidator.isDefined(rule.macro)) ? '{' + rule.macro + '} ' : ' ') + 'is not set';
+        		}
+        		if (error_message !== null) {
+        			if (CParamValidator.isDefined(rule.default) && CParamValidator.isType(rule.default, rule.type)) {
+        				params[key] = rule.default;
+        			}
+        			else {
+        				Zabbix.log(4, 'Default value for "' + key + '" must be a ' + rule.type + '. Skipped.');
+        				throw 'Incorrect value for variable "' + key + '". ' + error_message;
+        			}
+        		}
+
+        		return this;
+        	},
+
+        	validate: function(rules, params) {
+        		if (!CParamValidator.isType(params, 'object') || CParamValidator.isType(params, 'array')) {
+        			throw 'Incorrect parameters value. The value must be an object.';
+        		}
+        		for (var key in rules) {
+        			CParamValidator.check(key, rules[key], params);
+        		}
+        	}
+        }
+
+        const CHttpRequest = function(logger) {
+        	this.request = new HttpRequest();
+        	if (typeof logger !== 'object' || logger === null) {
+        		this.logger = Zabbix;
+        	}
+        	else {
+        		this.logger = logger;
+        	}
+
+        	this.clearHeader = function() {
+        		this.request.clearHeader();
+        	}
+
+        	this.addHeaders = function(value) {
+        		var headers = [];
+
+        		if (typeof value === 'object' && value !== null) {
+        			if (!Array.isArray(value)) {
+        				Object.keys(value).forEach(function(key) {
+        					headers.push(key + ': ' + value[key]);
+        				});
+        			}
+        			else {
+        				headers = value;
+        			}
+        		}
+        		else if (typeof value === 'string') {
+        			value.split('\r\n').forEach(function(header) {
+        				headers.push(header);
+        			});
+        		}
+
+        		for (var idx in headers) {
+        			this.request.addHeader(headers[idx]);
+        		}
+        	}
+
+        	this.setProxy = function(proxy) {
+        		this.request.setProxy(proxy);
+        	}
+
+        	this.plainRequest = function(method, url, data) {
+        		var resp = null;
+        		method = method.toLowerCase();
+        		this.logger.log(4, 'Sending ' + method + ' request:' + JSON.stringify(data));
+        		if (['get', 'post', 'put', 'patch', 'delete', 'trace'].indexOf(method) !== -1) {
+        			resp = this.request[method](url, data);
+        		}
+        		else if (['connect', 'head', 'options'].indexOf(method) !== -1) {
+        			resp = this.request[method](url);
+        		}
+        		else {
+        			throw 'Unexpected method. Method ' + method + ' is not supported.';
+        		}
+        		this.logger.log(4, 'Response has been received: ' + resp);
+
+        		return resp;
+        	}
+
+        	this.jsonRequest = function(method, url, data) {
+        		this.addHeaders('Content-Type: application/json');
+        		var resp = this.plainRequest(method, url, JSON.stringify(data));
+        		try {
+        			resp = JSON.parse(resp);
+        		}
+        		catch (error) {
+        			throw 'Failed to parse response: not well-formed JSON was received';
+        		}
+
+        		return resp;
+        	}
+
+        	this.getStatus = function() {
+        		return this.request.getStatus();
+        	}
+        }
+
+        const CWebhookHelper = {
+
+        	createProblemURL: function(event_source, zabbix_url, trigger_id, event_id) {
+        		if (event_source === '0') {
+        			return zabbix_url + '/tr_events.php?triggerid=' + trigger_id + '&eventid=' + event_id;
+        		} else if (event_source === '4') {
+        			return zabbix_url + '/zabbix.php?action=service.list';
+        		}
+
+        		return zabbix_url;
+        	},
+
+        };
+
+        var severityMapping = [
+        	'not_classified',
+        	'information',
+        	'warning',
+        	'average',
+        	'high',
+        	'disaster'
+        ],
+        	serviceLogName = 'Flowtriq Webhook',
+        	Logger = new CLogger(serviceLogName),
+        	Flowtriq = CWebhook;
+
+        Flowtriq.prototype.onCheckParams = function () {
+        	CParamValidator.validate({
+        		flowtriq_url: {type: 'string', url: true},
+        		flowtriq_api_key: {type: 'string'},
+        		alert_subject: {type: 'string'},
+        		alert_message: {type: 'string'},
+        		zabbix_url: {type: 'string', url: true},
+        		event_nseverity: {type: 'integer', min: 0, max: 5, default: 0},
+        		host_name: {type: 'string', default: ''},
+        		host_ip: {type: 'string', default: ''},
+        		trigger_name: {type: 'string', default: ''},
+        		trigger_description: {type: 'string', default: ''}
+        	}, this.params);
+
+        	if (this.params.event_source === '0') {
+        		CParamValidator.validate({
+        			trigger_id: {type: 'integer'},
+        			event_id: {type: 'integer'},
+        			event_update_status: {type: 'string', array: ['0', '1']}
+        		}, this.params);
+        	}
+
+        	this.data = {
+        		source: 'zabbix',
+        		subject: this.params.alert_subject,
+        		message: this.params.alert_message,
+        		severity: severityMapping[this.params.event_nseverity],
+        		severity_name: this.params.event_severity,
+        		host: {
+        			name: this.params.host_name,
+        			ip: this.params.host_ip
+        		},
+        		trigger: {
+        			name: this.params.trigger_name,
+        			description: this.params.trigger_description
+        		},
+        		event_id: String(this.params.event_id),
+        		zabbix_url: this.params.zabbix_url
+        	};
+        };
+
+        Flowtriq.prototype.sendRequest = function () {
+        	this.request.addHeaders({
+        		'X-API-Key': this.params.flowtriq_api_key
+        	});
+
+        	var response = this.request.jsonRequest('POST', this.params.flowtriq_url, this.data);
+
+        	if (this.request.getStatus() < 200 || this.request.getStatus() >= 300) {
+        		var errorMessage = 'Unknown error. HTTP status: ' + this.request.getStatus();
+
+        		if (CParamValidator.isType(response.error, 'string')) {
+        			errorMessage = response.error;
+        		}
+        		else if (CParamValidator.isType(response.message, 'string')) {
+        			errorMessage = response.message;
+        		}
+
+        		throw errorMessage;
+        	}
+
+        	return 'OK';
+        };
+
+        Flowtriq.prototype.onProblem = function (alert) {
+        	Logger.log(Logger.INFO, 'Source: ' + alert.source + '; Event: ' + alert.event);
+        	this.data.event_type = 'problem';
+
+        	if (CParamValidator.isDefined(alert.source) && alert.source === 'Trigger') {
+        		this.data.event_url = CWebhookHelper.createProblemURL(
+        			this.params.event_source, this.params.zabbix_url,
+        			this.params.trigger_id, this.params.event_id
+        		);
+        	}
+
+        	return this.sendRequest();
+        };
+
+        Flowtriq.prototype.onUpdate = function (alert) {
+        	Logger.log(Logger.INFO, 'Source: ' + alert.source + '; Event: ' + alert.event);
+        	this.data.event_type = 'update';
+
+        	return this.sendRequest();
+        };
+
+        Flowtriq.prototype.onResolve = function (alert) {
+        	Logger.log(Logger.INFO, 'Source: ' + alert.source + '; Event: ' + alert.event);
+        	this.data.event_type = 'resolve';
+
+        	return this.sendRequest();
+        };
+
+        Flowtriq.prototype.onDiscovery = function (alert) {
+        	Logger.log(Logger.INFO, 'Source: ' + alert.source + '; Event: ' + alert.event);
+        	this.data.event_type = 'discovery';
+
+        	return this.sendRequest();
+        };
+
+        Flowtriq.prototype.onAutoreg = function (alert) {
+        	Logger.log(Logger.INFO, 'Source: ' + alert.source + '; Event: ' + alert.event);
+        	this.data.event_type = 'autoregistration';
+
+        	return this.sendRequest();
+        };
+
+        try {
+        	var hook = new Flowtriq(value);
+        	hook.request = new CHttpRequest(Logger);
+        	return hook.run();
+        }
+        catch (error) {
+        	Logger.log(Logger.WARN, 'notification failed: ' + error);
+        	throw 'Sending failed: ' + error;
+        }
+      description: |
+        This media type integrates your Zabbix installation with Flowtriq (https://flowtriq.com), a DDoS detection and traffic analytics platform, using the Zabbix webhook feature.
+
+        Set the global macro {$ZABBIX.URL} with your Zabbix server URL.
+        Configure the "flowtriq_url" parameter with your Flowtriq webhook endpoint URL.
+        Configure the "flowtriq_api_key" parameter with your Flowtriq API key.
+      message_templates:
+        - event_source: TRIGGERS
+          operation_mode: PROBLEM
+          subject: 'Problem: {EVENT.NAME}'
+          message: |
+            Problem started at {EVENT.TIME} on {EVENT.DATE}
+            Problem name: {EVENT.NAME}
+            Host: {HOST.NAME}
+            Severity: {EVENT.SEVERITY}
+            Operational data: {EVENT.OPDATA}
+            Original problem ID: {EVENT.ID}
+            {TRIGGER.URL}
+        - event_source: TRIGGERS
+          operation_mode: RECOVERY
+          subject: 'Resolved in {EVENT.DURATION}: {EVENT.NAME}'
+          message: |
+            Problem has been resolved in {EVENT.DURATION} at {EVENT.RECOVERY.TIME} on {EVENT.RECOVERY.DATE}
+            Problem name: {EVENT.NAME}
+            Host: {HOST.NAME}
+            Severity: {EVENT.SEVERITY}
+            Original problem ID: {EVENT.ID}
+            {TRIGGER.URL}
+        - event_source: TRIGGERS
+          operation_mode: UPDATE
+          subject: 'Updated problem in {EVENT.AGE}: {EVENT.NAME}'
+          message: |
+            {USER.FULLNAME} {EVENT.UPDATE.ACTION} problem at {EVENT.UPDATE.DATE} {EVENT.UPDATE.TIME}.
+            {EVENT.UPDATE.MESSAGE}
+
+            Current problem status is {EVENT.STATUS}, age is {EVENT.AGE}, acknowledged: {EVENT.ACK.STATUS}.
+        - event_source: DISCOVERY
+          operation_mode: PROBLEM
+          subject: 'Discovery: {DISCOVERY.DEVICE.STATUS} {DISCOVERY.DEVICE.IPADDRESS}'
+          message: |
+            Discovery rule: {DISCOVERY.RULE.NAME}
+
+            Device IP: {DISCOVERY.DEVICE.IPADDRESS}
+            Device DNS: {DISCOVERY.DEVICE.DNS}
+            Device status: {DISCOVERY.DEVICE.STATUS}
+            Device uptime: {DISCOVERY.DEVICE.UPTIME}
+
+            Device service name: {DISCOVERY.SERVICE.NAME}
+            Device service port: {DISCOVERY.SERVICE.PORT}
+            Device service status: {DISCOVERY.SERVICE.STATUS}
+            Device service uptime: {DISCOVERY.SERVICE.UPTIME}
+        - event_source: AUTOREGISTRATION
+          operation_mode: PROBLEM
+          subject: 'Autoregistration: {HOST.HOST}'
+          message: |
+            Host name: {HOST.HOST}
+            Host IP: {HOST.IP}
+            Agent port: {HOST.PORT}
+        - event_source: INTERNAL
+          operation_mode: PROBLEM
+          subject: '[{EVENT.STATUS}] {EVENT.NAME}'
+          message: |
+            Problem started at {EVENT.TIME} on {EVENT.DATE}
+            Problem name: {EVENT.NAME}
+            Host: {HOST.NAME}
+            Original problem ID: {EVENT.ID}
+        - event_source: INTERNAL
+          operation_mode: RECOVERY
+          subject: '[{EVENT.STATUS}] {EVENT.NAME}'
+          message: |
+            Problem has been resolved in {EVENT.DURATION} at {EVENT.RECOVERY.TIME} on {EVENT.RECOVERY.DATE}
+            Problem name: {EVENT.NAME}
+            Host: {HOST.NAME}
+            Original problem ID: {EVENT.ID}
+        - event_source: SERVICE
+          operation_mode: PROBLEM
+          subject: 'Service "{SERVICE.NAME}" problem: {EVENT.NAME}'
+          message: |
+            Service problem started at {EVENT.TIME} on {EVENT.DATE}
+            Service problem name: {EVENT.NAME}
+            Service: {SERVICE.NAME}
+            Severity: {EVENT.SEVERITY}
+            Original problem ID: {EVENT.ID}
+            Service description: {SERVICE.DESCRIPTION}
+
+            {SERVICE.ROOTCAUSE}
+        - event_source: SERVICE
+          operation_mode: RECOVERY
+          subject: 'Service "{SERVICE.NAME}" resolved in {EVENT.DURATION}: {EVENT.NAME}'
+          message: |
+            Service "{SERVICE.NAME}" has been resolved at {EVENT.RECOVERY.TIME} on {EVENT.RECOVERY.DATE}
+            Problem name: {EVENT.NAME}
+            Problem duration: {EVENT.DURATION}
+            Severity: {EVENT.SEVERITY}
+            Original problem ID: {EVENT.ID}
+            Service description: {SERVICE.DESCRIPTION}
+        - event_source: SERVICE
+          operation_mode: UPDATE
+          subject: 'Changed "{SERVICE.NAME}" service status to {EVENT.UPDATE.SEVERITY} in {EVENT.AGE}'
+          message: |
+            Changed "{SERVICE.NAME}" service status to {EVENT.UPDATE.SEVERITY} at {EVENT.UPDATE.DATE} {EVENT.UPDATE.TIME}.
+            Current problem age is {EVENT.AGE}.
+            Service description: {SERVICE.DESCRIPTION}
+
+            {SERVICE.ROOTCAUSE}


### PR DESCRIPTION
## Summary

- Adds a webhook media type template for [Flowtriq](https://flowtriq.com), a DDoS detection and traffic analytics platform
- Posts Zabbix alerts (problems, recoveries, updates, discovery, autoregistration, service events) to a configurable Flowtriq webhook endpoint as structured JSON
- Supports API key authentication via `X-API-Key` header
- Follows the same CWebhook/CLogger/CParamValidator/CHttpRequest pattern used by existing media types (PagerDuty, Discord, etc.)

## Payload

The webhook sends a JSON payload containing:
- `source` ("zabbix"), `subject`, `message`, `severity`, `event_type`
- `host` object with name and IP
- `trigger` object with name and description
- `event_id`, `event_url`, `zabbix_url`

## Files

- `templates/media/flowtriq/media_flowtriq.yaml` - Media type template
- `templates/media/flowtriq/README.md` - Setup documentation

## Test plan

- [ ] Import `media_flowtriq.yaml` into a Zabbix 8.0 instance via Alerts > Media types
- [ ] Configure `flowtriq_url` and `flowtriq_api_key` parameters
- [ ] Assign the media type to a user and create an action
- [ ] Trigger a test alert and verify the JSON payload arrives at the Flowtriq endpoint
- [ ] Verify recovery and update events are also forwarded correctly