### PR TITLE
Expose running total of collected vps for monitoring against VPSLimit server configuration

### DIFF
--- a/include/zbxcacheconfig.h
+++ b/include/zbxcacheconfig.h
@@ -1373,6 +1373,7 @@ typedef struct
 	zbx_uint64_t	overcommit_limit;
 	zbx_uint64_t	overcommit;
 	zbx_uint64_t	values_limit;
+	zbx_uint64_t	collected_num;
 	zbx_uint64_t	written_num;
 }
 zbx_vps_monitor_stats_t;

--- a/src/libs/zbxcacheconfig/vps_monitor.c
+++ b/src/libs/zbxcacheconfig/vps_monitor.c
@@ -75,44 +75,44 @@ void	zbx_vps_monitor_add_collected(zbx_uint64_t values_num)
 	zbx_vps_monitor_t	*monitor = &(get_dc_config())->vps_monitor;
 	time_t			now;
 
-	if (0 == monitor->values_limit)
-		return;
-
 	now = time(NULL);
 
 	zbx_mutex_lock(vps_lock);
 
-	if (ZBX_VPS_FLUSH_PERIOD <= now - monitor->last_flush)
-	{
-		if (monitor->values_limit > monitor->values_num)
+	if (0 != monitor->values_limit) {
+		if (ZBX_VPS_FLUSH_PERIOD <= now - monitor->last_flush)
 		{
-			if (monitor->overcommit > monitor->values_limit - monitor->values_num)
-				monitor->overcommit -= monitor->values_limit - monitor->values_num;
-			else
-				monitor->overcommit = 0;
-
-			monitor->values_num = 0;
-		}
-		else
-		{
-			zbx_uint64_t	overcommit_available = monitor->overcommit_limit - monitor->overcommit;
-
-			if (monitor->values_num <= monitor->values_limit + overcommit_available)
+			if (monitor->values_limit > monitor->values_num)
 			{
-				monitor->overcommit += monitor->values_num - monitor->values_limit;
+				if (monitor->overcommit > monitor->values_limit - monitor->values_num)
+					monitor->overcommit -= monitor->values_limit - monitor->values_num;
+				else
+					monitor->overcommit = 0;
+
 				monitor->values_num = 0;
 			}
 			else
 			{
-				monitor->values_num -= monitor->values_limit + overcommit_available;
-				monitor->overcommit = monitor->overcommit_limit;
+				zbx_uint64_t	overcommit_available = monitor->overcommit_limit - monitor->overcommit;
+
+				if (monitor->values_num <= monitor->values_limit + overcommit_available)
+				{
+					monitor->overcommit += monitor->values_num - monitor->values_limit;
+					monitor->values_num = 0;
+				}
+				else
+				{
+					monitor->values_num -= monitor->values_limit + overcommit_available;
+					monitor->overcommit = monitor->overcommit_limit;
+				}
 			}
+
+			monitor->last_flush = now;
 		}
+		monitor->values_num += values_num;
+  }
 
-		monitor->last_flush = now;
-	}
-
-	monitor->values_num += values_num;
+	monitor->total_collected_num += values_num;
 
 	zbx_mutex_unlock(vps_lock);
 }
@@ -172,6 +172,7 @@ void	zbx_vps_monitor_get_stats(zbx_vps_monitor_stats_t *stats)
 
 	zbx_mutex_lock(vps_lock);
 	stats->overcommit = monitor->overcommit;
+	stats->collected_num = monitor->total_collected_num;
 	stats->written_num = monitor->total_values_num;
 	zbx_mutex_unlock(vps_lock);
 

--- a/src/libs/zbxcacheconfig/vps_monitor.h
+++ b/src/libs/zbxcacheconfig/vps_monitor.h
@@ -19,6 +19,7 @@
 
 typedef struct
 {
+	zbx_uint64_t	total_collected_num;
 	zbx_uint64_t	total_values_num;
 	zbx_uint64_t	values_num;
 	zbx_uint64_t	values_limit;

--- a/src/zabbix_server/stats/stats_server.c
+++ b/src/zabbix_server/stats/stats_server.c
@@ -134,6 +134,7 @@ void	zbx_server_stats_ext_get(struct zbx_json *json, const void *arg)
 
 	zbx_json_addobject(json, "vps");
 	zbx_json_adduint64(json, "status", (SUCCEED == zbx_vps_monitor_capped() ? 1 : 0));
+	zbx_json_adduint64(json, "collected_total", vps_stats.collected_num);
 	zbx_json_adduint64(json, "written_total", vps_stats.written_num);
 	zbx_json_adduint64(json, "limit", vps_stats.values_limit);
 


### PR DESCRIPTION
This change exposes a counter via the stats server which is the actual value evaluated (as a rate) for VPS throttling when employing the `VPSLimit` and `VPSOvercommitLimit` server configuration parameters.