### PR TITLE
Add compression support to agent active checks

### DIFF
--- a/ChangeLog.d/feature/ZBXNEXT-10703
+++ b/ChangeLog.d/feature/ZBXNEXT-10703
@@ -1,0 +1,1 @@
+...GI..... [ZBXNEXT-10703] added active checks compression to Zabbix agent and made zlib a build dependency (gpesin)

--- a/conf/zabbix_agentd.conf
+++ b/conf/zabbix_agentd.conf
@@ -199,6 +199,17 @@ Server=127.0.0.1
 
 ServerActive=127.0.0.1
 
+### Option: EnableCompression
+#	Enables compression for communications related to active checks.
+#	Zabbix server or proxy version 4.0 or later is required.
+#	0 - disable
+#	1 - enable
+#
+# Mandatory: no
+# Range: 0-1
+# Default:
+# EnableCompression=1
+
 ### Option: Hostname
 #	List of comma delimited unique, case sensitive hostnames.
 #	Required for active checks and must match hostnames as configured on the server.

--- a/configure.ac
+++ b/configure.ac
@@ -1511,6 +1511,16 @@ if test "x$ipv6" = "xyes"; then
 	have_ipv6="yes"
 fi
 
+if test "x$server" = "xyes" || test "x$proxy" = "xyes" || test "x$agent" = "xyes"; then
+	dnl Check for zlib, used by communications
+	ZLIB_CHECK_CONFIG([no])
+	if test "x$found_zlib" != "xyes"; then
+		AC_MSG_ERROR([Unable to use zlib (zlib check failed)])
+	fi
+
+	AC_SUBST(ZLIB_CFLAGS)
+fi
+
 if test "x$server" = "xyes" || test "x$proxy" = "xyes"; then
 
 
@@ -1731,14 +1741,6 @@ if test "x$server" = "xyes" || test "x$proxy" = "xyes"; then
 	PROXY_LIBS="$PROXY_LIBS $OPENIPMI_LIBS"
 
 	AC_SUBST(OPENIPMI_CFLAGS)
-
-	dnl Check for zlib, used by Zabbix server-proxy communications
-	ZLIB_CHECK_CONFIG([no])
-	if test "x$found_zlib" != "xyes"; then
-		AC_MSG_ERROR([Unable to use zlib (zlib check failed)])
-	fi
-
-	AC_SUBST(ZLIB_CFLAGS)
 
 	dnl Check for 'libpthread' library that supports PTHREAD_PROCESS_SHARED flag
 	LIBPTHREAD_CHECK_CONFIG([no])

--- a/include/zbxcommshigh.h
+++ b/include/zbxcommshigh.h
@@ -49,7 +49,8 @@ int	zbx_parse_redirect_response(struct zbx_json_parse *jp, char **host, unsigned
 
 int	zbx_comms_exchange_with_redirect(const char *source_ip, zbx_vector_addr_ptr_t *addrs, int timeout,
 		int connect_timeout, int retry_interval, int loglevel, const zbx_config_tls_t *config_tls,
-		const char *data, char *(*connect_callback)(void *), void *cb_data, char **out, char **error);
+		unsigned char protocol, const char *data, char *(*connect_callback)(void *), void *cb_data, char **out,
+		char **error);
 
 void	zbx_addrs_failover(zbx_vector_addr_ptr_t *addrs);
 

