### PR TITLE
Update condition for hostid check in operations.c

### DIFF
--- a/src/zabbix_server/operations/operations.c
+++ b/src/zabbix_server/operations/operations.c
@@ -419,7 +419,7 @@ static zbx_uint64_t	add_discovered_host(const zbx_db_event *event, int *status, 
 				zbx_db_free_result(result2);
 			}
 
-			if (0 == hostid)
+			if (0 == hostid && DOBJECT_STATUS_UP == atoi(row[17]))
 			{
 				zbx_db_result_t		result3;
 				zbx_db_row_t		row3;

--- a/src/zabbix_server/operations/operations.c
+++ b/src/zabbix_server/operations/operations.c
@@ -419,6 +419,10 @@ static zbx_uint64_t	add_discovered_host(const zbx_db_event *event, int *status, 
 				zbx_db_free_result(result2);
 			}
 
+			/*
+			 * A DOWN discovery service may locate an existing host, but it must not be used to create a
+			 * new monitored host.
+			 */
 			if (0 == hostid && DOBJECT_STATUS_UP == atoi(row[17]))
 			{
 				zbx_db_result_t		result3;


### PR DESCRIPTION
ZBX-28009 - Network discovery creates blank hosts for failed SNMP checks after upgrading from Zabbix 7.0.27 to 7.0.28