--- a/src/libs/zbxcommshigh/commshigh.c
+++ b/src/libs/zbxcommshigh/commshigh.c
@@ -558,11 +558,11 @@ static int	comms_check_redirect(const char *data, zbx_vector_addr_ptr_t *addrs)
  *                                                                            *
  ******************************************************************************/
 static int	zbx_comms_exchange_data(zbx_socket_t *sock, const char *data, zbx_addr_t *addr,
-		char **out, char **error)
+		unsigned char protocol, char **out, char **error)
 {
 	zabbix_log(LOG_LEVEL_DEBUG, "sending to [%s]:%d: %s", addr->ip, addr->port, data);
 
-	if (SUCCEED != zbx_tcp_send(sock, data))
+	if (SUCCEED != zbx_tcp_send_ext(sock, data, strlen(data), 0, protocol, 0))
 	{
 		zabbix_log(LOG_LEVEL_DEBUG, "unable to send to [%s]:%d: %s",
 					addr->ip, addr->port, zbx_socket_strerror());
@@ -618,7 +618,8 @@ static int	zbx_comms_exchange_data(zbx_socket_t *sock, const char *data, zbx_add
  ******************************************************************************/
 int	zbx_comms_exchange_with_redirect(const char *source_ip, zbx_vector_addr_ptr_t *addrs, int timeout,
 		int connect_timeout, int retry_interval, int loglevel, const zbx_config_tls_t *config_tls,
-		const char *data, char *(*connect_callback)(void *), void *cb_data, char **out, char **error)
+		unsigned char protocol, const char *data, char *(*connect_callback)(void *), void *cb_data, char **out,
+		char **error)
 {
 	zbx_socket_t		sock;
 	int			conn_ret, ret = FAIL, retries = 0;
@@ -645,7 +646,7 @@ int	zbx_comms_exchange_with_redirect(const char *source_ip, zbx_vector_addr_ptr_
 		if (NULL != connect_callback)
 			data = connect_callback(cb_data);
 
-		if (SUCCEED == (ret = zbx_comms_exchange_data(&sock, data, addrs->values[0], out, error)))
+		if (SUCCEED == (ret = zbx_comms_exchange_data(&sock, data, addrs->values[0], protocol, out, error)))
 		{
 			if (ZBX_REDIRECT_FAIL != (conn_ret = comms_check_redirect(sock.buffer, addrs)))
 			{
@@ -744,4 +745,3 @@ char	*zbx_sanitize_proxyconfig_json(char *jbuffer)
 
 	return NULL;
 }
-

--- a/src/zabbix_agent/active_checks/active_checks.c
+++ b/src/zabbix_agent/active_checks/active_checks.c
@@ -101,6 +101,7 @@ static ZBX_THREAD_LOCAL zbx_hashset_t			commands_hash;
 static ZBX_THREAD_LOCAL zbx_vector_expression_t		regexps;
 static ZBX_THREAD_LOCAL char				*session_token;
 static ZBX_THREAD_LOCAL zbx_uint64_t			last_valueid = 0;
+static ZBX_THREAD_LOCAL unsigned char			active_comms_protocol = ZBX_TCP_PROTOCOL;
 static ZBX_THREAD_LOCAL zbx_vector_pre_persistent_t	pre_persistent_vec;	/* used for staging of data going */
 										/* into persistent files */
 /* used for deleting inactive persistent files */
@@ -942,7 +943,7 @@ static int	refresh_active_checks(zbx_vector_addr_ptr_t *addrs, const zbx_config_
 	level = SUCCEED != last_ret ? LOG_LEVEL_DEBUG : LOG_LEVEL_WARNING;
 
 	ret = zbx_comms_exchange_with_redirect(config_source_ip, addrs, config_timeout, config_timeout, 0, level,
-			config_tls, json.buffer, NULL, NULL, &data, NULL);
+			config_tls, active_comms_protocol, json.buffer, NULL, NULL, &data, NULL);
 
 	if (SUCCEED == ret && '\0' == *data)
 	{
@@ -1268,7 +1269,8 @@ static int	send_buffer(zbx_vector_addr_ptr_t *addrs, zbx_vector_pre_persistent_t
 	level = 0 == buffer.first_error ? LOG_LEVEL_WARNING : LOG_LEVEL_DEBUG;
 
 	ret = zbx_comms_exchange_with_redirect(config_source_ip, addrs, MIN(buffer.count * config_timeout, 60),
-			config_timeout, 0, level, config_tls, json.buffer, connect_callback, &json, &data, NULL);
+			config_timeout, 0, level, config_tls, active_comms_protocol, json.buffer, connect_callback, &json,
+			&data, NULL);
 
 	if (SUCCEED == ret)
 	{
@@ -1898,7 +1900,7 @@ static void	send_heartbeat_msg(zbx_vector_addr_ptr_t *addrs, const zbx_config_tl
 	level = SUCCEED != last_ret ? LOG_LEVEL_DEBUG : LOG_LEVEL_WARNING;
 
 	ret = zbx_comms_exchange_with_redirect(config_source_ip, addrs, config_timeout, config_timeout, 0, level,
-			config_tls, json.buffer, NULL, NULL, NULL, &error);
+			config_tls, active_comms_protocol, json.buffer, NULL, NULL, NULL, &error);
 
 	if (SUCCEED == ret)
 	{
@@ -1935,6 +1937,9 @@ ZBX_THREAD_ENTRY(active_checks_thread, args)
 					process_num = ((zbx_thread_args_t *)args)->info.process_num;
 
 	activechks_args_in = (zbx_thread_activechk_args *)((((zbx_thread_args_t *)args))->args);
+	active_comms_protocol = ZBX_TCP_PROTOCOL;
+	if (0 != activechks_args_in->config_enable_compression)
+		active_comms_protocol |= ZBX_TCP_COMPRESS;
 
 	zabbix_log(LOG_LEVEL_INFORMATION, "%s #%d started [%s #%d]", get_program_type_string(info->program_type),
 			server_num, get_process_type_string(process_type), process_num);

--- a/src/zabbix_agent/active_checks/active_checks.h
+++ b/src/zabbix_agent/active_checks/active_checks.h
@@ -34,6 +34,7 @@ typedef struct
 	const char		*config_hostname;
 	const char		*config_host_metadata;
 	const char		*config_host_metadata_item;
+	int			config_enable_compression;
 	int			config_heartbeat_frequency;
 	const char		*config_host_interface;
 	const char		*config_host_interface_item;

--- a/src/zabbix_agent/zabbix_agentd.c
+++ b/src/zabbix_agent/zabbix_agentd.c
@@ -45,6 +45,7 @@ ZBX_GET_CONFIG_VAR(int, zbx_config_unsafe_user_parameters, 0)
 static int	zbx_config_listen_port = ZBX_DEFAULT_AGENT_PORT;
 static char	*zbx_config_listen_ip = NULL;
 static int	zbx_config_refresh_active_checks = 5;
+static int	zbx_config_enable_compression = 1;
 ZBX_GET_CONFIG_VAR2(char*, const char *, zbx_config_source_ip, NULL)
 static int	config_log_level = LOG_LEVEL_WARNING;
 static int	zbx_config_buffer_size = 100;
@@ -845,6 +846,7 @@ static int	add_serveractive_host_agent_cb(const zbx_vector_addr_ptr_t *addrs, zb
 				0 < hostnames->values_num ? hostnames->values[i] : "");
 		config_active_args[forks].config_host_metadata = zbx_config_host_metadata;
 		config_active_args[forks].config_host_metadata_item = zbx_config_host_metadata_item;
+		config_active_args[forks].config_enable_compression = zbx_config_enable_compression;
 		config_active_args[forks].config_heartbeat_frequency = zbx_config_heartbeat_frequency;
 		config_active_args[forks].config_host_interface = zbx_config_host_interface;
 		config_active_args[forks].config_host_interface_item = zbx_config_host_interface_item;
@@ -944,6 +946,8 @@ static void	zbx_load_config(int requirement, ZBX_TASK_EX *task)
 				ZBX_CONF_PARM_OPT,	0,			0},
 		{"ServerActive",		&active_hosts,				ZBX_CFG_TYPE_STRING_LIST,
 				ZBX_CONF_PARM_OPT,	0,			0},
+		{"EnableCompression",		&zbx_config_enable_compression,		ZBX_CFG_TYPE_INT,
+				ZBX_CONF_PARM_OPT,	0,			1},
 		{"Hostname",			&zbx_config_hostnames,			ZBX_CFG_TYPE_STRING_LIST,
 				ZBX_CONF_PARM_OPT,	0,			0},
 		{"HostnameItem",		&config_hostname_item,			ZBX_CFG_TYPE_STRING,

--- a/src/zabbix_sender/win32/zabbix_sender.c
+++ b/src/zabbix_sender/win32/zabbix_sender.c
@@ -102,7 +102,7 @@ int	zabbix_sender_send_values(const char *address, unsigned short port, const ch
 	config_tls.connect_mode = ZBX_TCP_SEC_UNENCRYPTED;
 
 	ret = zbx_comms_exchange_with_redirect(source, &zbx_addrs, GET_SENDER_TIMEOUT, 30, 0, 0, &config_tls,
-			json.buffer, NULL, NULL, result, NULL);
+			ZBX_TCP_PROTOCOL, json.buffer, NULL, NULL, result, NULL);
 
 	if (SUCCEED != ret && NULL != result)
 		*result = zbx_strdup(NULL, zbx_socket_strerror());

--- a/src/zabbix_sender/zabbix_sender.c
+++ b/src/zabbix_sender/zabbix_sender.c
@@ -648,8 +648,8 @@ static	ZBX_THREAD_ENTRY(send_value, args)
 #endif
 
 	ret = zbx_comms_exchange_with_redirect(config_source_ip, sendval_args->addrs, CONFIG_SENDER_TIMEOUT,
-			config_timeout, 0, LOG_LEVEL_DEBUG, sendval_args->zbx_config_tls, sendval_args->json->buffer,
-			connect_callback, sendval_args->json, &data, NULL);
+			config_timeout, 0, LOG_LEVEL_DEBUG, sendval_args->zbx_config_tls, ZBX_TCP_PROTOCOL,
+			sendval_args->json->buffer, connect_callback, sendval_args->json, &data, NULL);
 
 
 	if (SUCCEED == ret)


### PR DESCRIPTION
## Summary

- compress active check requests, values and heartbeats sent by the classic Zabbix agent
- add the `EnableCompression` configuration option, enabled by default
- allow disabling compression when connecting to a server or proxy older than 4.0
- require zlib for agent-only builds as well as server and proxy builds
- keep `zabbix_sender` behavior unchanged

## Motivation

The classic agent currently always sends active check traffic without the `ZBX_TCP_COMPRESS` protocol flag, even though current servers and proxies can receive compressed payloads. This is particularly noticeable on constrained or metered links.

The option defaults to enabled because the protocol has been supported since Zabbix 4.0. Setting `EnableCompression=0` preserves compatibility with older receivers.

This change also lets downstream distributions build the feature without carrying an implementation patch. The corresponding OpenWrt packaging work is tracked in openwrt/packages#29998.

## Testing

- built `zabbix_agentd` from current `master` with OpenSSL and zlib
- validated configurations with `EnableCompression=0` and `1`
- confirmed `EnableCompression=2` is rejected
- captured loopback active-check heartbeats:
  - disabled: protocol flags `0x01`, 115-byte payload
  - enabled: protocol flags `0x03`, 98-byte zlib payload expanding to 115 bytes
- verified the resulting agent links against `libz.so.1`
